### PR TITLE
fix: Release candidate fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,11 @@ jobs:
             backend: cpu
             target: x86_64-unknown-linux-gnu
             artifact_suffix: linux-x86_64-cpu
+          - name: Linux aarch64 CPU
+            os: ubuntu-24.04-arm
+            backend: cpu
+            target: aarch64-unknown-linux-gnu
+            artifact_suffix: linux-aarch64-cpu
     env:
       LLAMA_STAGE_BACKEND: ${{ matrix.backend }}
       MESH_NATIVE_SDK_TARGET: ${{ matrix.target }}
@@ -302,6 +307,65 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: release-native-runtime-${{ matrix.artifact_suffix }}
+          path: |
+            dist/native-runtimes/*.tar.gz
+            dist/native-runtimes/*.sha256
+          if-no-files-found: error
+
+  build_native_runtime_linux_aarch64_cuda:
+    name: Build native runtime Linux aarch64 CUDA (${{ matrix.cuda_major }})
+    needs: metadata
+    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cuda_version: '12.9.2'
+            cuda_major: '12'
+          - cuda_version: '13.1.2'
+            cuda_major: '13'
+    container:
+      image: nvidia/cuda:${{ matrix.cuda_version }}-devel-ubuntu24.04
+    env:
+      LLAMA_STAGE_BACKEND: cuda
+      MESH_NATIVE_RUNTIME_TARGET: aarch64-unknown-linux-gnu
+      MESH_LLM_CUDA_TOOLKIT_MAJOR: ${{ matrix.cuda_major }}
+    steps:
+      - name: Install base packages
+        run: |
+          for attempt in 1 2 3; do
+            apt-get -o Acquire::Retries=5 update &&
+              DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y --fix-missing ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential lld patchelf &&
+              break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          rm -rf /var/lib/apt/lists/*
+      - uses: actions/checkout@v5
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Package native runtime
+        run: |
+          scripts/package-native-runtime.sh \
+            --build \
+            --backend cuda \
+            --target aarch64-unknown-linux-gnu \
+            --out dist/native-runtimes
+      - name: Verify native runtime artifact
+        run: scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
+      - name: Upload native runtime
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-native-runtime-linux-aarch64-cuda-${{ matrix.cuda_major }}
           path: |
             dist/native-runtimes/*.tar.gz
             dist/native-runtimes/*.sha256
@@ -828,6 +892,7 @@ jobs:
       - inference_smoke_tests
       - build_native_sdk_runtime
       - build_native_runtime
+      - build_native_runtime_linux_aarch64_cuda
       - build_swift_sdk_artifact
       - build_linux_arm64
       - build_linux_aarch64_cuda
@@ -836,7 +901,7 @@ jobs:
       - build_linux_vulkan
       - build_windows_cpu
       - build_windows_gpu
-    if: ${{ always() && needs.metadata.result == 'success' && needs.metadata.outputs.canary != 'true' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_native_sdk_runtime.result == 'success' && needs.build_native_runtime.result == 'success' && needs.build_swift_sdk_artifact.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_aarch64_cuda.result == 'success' || needs.build_linux_aarch64_cuda.result == 'skipped') && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') && needs.build_windows_cpu.result == 'success' && (needs.build_windows_gpu.result == 'success' || needs.build_windows_gpu.result == 'skipped') }}
+    if: ${{ always() && needs.metadata.result == 'success' && needs.metadata.outputs.canary != 'true' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_native_sdk_runtime.result == 'success' && needs.build_native_runtime.result == 'success' && (needs.build_native_runtime_linux_aarch64_cuda.result == 'success' || needs.build_native_runtime_linux_aarch64_cuda.result == 'skipped') && needs.build_swift_sdk_artifact.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_aarch64_cuda.result == 'success' || needs.build_linux_aarch64_cuda.result == 'skipped') && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') && needs.build_windows_cpu.result == 'success' && (needs.build_windows_gpu.result == 'success' || needs.build_windows_gpu.result == 'skipped') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -879,6 +944,9 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --out release-artifacts/native-runtimes.json \
             release-artifacts/meshllm-native-runtime-*.tar.gz
+          scripts/validate-release-native-runtime-matrix.py \
+            --manifest release-artifacts/native-runtimes.json \
+            release-artifacts/*
           shasum -a 256 release-artifacts/native-runtimes.json | awk '{print $1 "  native-runtimes.json"}' > release-artifacts/native-runtimes.json.sha256
 
       - name: Download generated SwiftPM manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,11 @@ jobs:
             backend: cpu
             target: x86_64-unknown-linux-gnu
             artifact_suffix: linux-x86_64-cpu
+          - name: Linux aarch64 CPU
+            os: ubuntu-24.04-arm
+            backend: cpu
+            target: aarch64-unknown-linux-gnu
+            artifact_suffix: linux-aarch64-cpu
     env:
       LLAMA_STAGE_BACKEND: ${{ matrix.backend }}
       MESH_NATIVE_RUNTIME_TARGET: ${{ matrix.target }}

--- a/crates/mesh-llm-cli/src/lib.rs
+++ b/crates/mesh-llm-cli/src/lib.rs
@@ -13,6 +13,5 @@ pub use parser::{
     AuthCommand, BinaryFlavor, Cli, Command, ConfigCommand, DiscoveryScope, DoctorCommand,
     GpuCommand, MeshDiscoveryMode, MeshGuardrailCliMode, NormalizedRuntimeArgs, PluginCommand,
     RuntimeSurface, SkillAgentArg, SkillCommand, TrustCommand, TrustPolicy,
-    legacy_runtime_surface_warning, normalize_runtime_surface_args, runtime_surface_help,
-    validate_discovery_mode_args,
+    legacy_runtime_surface_warning, normalize_runtime_surface_args, validate_discovery_mode_args,
 };

--- a/crates/mesh-llm-cli/src/lib.rs
+++ b/crates/mesh-llm-cli/src/lib.rs
@@ -13,5 +13,6 @@ pub use parser::{
     AuthCommand, BinaryFlavor, Cli, Command, ConfigCommand, DiscoveryScope, DoctorCommand,
     GpuCommand, MeshDiscoveryMode, MeshGuardrailCliMode, NormalizedRuntimeArgs, PluginCommand,
     RuntimeSurface, SkillAgentArg, SkillCommand, TrustCommand, TrustPolicy,
-    legacy_runtime_surface_warning, normalize_runtime_surface_args, validate_discovery_mode_args,
+    legacy_runtime_surface_warning, normalize_runtime_surface_args, runtime_surface_help,
+    validate_discovery_mode_args,
 };

--- a/crates/mesh-llm-cli/src/parser.rs
+++ b/crates/mesh-llm-cli/src/parser.rs
@@ -9,6 +9,10 @@ use crate::runtime::RuntimeCommand;
 use mesh_llm_events::LogFormat;
 use serde::Serialize;
 
+mod runtime_surface_help;
+
+pub use runtime_surface_help::runtime_surface_help;
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum BinaryFlavor {
     #[default]
@@ -1030,42 +1034,6 @@ pub enum RuntimeSurface {
     Client,
 }
 
-pub fn runtime_surface_help(surface: RuntimeSurface) -> String {
-    match surface {
-        RuntimeSurface::Serve => concat!(
-            "Serve local models and join or publish a mesh.\n\n",
-            "Usage: mesh-llm serve [OPTIONS]\n\n",
-            "Common serving options:\n",
-            "      --model <MODEL>          Startup model to serve from the catalog, a path, or a Hugging Face ref\n",
-            "      --gguf <GGUF>            Raw local GGUF file to serve directly\n",
-            "      --mmproj <MMPROJ>        Multimodal projector for the primary served model\n",
-            "      --auto                   Auto-join the best discovered mesh\n",
-            "      --join <JOIN>            Join a mesh via invite token\n",
-            "      --publish                Publish this mesh for discovery\n",
-            "      --port <PORT>            OpenAI-compatible API port [default: 9337]\n",
-            "      --console <CONSOLE>      Management console/API port [default: 3131]\n",
-            "      --log-format <FORMAT>    Terminal output format [default: pretty]\n\n",
-            "Bare `mesh-llm serve` loads startup models from ~/.mesh-llm/config.toml.\n",
-            "Add [[models]] there or pass --model / --gguf explicitly.\n",
-            "Run `mesh-llm --help-advanced` for the full runtime option surface.\n"
-        )
-        .to_string(),
-        RuntimeSurface::Client => concat!(
-            "Run as a client-only mesh node with no local model required.\n\n",
-            "Usage: mesh-llm client [OPTIONS]\n\n",
-            "Common client options:\n",
-            "      --auto                   Auto-join the best discovered mesh\n",
-            "      --discover [NAME]        Discover and join a mesh by name\n",
-            "      --join <JOIN>            Join a mesh via invite token\n",
-            "      --port <PORT>            Local OpenAI-compatible proxy port [default: 9337]\n",
-            "      --console <CONSOLE>      Management console/API port [default: 3131]\n",
-            "      --log-format <FORMAT>    Terminal output format [default: pretty]\n\n",
-            "Run `mesh-llm --help-advanced` for the full runtime option surface.\n"
-        )
-        .to_string(),
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct NormalizedRuntimeArgs {
     pub original: Vec<OsString>,
@@ -1371,28 +1339,6 @@ mod tests {
                 .map(OsString::from)
                 .collect::<Vec<_>>()
         );
-    }
-
-    #[test]
-    fn serve_surface_help_describes_serving_options() {
-        let help = runtime_surface_help(RuntimeSurface::Serve);
-
-        assert!(help.contains("Usage: mesh-llm serve"));
-        assert!(help.contains("--model"));
-        assert!(help.contains("--gguf"));
-        assert!(help.contains("startup models"));
-        assert!(!help.contains("Pool GPUs over the internet for LLM inference\n\nUsage: mesh-llm"));
-    }
-
-    #[test]
-    fn client_surface_help_describes_client_options() {
-        let help = runtime_surface_help(RuntimeSurface::Client);
-
-        assert!(help.contains("Usage: mesh-llm client"));
-        assert!(help.contains("--auto"));
-        assert!(help.contains("--discover"));
-        assert!(help.contains("client-only"));
-        assert!(!help.contains("--model <MODEL>"));
     }
 
     #[test]

--- a/crates/mesh-llm-cli/src/parser.rs
+++ b/crates/mesh-llm-cli/src/parser.rs
@@ -1030,6 +1030,42 @@ pub enum RuntimeSurface {
     Client,
 }
 
+pub fn runtime_surface_help(surface: RuntimeSurface) -> String {
+    match surface {
+        RuntimeSurface::Serve => concat!(
+            "Serve local models and join or publish a mesh.\n\n",
+            "Usage: mesh-llm serve [OPTIONS]\n\n",
+            "Common serving options:\n",
+            "      --model <MODEL>          Startup model to serve from the catalog, a path, or a Hugging Face ref\n",
+            "      --gguf <GGUF>            Raw local GGUF file to serve directly\n",
+            "      --mmproj <MMPROJ>        Multimodal projector for the primary served model\n",
+            "      --auto                   Auto-join the best discovered mesh\n",
+            "      --join <JOIN>            Join a mesh via invite token\n",
+            "      --publish                Publish this mesh for discovery\n",
+            "      --port <PORT>            OpenAI-compatible API port [default: 9337]\n",
+            "      --console <CONSOLE>      Management console/API port [default: 3131]\n",
+            "      --log-format <FORMAT>    Terminal output format [default: pretty]\n\n",
+            "Bare `mesh-llm serve` loads startup models from ~/.mesh-llm/config.toml.\n",
+            "Add [[models]] there or pass --model / --gguf explicitly.\n",
+            "Run `mesh-llm --help-advanced` for the full runtime option surface.\n"
+        )
+        .to_string(),
+        RuntimeSurface::Client => concat!(
+            "Run as a client-only mesh node with no local model required.\n\n",
+            "Usage: mesh-llm client [OPTIONS]\n\n",
+            "Common client options:\n",
+            "      --auto                   Auto-join the best discovered mesh\n",
+            "      --discover [NAME]        Discover and join a mesh by name\n",
+            "      --join <JOIN>            Join a mesh via invite token\n",
+            "      --port <PORT>            Local OpenAI-compatible proxy port [default: 9337]\n",
+            "      --console <CONSOLE>      Management console/API port [default: 3131]\n",
+            "      --log-format <FORMAT>    Terminal output format [default: pretty]\n\n",
+            "Run `mesh-llm --help-advanced` for the full runtime option surface.\n"
+        )
+        .to_string(),
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct NormalizedRuntimeArgs {
     pub original: Vec<OsString>,
@@ -1335,6 +1371,28 @@ mod tests {
                 .map(OsString::from)
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn serve_surface_help_describes_serving_options() {
+        let help = runtime_surface_help(RuntimeSurface::Serve);
+
+        assert!(help.contains("Usage: mesh-llm serve"));
+        assert!(help.contains("--model"));
+        assert!(help.contains("--gguf"));
+        assert!(help.contains("startup models"));
+        assert!(!help.contains("Pool GPUs over the internet for LLM inference\n\nUsage: mesh-llm"));
+    }
+
+    #[test]
+    fn client_surface_help_describes_client_options() {
+        let help = runtime_surface_help(RuntimeSurface::Client);
+
+        assert!(help.contains("Usage: mesh-llm client"));
+        assert!(help.contains("--auto"));
+        assert!(help.contains("--discover"));
+        assert!(help.contains("client-only"));
+        assert!(!help.contains("--model <MODEL>"));
     }
 
     #[test]

--- a/crates/mesh-llm-cli/src/parser/runtime_surface_help.rs
+++ b/crates/mesh-llm-cli/src/parser/runtime_surface_help.rs
@@ -1,0 +1,64 @@
+use super::RuntimeSurface;
+
+pub fn runtime_surface_help(surface: RuntimeSurface) -> String {
+    match surface {
+        RuntimeSurface::Serve => concat!(
+            "Serve local models and join or publish a mesh.\n\n",
+            "Usage: mesh-llm serve [OPTIONS]\n\n",
+            "Common serving options:\n",
+            "      --model <MODEL>          Startup model to serve from the catalog, a path, or a Hugging Face ref\n",
+            "      --gguf <GGUF>            Raw local GGUF file to serve directly\n",
+            "      --mmproj <MMPROJ>        Multimodal projector for the primary served model\n",
+            "      --auto                   Auto-join the best discovered mesh\n",
+            "      --join <JOIN>            Join a mesh via invite token\n",
+            "      --publish                Publish this mesh for discovery\n",
+            "      --port <PORT>            OpenAI-compatible API port [default: 9337]\n",
+            "      --console <CONSOLE>      Management console/API port [default: 3131]\n",
+            "      --log-format <FORMAT>    Terminal output format [default: pretty]\n\n",
+            "Bare `mesh-llm serve` loads startup models from ~/.mesh-llm/config.toml.\n",
+            "Add [[models]] there or pass --model / --gguf explicitly.\n",
+            "Run `mesh-llm --help-advanced` for the full runtime option surface.\n"
+        )
+        .to_string(),
+        RuntimeSurface::Client => concat!(
+            "Run as a client-only mesh node with no local model required.\n\n",
+            "Usage: mesh-llm client [OPTIONS]\n\n",
+            "Common client options:\n",
+            "      --auto                   Auto-join the best discovered mesh\n",
+            "      --discover [NAME]        Discover and join a mesh by name\n",
+            "      --join <JOIN>            Join a mesh via invite token\n",
+            "      --port <PORT>            Local OpenAI-compatible proxy port [default: 9337]\n",
+            "      --console <CONSOLE>      Management console/API port [default: 3131]\n",
+            "      --log-format <FORMAT>    Terminal output format [default: pretty]\n\n",
+            "Run `mesh-llm --help-advanced` for the full runtime option surface.\n"
+        )
+        .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serve_surface_help_describes_serving_options() {
+        let help = runtime_surface_help(RuntimeSurface::Serve);
+
+        assert!(help.contains("Usage: mesh-llm serve"));
+        assert!(help.contains("--model"));
+        assert!(help.contains("--gguf"));
+        assert!(help.contains("startup models"));
+        assert!(!help.contains("Pool GPUs over the internet for LLM inference\n\nUsage: mesh-llm"));
+    }
+
+    #[test]
+    fn client_surface_help_describes_client_options() {
+        let help = runtime_surface_help(RuntimeSurface::Client);
+
+        assert!(help.contains("Usage: mesh-llm client"));
+        assert!(help.contains("--auto"));
+        assert!(help.contains("--discover"));
+        assert!(help.contains("client-only"));
+        assert!(!help.contains("--model <MODEL>"));
+    }
+}

--- a/crates/mesh-llm-commands/src/plugin.rs
+++ b/crates/mesh-llm-commands/src/plugin.rs
@@ -41,7 +41,7 @@ pub async fn run_plugin_command(
         PluginCommand::Enable { name } => set_enabled(name, true)?,
         PluginCommand::Disable { name } => set_enabled(name, false)?,
         PluginCommand::Delete { name } => delete(name)?,
-        PluginCommand::Info { name } => info(name, runtime_rows)?,
+        PluginCommand::Info { name } => return info(name, runtime_rows),
         PluginCommand::Search { query } => search(query.as_deref()).await?,
         PluginCommand::List => {
             let Some(runtime_rows) = runtime_rows else {
@@ -99,7 +99,7 @@ fn delete(name: &str) -> Result<()> {
     Ok(())
 }
 
-fn info(name: &str, runtime_rows: Option<&PluginListRows>) -> Result<()> {
+fn info(name: &str, runtime_rows: Option<&PluginListRows>) -> Result<bool> {
     let store = PluginStore::new(default_store_root()?);
     if let Some(metadata) = store.load_optional(name)? {
         println!("name\t{}", metadata.name);
@@ -118,15 +118,22 @@ fn info(name: &str, runtime_rows: Option<&PluginListRows>) -> Result<()> {
         if let Some(error) = metadata.last_error {
             println!("error\t{error}");
         }
-        return Ok(());
+        return Ok(true);
     }
-    if let Some(row) =
-        runtime_rows.and_then(|rows| rows.externals.iter().find(|row| row.name == name))
-    {
+    let Some(runtime_rows) = runtime_rows else {
+        return Ok(false);
+    };
+    if let Some(row) = runtime_rows.externals.iter().find(|row| row.name == name) {
         for line in runtime_plugin_info_lines(row) {
             println!("{line}");
         }
-        return Ok(());
+        return Ok(true);
+    }
+    if let Some(row) = runtime_rows.inactive.iter().find(|row| row.name == name) {
+        for line in inactive_plugin_info_lines(row) {
+            println!("{line}");
+        }
+        return Ok(true);
     }
     bail!("plugin '{name}' is not installed")
 }
@@ -138,6 +145,15 @@ fn runtime_plugin_info_lines(row: &RuntimePluginRow) -> Vec<String> {
         format!("command\t{}", row.command),
         format!("args\t{}", row.args.join(" ")),
         "source\tbuilt-in/runtime".to_string(),
+    ]
+}
+
+fn inactive_plugin_info_lines(row: &InactivePluginRow) -> Vec<String> {
+    vec![
+        format!("name\t{}", row.name),
+        format!("kind\t{}", row.kind),
+        format!("status\t{}", row.status),
+        format!("error\t{}", row.error.clone().unwrap_or_default()),
     ]
 }
 
@@ -334,6 +350,26 @@ mod tests {
                 "command\t/tmp/mesh-llm".to_string(),
                 "args\t--log-format json --plugin blobstore".to_string(),
                 "source\tbuilt-in/runtime".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn inactive_plugin_info_lines_describe_startup_failure() {
+        let row = InactivePluginRow {
+            name: "image-tools".to_string(),
+            kind: "external".to_string(),
+            status: "inactive".to_string(),
+            error: Some("command not found".to_string()),
+        };
+
+        assert_eq!(
+            inactive_plugin_info_lines(&row),
+            vec![
+                "name\timage-tools".to_string(),
+                "kind\texternal".to_string(),
+                "status\tinactive".to_string(),
+                "error\tcommand not found".to_string(),
             ]
         );
     }

--- a/crates/mesh-llm-commands/src/plugin.rs
+++ b/crates/mesh-llm-commands/src/plugin.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use mesh_llm_plugin_manager::{
     PluginCatalog, PluginInstallOptions, PluginProgressEvent, PluginProgressReporter, PluginStore,
     default_store_root, install_plugin, update_plugin,
@@ -41,7 +41,7 @@ pub async fn run_plugin_command(
         PluginCommand::Enable { name } => set_enabled(name, true)?,
         PluginCommand::Disable { name } => set_enabled(name, false)?,
         PluginCommand::Delete { name } => delete(name)?,
-        PluginCommand::Info { name } => info(name)?,
+        PluginCommand::Info { name } => info(name, runtime_rows)?,
         PluginCommand::Search { query } => search(query.as_deref()).await?,
         PluginCommand::List => {
             let Some(runtime_rows) = runtime_rows else {
@@ -99,26 +99,46 @@ fn delete(name: &str) -> Result<()> {
     Ok(())
 }
 
-fn info(name: &str) -> Result<()> {
+fn info(name: &str, runtime_rows: Option<&PluginListRows>) -> Result<()> {
     let store = PluginStore::new(default_store_root()?);
-    let metadata = store.load(name)?;
-    println!("name\t{}", metadata.name);
-    println!("version\t{}", metadata.installed_version);
-    println!("enabled\t{}", metadata.enabled);
-    println!("source\t{}", metadata.source_repository);
-    println!("target\t{}", metadata.target_triple);
-    println!("asset\t{}", metadata.downloaded_asset_name);
-    println!("path\t{}", metadata.install_path.display());
-    if let Some(protocol) = metadata.last_protocol_version {
-        println!("protocol\t{protocol}");
+    if let Some(metadata) = store.load_optional(name)? {
+        println!("name\t{}", metadata.name);
+        println!("version\t{}", metadata.installed_version);
+        println!("enabled\t{}", metadata.enabled);
+        println!("source\t{}", metadata.source_repository);
+        println!("target\t{}", metadata.target_triple);
+        println!("asset\t{}", metadata.downloaded_asset_name);
+        println!("path\t{}", metadata.install_path.display());
+        if let Some(protocol) = metadata.last_protocol_version {
+            println!("protocol\t{protocol}");
+        }
+        if let Some(status) = metadata.last_status {
+            println!("status\t{status}");
+        }
+        if let Some(error) = metadata.last_error {
+            println!("error\t{error}");
+        }
+        return Ok(());
     }
-    if let Some(status) = metadata.last_status {
-        println!("status\t{status}");
+    if let Some(row) =
+        runtime_rows.and_then(|rows| rows.externals.iter().find(|row| row.name == name))
+    {
+        for line in runtime_plugin_info_lines(row) {
+            println!("{line}");
+        }
+        return Ok(());
     }
-    if let Some(error) = metadata.last_error {
-        println!("error\t{error}");
-    }
-    Ok(())
+    bail!("plugin '{name}' is not installed")
+}
+
+fn runtime_plugin_info_lines(row: &RuntimePluginRow) -> Vec<String> {
+    vec![
+        format!("name\t{}", row.name),
+        "kind\truntime".to_string(),
+        format!("command\t{}", row.command),
+        format!("args\t{}", row.args.join(" ")),
+        "source\tbuilt-in/runtime".to_string(),
+    ]
 }
 
 async fn search(query: Option<&str>) -> Result<()> {
@@ -286,5 +306,35 @@ fn format_bytes(bytes: u64) -> String {
         format!("{bytes} {unit}")
     } else {
         format!("{value:.1} {unit}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_plugin_info_lines_describe_builtin_runtime_plugin() {
+        let row = RuntimePluginRow {
+            name: "blobstore".to_string(),
+            command: "/tmp/mesh-llm".to_string(),
+            args: vec![
+                "--log-format".to_string(),
+                "json".to_string(),
+                "--plugin".to_string(),
+                "blobstore".to_string(),
+            ],
+        };
+
+        assert_eq!(
+            runtime_plugin_info_lines(&row),
+            vec![
+                "name\tblobstore".to_string(),
+                "kind\truntime".to_string(),
+                "command\t/tmp/mesh-llm".to_string(),
+                "args\t--log-format json --plugin blobstore".to_string(),
+                "source\tbuilt-in/runtime".to_string(),
+            ]
+        );
     }
 }

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -13,6 +13,14 @@ use std::time::{Duration, Instant};
 
 use formatters::{AvailableRuntimeRow, NativeRuntimeDoctorReport, runtime_native_formatter};
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct NativeRuntimeDoctorReadiness {
+    healthy: bool,
+    status: String,
+    blockers: Vec<String>,
+    recommendations: Vec<String>,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct NativeRuntimeConfigSelection<'a> {
     pub mesh_version: Option<&'a str>,
@@ -314,8 +322,14 @@ pub fn run_native_runtime_doctor(
                 && runtime.manifest.runtime.skippy_abi == candidate.artifact.skippy_abi
         })
     });
+    let readiness =
+        native_runtime_doctor_readiness(selected.map(|runtime| runtime.native_runtime_id.as_str()));
 
     let report = NativeRuntimeDoctorReport {
+        healthy: readiness.healthy,
+        status: readiness.status,
+        blockers: readiness.blockers,
+        recommendations: readiness.recommendations,
         running_mesh_version: CURRENT_MESH_VERSION.to_string(),
         selected_mesh_version: selected_mesh_version.to_string(),
         configured_skippy_abi: skippy_abi_version.map(ToString::to_string),
@@ -329,5 +343,82 @@ pub fn run_native_runtime_doctor(
         selected_version_installed_count: selected_version_runtimes.len(),
     };
 
-    runtime_native_formatter(json_output).render_doctor(&report)
+    runtime_native_formatter(json_output).render_doctor(&report)?;
+    if !report.healthy {
+        anyhow::bail!(
+            "{}",
+            report
+                .blockers
+                .first()
+                .map(String::as_str)
+                .unwrap_or("native runtime doctor found a blocking readiness issue")
+        );
+    }
+    Ok(())
+}
+
+fn native_runtime_doctor_readiness(
+    selected_runtime_id: Option<&str>,
+) -> NativeRuntimeDoctorReadiness {
+    if selected_runtime_id.is_some() {
+        return NativeRuntimeDoctorReadiness {
+            healthy: true,
+            status: "ok".to_string(),
+            blockers: Vec::new(),
+            recommendations: Vec::new(),
+        };
+    }
+    NativeRuntimeDoctorReadiness {
+        healthy: false,
+        status: "unhealthy".to_string(),
+        blockers: vec![
+            "No compatible native runtime is installed for the selected MeshLLM version and host."
+                .to_string(),
+        ],
+        recommendations: vec![
+            "Run `mesh-llm runtime install` to install the recommended native runtime.".to_string(),
+            "Run `mesh-llm runtime list --available` to inspect compatible and rejected runtimes."
+                .to_string(),
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doctor_readiness_blocks_missing_selected_runtime() {
+        let readiness = native_runtime_doctor_readiness(None);
+
+        assert!(!readiness.healthy);
+        assert_eq!(readiness.status, "unhealthy");
+        assert!(
+            readiness
+                .blockers
+                .iter()
+                .any(|item| item.contains("No compatible native runtime"))
+        );
+        assert!(
+            readiness
+                .recommendations
+                .iter()
+                .any(|item| item.contains("mesh-llm runtime install"))
+        );
+        assert!(
+            readiness
+                .recommendations
+                .iter()
+                .any(|item| item.contains("mesh-llm runtime list --available"))
+        );
+    }
+
+    #[test]
+    fn doctor_readiness_accepts_selected_runtime() {
+        let readiness = native_runtime_doctor_readiness(Some("meshllm-native-runtime-test-cpu"));
+
+        assert!(readiness.healthy);
+        assert_eq!(readiness.status, "ok");
+        assert!(readiness.blockers.is_empty());
+    }
 }

--- a/crates/mesh-llm-commands/src/runtime_native/formatters.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/formatters.rs
@@ -24,6 +24,10 @@ pub(crate) struct AvailableRuntimeRow {
 
 #[derive(Serialize)]
 pub(crate) struct NativeRuntimeDoctorReport {
+    pub(crate) healthy: bool,
+    pub(crate) status: String,
+    pub(crate) blockers: Vec<String>,
+    pub(crate) recommendations: Vec<String>,
     pub(crate) running_mesh_version: String,
     pub(crate) selected_mesh_version: String,
     pub(crate) configured_skippy_abi: Option<String>,
@@ -270,6 +274,7 @@ fn print_doctor_human(report: &NativeRuntimeDoctorReport) {
     println!("🩺 MeshLLM doctor");
     println!();
     println!("Native runtime:");
+    println!("  status: {}", report.status);
     println!("  running MeshLLM version: {}", report.running_mesh_version);
     println!(
         "  selected runtime version: {}",
@@ -306,7 +311,6 @@ fn print_doctor_human(report: &NativeRuntimeDoctorReport) {
         }
         None => {
             println!("  selected: none");
-            println!("  status: no native runtime installed for selected MeshLLM version");
         }
     }
     println!("  installed: {}", report.installed_count);
@@ -314,6 +318,20 @@ fn print_doctor_human(report: &NativeRuntimeDoctorReport) {
         "  installed for selected version: {}",
         report.selected_version_installed_count
     );
+    if !report.blockers.is_empty() {
+        println!();
+        println!("Blockers:");
+        for blocker in &report.blockers {
+            println!("  - {blocker}");
+        }
+    }
+    if !report.recommendations.is_empty() {
+        println!();
+        println!("Recommended next steps:");
+        for recommendation in &report.recommendations {
+            println!("  - {recommendation}");
+        }
+    }
 }
 
 fn format_rejection(reason: &CandidateRejection) -> String {

--- a/crates/mesh-llm-commands/src/runtime_native/formatters.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/formatters.rs
@@ -281,7 +281,7 @@ fn print_doctor_human(report: &NativeRuntimeDoctorReport) {
         report.selected_mesh_version
     );
     if report.selected_mesh_version != report.running_mesh_version {
-        println!("  status: native runtime version is pinned by config");
+        println!("  version pin: native runtime version is pinned by config");
     }
     if let Some(skippy_abi) = &report.configured_skippy_abi {
         println!("  configured Skippy ABI: {skippy_abi}");

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -267,8 +267,22 @@ fn vulkaninfo_device_names(output: &str) -> Vec<String> {
         .filter_map(|line| line.strip_prefix("deviceName"))
         .filter_map(|line| line.split_once('=').map(|(_, value)| value.trim()))
         .filter(|value| !value.is_empty())
+        .filter(|value| !looks_like_software_vulkan_adapter(value))
         .map(str::to_string)
         .collect()
+}
+
+fn looks_like_software_vulkan_adapter(value: &str) -> bool {
+    let label = value.to_ascii_lowercase();
+    [
+        "llvmpipe",
+        "swiftshader",
+        "lavapipe",
+        "softpipe",
+        "software rasterizer",
+    ]
+    .iter()
+    .any(|marker| label.contains(marker))
 }
 
 fn looks_like_display_controller(line: &str) -> bool {
@@ -407,6 +421,23 @@ driverName         = NVIDIA
         assert_eq!(
             gpu_labels_from_command_output("vulkaninfo", &["--summary"], output),
             vec!["NVIDIA Tegra Orin (nvgpu)".to_string()]
+        );
+    }
+
+    #[test]
+    fn vulkaninfo_labels_ignore_software_adapters() {
+        let output = "\
+GPU0:
+deviceName         = llvmpipe (LLVM 18.1.8, 256 bits)
+GPU1:
+deviceName         = SwiftShader Device (Subzero)
+GPU2:
+deviceName         = AMD Radeon PRO W7900
+";
+
+        assert_eq!(
+            gpu_labels_from_command_output("vulkaninfo", &["--summary"], output),
+            vec!["AMD Radeon PRO W7900".to_string()]
         );
     }
 

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -135,13 +135,24 @@ fn apply_gpu_arch_overrides(gpus: &mut [HostGpuProfile]) {
 }
 
 fn cuda_majors_from_nvidia_smi() -> BTreeSet<u32> {
-    let mut majors = BTreeSet::new();
     let Some(output) = command_output("nvidia-smi", &[]) else {
-        return majors;
+        return BTreeSet::new();
     };
+    cuda_majors_from_nvidia_smi_output(&output)
+}
+
+fn cuda_majors_from_nvidia_smi_output(output: &str) -> BTreeSet<u32> {
+    let mut majors = BTreeSet::new();
     for token in output.split_whitespace() {
         if let Some(major) = cuda_major_from_token(token) {
             majors.insert(major);
+        }
+    }
+    for line in output.lines() {
+        if let Some((_, version)) = line.split_once("CUDA Version:") {
+            if let Some(major) = leading_major_version(version) {
+                majors.insert(major);
+            }
         }
     }
     majors
@@ -152,6 +163,15 @@ fn cuda_major_from_token(token: &str) -> Option<u32> {
         .strip_prefix("CUDA")?
         .trim_start_matches("Version:")
         .trim_matches(|ch: char| !ch.is_ascii_digit())
+        .split('.')
+        .next()
+        .and_then(|value| value.parse::<u32>().ok())
+}
+
+fn leading_major_version(value: &str) -> Option<u32> {
+    value
+        .trim()
+        .trim_start_matches(|ch: char| !ch.is_ascii_digit())
         .split('.')
         .next()
         .and_then(|value| value.parse::<u32>().ok())
@@ -213,13 +233,50 @@ fn append_command_lines(labels: &mut Vec<String>, program: &str, args: &[&str]) 
     let Some(output) = command_output(program, args) else {
         return;
     };
-    labels.extend(
-        output
+    labels.extend(gpu_labels_from_command_output(program, args, &output));
+}
+
+fn gpu_labels_from_command_output(program: &str, args: &[&str], output: &str) -> Vec<String> {
+    match (program, args) {
+        ("nvidia-smi", ["-L"]) => output
+            .lines()
+            .map(str::trim)
+            .filter(|line| line.starts_with("GPU ") && line.contains(':'))
+            .map(str::to_string)
+            .collect(),
+        ("vulkaninfo", ["--summary"]) => vulkaninfo_device_names(output),
+        ("lspci", []) => output
+            .lines()
+            .map(str::trim)
+            .filter(|line| looks_like_display_controller(line))
+            .map(str::to_string)
+            .collect(),
+        _ => output
             .lines()
             .map(str::trim)
             .filter(|line| looks_like_gpu_label(line))
-            .map(str::to_string),
-    );
+            .map(str::to_string)
+            .collect(),
+    }
+}
+
+fn vulkaninfo_device_names(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .map(str::trim)
+        .filter_map(|line| line.strip_prefix("deviceName"))
+        .filter_map(|line| line.split_once('=').map(|(_, value)| value.trim()))
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn looks_like_display_controller(line: &str) -> bool {
+    let label = line.to_ascii_lowercase();
+    (label.contains("vga compatible controller")
+        || label.contains("3d controller")
+        || label.contains("display controller"))
+        && looks_like_gpu_label(line)
 }
 
 fn command_output(program: &str, args: &[&str]) -> Option<String> {
@@ -324,5 +381,48 @@ mod tests {
             detected_native_runtime_flavors(&[profile("AMD Radeon PRO W7900")], None, None, None);
 
         assert!(flavors.contains(&NativeRuntimeBackendKind::Rocm));
+    }
+
+    #[test]
+    fn parses_cuda_version_label_from_nvidia_smi_banner() {
+        let output = "| NVIDIA-SMI 595.78 Driver Version: 595.78 CUDA Version: 13.2 |\n";
+
+        assert_eq!(
+            cuda_majors_from_nvidia_smi_output(output),
+            BTreeSet::from([13])
+        );
+    }
+
+    #[test]
+    fn vulkaninfo_labels_keep_only_device_names() {
+        let output = "\
+VULKANINFO
+Vulkan Instance Version: 1.4.321
+GPU0:
+deviceName         = NVIDIA Tegra Orin (nvgpu)
+deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
+driverName         = NVIDIA
+";
+
+        assert_eq!(
+            gpu_labels_from_command_output("vulkaninfo", &["--summary"], output),
+            vec!["NVIDIA Tegra Orin (nvgpu)".to_string()]
+        );
+    }
+
+    #[test]
+    fn lspci_labels_ignore_nvidia_pci_bridges() {
+        let output = "\
+0004:00:00.0 PCI bridge: NVIDIA Corporation Device 229c (rev a1)
+0008:01:00.0 3D controller: NVIDIA Corporation GA102GL [RTX A6000] (rev a1)
+";
+
+        assert_eq!(
+            gpu_labels_from_command_output("lspci", &[], output),
+            vec![
+                "0008:01:00.0 3D controller: NVIDIA Corporation GA102GL [RTX A6000] (rev a1)"
+                    .to_string()
+            ]
+        );
     }
 }

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -149,10 +149,10 @@ fn cuda_majors_from_nvidia_smi_output(output: &str) -> BTreeSet<u32> {
         }
     }
     for line in output.lines() {
-        if let Some((_, version)) = line.split_once("CUDA Version:") {
-            if let Some(major) = leading_major_version(version) {
-                majors.insert(major);
-            }
+        if let Some((_, version)) = line.split_once("CUDA Version:")
+            && let Some(major) = leading_major_version(version)
+        {
+            majors.insert(major);
         }
     }
     majors

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -2699,10 +2699,6 @@ fn bridge_skippy_native_logs(
     });
 }
 
-fn write_stderr_newline() {
-    let _ = std::io::stderr().write_all(b"\n");
-}
-
 async fn emit_shutdown(reason: Option<String>) {
     crate::system::backend::mark_runtime_shutting_down();
     let _ = emit_event(OutputEvent::Shutdown { reason });
@@ -3506,10 +3502,6 @@ async fn prepare_runtime_startup(
             message: "`mesh-llm serve` needs at least one startup model. Add `[[models]]` or pass `--model` / `--gguf` explicitly.".to_string(),
             context: Some(config_path.display().to_string()),
         });
-        if let Some(help_text) = &options.help_text {
-            eprint!("{help_text}");
-            write_stderr_newline();
-        }
         return Ok(None);
     }
 

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -200,11 +200,22 @@ mod dynamic {
                     manifest_url = ?options.manifest_url,
                     bundle_dirs = ?options.bundle_dirs,
                     allow_download = options.allow_download,
-                    "Failed to install a compatible MeshLLM native runtime during startup; continuing without dynamic native runtime"
+                    "Failed to install a compatible MeshLLM native runtime during startup; stopping before Skippy FFI load"
                 );
-                Ok(None)
+                Err(err.context(startup_missing_native_runtime_guidance(&options)))
             }
         }
+    }
+
+    fn startup_missing_native_runtime_guidance(options: &NativeRuntimeInstallOptions) -> String {
+        let abi = options
+            .skippy_abi_version
+            .as_deref()
+            .unwrap_or("the configured Skippy ABI");
+        format!(
+            "no compatible MeshLLM native runtime is installed or installable for MeshLLM {} / Skippy ABI {abi}; run `mesh-llm runtime install` or inspect available runtimes with `mesh-llm runtime list --available`",
+            options.mesh_version
+        )
     }
 
     fn resolve_installed_native_runtime_plan(
@@ -676,13 +687,13 @@ mod dynamic {
         }
 
         #[tokio::test]
-        async fn cache_miss_install_failure_returns_none_without_retry() {
+        async fn cache_miss_install_failure_stops_startup_before_ffi_load() {
             let temp = tempfile::tempdir().unwrap();
             let cache = NativeRuntimeCache::new(temp.path().join("cache"));
             let install_calls = Arc::new(Mutex::new(Vec::<NativeRuntimeInstallOptions>::new()));
             let load_calls = Arc::new(Mutex::new(0_usize));
 
-            let runtime = try_load_installed_native_runtime_with(
+            let error = try_load_installed_native_runtime_with(
                 || false,
                 || Ok(cache.clone()),
                 HostRuntimeProfile::current_without_gpu_probe,
@@ -713,9 +724,12 @@ mod dynamic {
                 },
             )
             .await
-            .unwrap();
+            .expect_err("missing native runtime should stop startup");
 
-            assert!(runtime.is_none());
+            let message = error.to_string();
+            assert!(message.contains("no compatible MeshLLM native runtime"));
+            assert!(message.contains("mesh-llm runtime install"));
+            assert!(message.contains("mesh-llm runtime list --available"));
             assert_eq!(install_calls.lock().unwrap().len(), 1);
             assert_eq!(*load_calls.lock().unwrap(), 0);
         }

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -211,7 +211,7 @@ mod dynamic {
         let abi = options
             .skippy_abi_version
             .as_deref()
-            .unwrap_or("the configured Skippy ABI");
+            .unwrap_or("not configured");
         format!(
             "no compatible MeshLLM native runtime is installed or installable for MeshLLM {} / Skippy ABI {abi}; run `mesh-llm runtime install` or inspect available runtimes with `mesh-llm runtime list --available`",
             options.mesh_version

--- a/crates/mesh-llm-system/src/embedded_release_footer.rs
+++ b/crates/mesh-llm-system/src/embedded_release_footer.rs
@@ -138,7 +138,7 @@ pub fn read_embedded_release_footer(
     let footer_bytes = &binary_bytes[footer_start..];
 
     if &footer_bytes[..8] != EMBEDDED_RELEASE_FOOTER_MAGIC {
-        if looks_like_corrupted_footer(binary_bytes.len(), footer_bytes) {
+        if looks_like_corrupted_footer(binary_bytes, footer_bytes) {
             return Err(EmbeddedReleaseFooterError::BadMagic);
         }
         return detect_truncated_footer_tail(binary_bytes)
@@ -262,20 +262,42 @@ fn footer_prefix_bytes() -> [u8; EMBEDDED_RELEASE_FOOTER_PREFIX_LEN] {
     prefix
 }
 
-fn looks_like_corrupted_footer(binary_len: usize, footer_bytes: &[u8]) -> bool {
+fn looks_like_corrupted_footer(binary_bytes: &[u8], footer_bytes: &[u8]) -> bool {
     let version = u32::from_le_bytes(footer_bytes[8..12].try_into().expect("slice length"));
     let reserved = u32::from_le_bytes(footer_bytes[20..24].try_into().expect("slice length"));
     let payload_len = u64::from_le_bytes(footer_bytes[12..20].try_into().expect("slice length"));
     let Ok(payload_len) = usize::try_from(payload_len) else {
         return false;
     };
-    let footer_start = binary_len - EMBEDDED_RELEASE_FOOTER_LEN;
+    let footer_start = binary_bytes.len() - EMBEDDED_RELEASE_FOOTER_LEN;
 
-    let plausible_payload = footer_start >= payload_len;
+    let plausible_payload = payload_len > 0
+        && footer_start >= payload_len
+        && looks_like_release_payload(&binary_bytes[footer_start - payload_len..footer_start]);
     let canonical_version = version == EMBEDDED_RELEASE_FOOTER_VERSION;
     let canonical_reserved = reserved == 0;
 
     plausible_payload && (canonical_version || canonical_reserved)
+}
+
+fn looks_like_release_payload(payload_bytes: &[u8]) -> bool {
+    let payload_bytes = trim_ascii_whitespace(payload_bytes);
+    payload_bytes.first() == Some(&b'{')
+        && payload_bytes
+            .windows(b"artifact_digest".len())
+            .any(|window| window == b"artifact_digest")
+}
+
+fn trim_ascii_whitespace(bytes: &[u8]) -> &[u8] {
+    let start = bytes
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .unwrap_or(bytes.len());
+    let end = bytes
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map_or(start, |index| index + 1);
+    &bytes[start..end]
 }
 
 #[cfg(test)]
@@ -431,6 +453,25 @@ mod tests {
             },
         );
         assert_eq!(verification.status, EmbeddedReleaseFooterStatus::Missing);
+    }
+
+    #[test]
+    fn embedded_release_footer_shaped_plain_binary_tail_is_missing() {
+        let mut binary = b"plain unsigned release binary".to_vec();
+        binary.extend_from_slice(b"NOTSURE!");
+        binary.extend_from_slice(&EMBEDDED_RELEASE_FOOTER_VERSION.to_le_bytes());
+        binary.extend_from_slice(&0u64.to_le_bytes());
+        binary.extend_from_slice(&0u32.to_le_bytes());
+
+        let verification = verify_embedded_release_footer(
+            &binary,
+            &TestPayloadVerifier {
+                expected_payload_bytes: Vec::new(),
+            },
+        );
+
+        assert_eq!(verification.status, EmbeddedReleaseFooterStatus::Missing);
+        assert!(verification.error.is_none());
     }
 
     #[test]

--- a/crates/mesh-llm-system/src/embedded_release_footer.rs
+++ b/crates/mesh-llm-system/src/embedded_release_footer.rs
@@ -100,6 +100,13 @@ impl std::fmt::Display for EmbeddedReleaseFooterError {
 
 impl std::error::Error for EmbeddedReleaseFooterError {}
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct EmbeddedReleaseFooterFields {
+    version: u32,
+    payload_len: u64,
+    reserved: u32,
+}
+
 pub fn stamp_embedded_release_payload(
     binary_bytes: &[u8],
     payload_bytes: &[u8],
@@ -138,7 +145,7 @@ pub fn read_embedded_release_footer(
     let footer_bytes = &binary_bytes[footer_start..];
 
     if &footer_bytes[..8] != EMBEDDED_RELEASE_FOOTER_MAGIC {
-        if looks_like_corrupted_footer(binary_bytes, footer_bytes) {
+        if looks_like_corrupted_footer(binary_bytes) {
             return Err(EmbeddedReleaseFooterError::BadMagic);
         }
         return detect_truncated_footer_tail(binary_bytes)
@@ -146,19 +153,19 @@ pub fn read_embedded_release_footer(
             .map_err(|()| EmbeddedReleaseFooterError::Truncated);
     }
 
-    let version = u32::from_le_bytes(footer_bytes[8..12].try_into().expect("slice length"));
-    if version != EMBEDDED_RELEASE_FOOTER_VERSION {
-        return Err(EmbeddedReleaseFooterError::UnsupportedVersion(version));
+    let fields = parse_embedded_release_footer_fields(footer_bytes);
+    if fields.version != EMBEDDED_RELEASE_FOOTER_VERSION {
+        return Err(EmbeddedReleaseFooterError::UnsupportedVersion(
+            fields.version,
+        ));
     }
 
-    let payload_len = u64::from_le_bytes(footer_bytes[12..20].try_into().expect("slice length"));
-    let reserved = u32::from_le_bytes(footer_bytes[20..24].try_into().expect("slice length"));
-    if reserved != 0 {
-        return Err(EmbeddedReleaseFooterError::NonZeroReserved(reserved));
+    if fields.reserved != 0 {
+        return Err(EmbeddedReleaseFooterError::NonZeroReserved(fields.reserved));
     }
 
-    let payload_len = usize::try_from(payload_len)
-        .map_err(|_| EmbeddedReleaseFooterError::PayloadLengthOverflow(payload_len))?;
+    let payload_len = usize::try_from(fields.payload_len)
+        .map_err(|_| EmbeddedReleaseFooterError::PayloadLengthOverflow(fields.payload_len))?;
     if footer_start < payload_len {
         return Err(EmbeddedReleaseFooterError::PayloadLengthOverflow(
             payload_len as u64,
@@ -262,42 +269,37 @@ fn footer_prefix_bytes() -> [u8; EMBEDDED_RELEASE_FOOTER_PREFIX_LEN] {
     prefix
 }
 
-fn looks_like_corrupted_footer(binary_bytes: &[u8], footer_bytes: &[u8]) -> bool {
-    let version = u32::from_le_bytes(footer_bytes[8..12].try_into().expect("slice length"));
-    let reserved = u32::from_le_bytes(footer_bytes[20..24].try_into().expect("slice length"));
-    let payload_len = u64::from_le_bytes(footer_bytes[12..20].try_into().expect("slice length"));
-    let Ok(payload_len) = usize::try_from(payload_len) else {
+fn parse_embedded_release_footer_fields(footer_bytes: &[u8]) -> EmbeddedReleaseFooterFields {
+    EmbeddedReleaseFooterFields {
+        version: u32::from_le_bytes(footer_bytes[8..12].try_into().expect("slice length")),
+        payload_len: u64::from_le_bytes(footer_bytes[12..20].try_into().expect("slice length")),
+        reserved: u32::from_le_bytes(footer_bytes[20..24].try_into().expect("slice length")),
+    }
+}
+
+fn looks_like_corrupted_footer(binary_bytes: &[u8]) -> bool {
+    let footer_start = binary_bytes.len() - EMBEDDED_RELEASE_FOOTER_LEN;
+    let footer_bytes = &binary_bytes[footer_start..];
+    let fields = parse_embedded_release_footer_fields(footer_bytes);
+    let Ok(payload_len) = usize::try_from(fields.payload_len) else {
         return false;
     };
-    let footer_start = binary_bytes.len() - EMBEDDED_RELEASE_FOOTER_LEN;
 
     let plausible_payload = payload_len > 0
         && footer_start >= payload_len
         && looks_like_release_payload(&binary_bytes[footer_start - payload_len..footer_start]);
-    let canonical_version = version == EMBEDDED_RELEASE_FOOTER_VERSION;
-    let canonical_reserved = reserved == 0;
+    let canonical_version = fields.version == EMBEDDED_RELEASE_FOOTER_VERSION;
+    let canonical_reserved = fields.reserved == 0;
 
     plausible_payload && (canonical_version || canonical_reserved)
 }
 
 fn looks_like_release_payload(payload_bytes: &[u8]) -> bool {
-    let payload_bytes = trim_ascii_whitespace(payload_bytes);
+    let payload_bytes = payload_bytes.trim_ascii();
     payload_bytes.first() == Some(&b'{')
         && payload_bytes
             .windows(b"artifact_digest".len())
             .any(|window| window == b"artifact_digest")
-}
-
-fn trim_ascii_whitespace(bytes: &[u8]) -> &[u8] {
-    let start = bytes
-        .iter()
-        .position(|byte| !byte.is_ascii_whitespace())
-        .unwrap_or(bytes.len());
-    let end = bytes
-        .iter()
-        .rposition(|byte| !byte.is_ascii_whitespace())
-        .map_or(start, |index| index + 1);
-    &bytes[start..end]
 }
 
 #[cfg(test)]

--- a/crates/mesh-llm-ui/pnpm-workspace.yaml
+++ b/crates/mesh-llm-ui/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 allowBuilds:
   fsevents: true
   onnxruntime-common: true

--- a/crates/mesh-llm-ui/pnpm-workspace.yaml
+++ b/crates/mesh-llm-ui/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
-  - "."
+  - '.'
 
 allowBuilds:
   fsevents: true

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -151,15 +151,21 @@ async fn dispatch_model_prepare(cmd: &Command) -> Result<()> {
 }
 
 async fn run_plugin_command(command: &mesh_llm_cli::PluginCommand, cli: &Cli) -> Result<()> {
-    let rows = if matches!(
-        command,
-        mesh_llm_cli::PluginCommand::List | mesh_llm_cli::PluginCommand::Info { .. }
-    ) {
-        Some(resolved_plugin_list_rows(cli)?)
-    } else {
-        None
-    };
-    mesh_llm_commands::plugin::run_plugin_command(command, rows.as_ref()).await?;
+    match command {
+        mesh_llm_cli::PluginCommand::List => {
+            let rows = resolved_plugin_list_rows(cli)?;
+            mesh_llm_commands::plugin::run_plugin_command(command, Some(&rows)).await?;
+        }
+        mesh_llm_cli::PluginCommand::Info { .. } => {
+            if !mesh_llm_commands::plugin::run_plugin_command(command, None).await? {
+                let rows = resolved_plugin_list_rows(cli)?;
+                mesh_llm_commands::plugin::run_plugin_command(command, Some(&rows)).await?;
+            }
+        }
+        _ => {
+            mesh_llm_commands::plugin::run_plugin_command(command, None).await?;
+        }
+    }
     Ok(())
 }
 

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -151,7 +151,10 @@ async fn dispatch_model_prepare(cmd: &Command) -> Result<()> {
 }
 
 async fn run_plugin_command(command: &mesh_llm_cli::PluginCommand, cli: &Cli) -> Result<()> {
-    let rows = if matches!(command, mesh_llm_cli::PluginCommand::List) {
+    let rows = if matches!(
+        command,
+        mesh_llm_cli::PluginCommand::List | mesh_llm_cli::PluginCommand::Info { .. }
+    ) {
         Some(resolved_plugin_list_rows(cli)?)
     } else {
         None

--- a/crates/mesh-llm/src/commands/runtime.rs
+++ b/crates/mesh-llm/src/commands/runtime.rs
@@ -516,6 +516,7 @@ fn display_runtime_state(value: &str) -> &'static str {
 fn display_backend_label(value: &str) -> &'static str {
     match value {
         "llama" => "Llama",
+        "skippy" => "Skippy",
         _ => "Unknown",
     }
 }
@@ -561,7 +562,7 @@ fn find_pid(processes: &[serde_json::Value], model: &serde_json::Value) -> Optio
 mod tests {
     use super::{
         build_apply_config_request, build_control_endpoint_request, build_guardrail_mode_request,
-        control_bootstrap_lines, runtime_success_lines, yes_no,
+        control_bootstrap_lines, display_backend_label, runtime_success_lines, yes_no,
     };
     use mesh_llm_cli::MeshGuardrailCliMode;
     use mesh_llm_host_runtime::command_support::plugin::{GpuAssignment, GpuConfig, MeshConfig};
@@ -622,6 +623,12 @@ mod tests {
     fn control_plane_bootstrap_yes_no_labels_are_stable() {
         assert_eq!(yes_no(true), "yes");
         assert_eq!(yes_no(false), "no");
+    }
+
+    #[test]
+    fn status_backend_labels_include_skippy() {
+        assert_eq!(display_backend_label("skippy"), "Skippy");
+        assert_eq!(display_backend_label("llama"), "Llama");
     }
 
     #[test]

--- a/crates/mesh-llm/src/lib.rs
+++ b/crates/mesh-llm/src/lib.rs
@@ -56,7 +56,7 @@ fn maybe_print_binary_help_and_exit() {
         std::process::exit(0);
     }
     if let Some(surface) = runtime_surface_help_request(args.iter().cloned()) {
-        print!("{}", mesh_llm_cli::runtime_surface_help(surface));
+        print!("{}", mesh_llm_cli::parser::runtime_surface_help(surface));
         std::process::exit(0);
     }
     if args.iter().any(|arg| arg == "--help-advanced") {
@@ -83,17 +83,11 @@ where
     I: IntoIterator<Item = std::ffi::OsString>,
 {
     let args: Vec<_> = args.into_iter().collect();
-    let [_program, surface, help] = args.as_slice() else {
-        return None;
-    };
+    let help = args.last()?;
     if help != "--help" && help != "-h" {
         return None;
     }
-    match surface.to_str() {
-        Some("serve") => Some(mesh_llm_cli::RuntimeSurface::Serve),
-        Some("client") => Some(mesh_llm_cli::RuntimeSurface::Client),
-        _ => None,
-    }
+    mesh_llm_cli::normalize_runtime_surface_args(args).explicit_surface
 }
 
 fn print_advanced_help() {
@@ -288,6 +282,29 @@ mod cli_entrypoint_tests {
         assert_eq!(
             super::runtime_surface_help_request([
                 OsString::from("mesh-llm"),
+                OsString::from("client"),
+                OsString::from("-h"),
+            ]),
+            Some(mesh_llm_cli::RuntimeSurface::Client)
+        );
+    }
+
+    #[test]
+    fn runtime_surface_help_request_skips_leading_global_flags() {
+        assert_eq!(
+            super::runtime_surface_help_request([
+                OsString::from("mesh-llm"),
+                OsString::from("--log-format"),
+                OsString::from("json"),
+                OsString::from("serve"),
+                OsString::from("--help"),
+            ]),
+            Some(mesh_llm_cli::RuntimeSurface::Serve)
+        );
+        assert_eq!(
+            super::runtime_surface_help_request([
+                OsString::from("mesh-llm"),
+                OsString::from("--relay-auth=https://relay.example=token"),
                 OsString::from("client"),
                 OsString::from("-h"),
             ]),

--- a/crates/mesh-llm/src/lib.rs
+++ b/crates/mesh-llm/src/lib.rs
@@ -8,6 +8,40 @@ mod commands;
 
 pub use mesh_llm_host_runtime::*;
 
+#[cfg(test)]
+mod cli_entrypoint_tests {
+    use std::ffi::OsString;
+
+    #[test]
+    fn runtime_surface_help_request_handles_serve_and_client_help() {
+        assert_eq!(
+            super::runtime_surface_help_request([
+                OsString::from("mesh-llm"),
+                OsString::from("serve"),
+                OsString::from("--help"),
+            ]),
+            Some(mesh_llm_cli::RuntimeSurface::Serve)
+        );
+        assert_eq!(
+            super::runtime_surface_help_request([
+                OsString::from("mesh-llm"),
+                OsString::from("client"),
+                OsString::from("-h"),
+            ]),
+            Some(mesh_llm_cli::RuntimeSurface::Client)
+        );
+    }
+
+    #[test]
+    fn binary_help_request_handles_help_help() {
+        assert!(super::binary_help_request([
+            OsString::from("mesh-llm"),
+            OsString::from("help"),
+            OsString::from("--help"),
+        ]));
+    }
+}
+
 pub async fn run_main() -> i32 {
     match run_cli_entrypoint().await {
         Ok(()) => 0,
@@ -51,13 +85,48 @@ async fn run_cli_entrypoint() -> anyhow::Result<()> {
 
 fn maybe_print_binary_help_and_exit() {
     let args: Vec<_> = std::env::args_os().collect();
-    if args.len() == 1 {
+    if binary_help_request(args.iter().cloned()) {
         mesh_llm_cli::Cli::command().print_help().ok();
+        std::process::exit(0);
+    }
+    if let Some(surface) = runtime_surface_help_request(args.iter().cloned()) {
+        print!("{}", mesh_llm_cli::runtime_surface_help(surface));
         std::process::exit(0);
     }
     if args.iter().any(|arg| arg == "--help-advanced") {
         print_advanced_help();
         std::process::exit(0);
+    }
+}
+
+fn binary_help_request<I>(args: I) -> bool
+where
+    I: IntoIterator<Item = std::ffi::OsString>,
+{
+    let args: Vec<_> = args.into_iter().collect();
+    match args.as_slice() {
+        [_program] => true,
+        [_program, arg] => arg == "--help" || arg == "-h",
+        [_program, help, arg] => help == "help" && (arg == "--help" || arg == "-h"),
+        _ => false,
+    }
+}
+
+fn runtime_surface_help_request<I>(args: I) -> Option<mesh_llm_cli::RuntimeSurface>
+where
+    I: IntoIterator<Item = std::ffi::OsString>,
+{
+    let args: Vec<_> = args.into_iter().collect();
+    let [_program, surface, help] = args.as_slice() else {
+        return None;
+    };
+    if help != "--help" && help != "-h" {
+        return None;
+    }
+    match surface.to_str() {
+        Some("serve") => Some(mesh_llm_cli::RuntimeSurface::Serve),
+        Some("client") => Some(mesh_llm_cli::RuntimeSurface::Client),
+        _ => None,
     }
 }
 

--- a/crates/mesh-llm/src/lib.rs
+++ b/crates/mesh-llm/src/lib.rs
@@ -8,40 +8,6 @@ mod commands;
 
 pub use mesh_llm_host_runtime::*;
 
-#[cfg(test)]
-mod cli_entrypoint_tests {
-    use std::ffi::OsString;
-
-    #[test]
-    fn runtime_surface_help_request_handles_serve_and_client_help() {
-        assert_eq!(
-            super::runtime_surface_help_request([
-                OsString::from("mesh-llm"),
-                OsString::from("serve"),
-                OsString::from("--help"),
-            ]),
-            Some(mesh_llm_cli::RuntimeSurface::Serve)
-        );
-        assert_eq!(
-            super::runtime_surface_help_request([
-                OsString::from("mesh-llm"),
-                OsString::from("client"),
-                OsString::from("-h"),
-            ]),
-            Some(mesh_llm_cli::RuntimeSurface::Client)
-        );
-    }
-
-    #[test]
-    fn binary_help_request_handles_help_help() {
-        assert!(super::binary_help_request([
-            OsString::from("mesh-llm"),
-            OsString::from("help"),
-            OsString::from("--help"),
-        ]));
-    }
-}
-
 pub async fn run_main() -> i32 {
     match run_cli_entrypoint().await {
         Ok(()) => 0,
@@ -302,5 +268,39 @@ fn map_trust_policy(
         mesh_llm_cli::TrustPolicy::Allowlist => {
             mesh_llm_host_runtime::crypto::TrustPolicy::Allowlist
         }
+    }
+}
+
+#[cfg(test)]
+mod cli_entrypoint_tests {
+    use std::ffi::OsString;
+
+    #[test]
+    fn runtime_surface_help_request_handles_serve_and_client_help() {
+        assert_eq!(
+            super::runtime_surface_help_request([
+                OsString::from("mesh-llm"),
+                OsString::from("serve"),
+                OsString::from("--help"),
+            ]),
+            Some(mesh_llm_cli::RuntimeSurface::Serve)
+        );
+        assert_eq!(
+            super::runtime_surface_help_request([
+                OsString::from("mesh-llm"),
+                OsString::from("client"),
+                OsString::from("-h"),
+            ]),
+            Some(mesh_llm_cli::RuntimeSurface::Client)
+        );
+    }
+
+    #[test]
+    fn binary_help_request_handles_help_help() {
+        assert!(super::binary_help_request([
+            OsString::from("mesh-llm"),
+            OsString::from("help"),
+            OsString::from("--help"),
+        ]));
     }
 }

--- a/scripts/rc-release-smoke.sh
+++ b/scripts/rc-release-smoke.sh
@@ -193,7 +193,7 @@ CHAT_RESPONSE="$(
 )"
 printf '%s' "$CHAT_RESPONSE" >"$AUDIT/chat-completions.json"
 printf '%s' "$CHAT_RESPONSE" |
-    python3 -c 'import json,sys; content=json.load(sys.stdin)["choices"][0]["message"]["content"]; raise SystemExit(0 if content.strip() else 1)'
+    python3 -c 'import json,sys; content=json.load(sys.stdin)["choices"][0]["message"]["content"]; raise SystemExit(0 if content.strip() == "rc-ok" else 1)'
 
 cleanup
 MESH_PID=""

--- a/scripts/rc-release-smoke.sh
+++ b/scripts/rc-release-smoke.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# rc-release-smoke.sh - verify the clean release install and inference path.
+#
+# Usage:
+#   scripts/rc-release-smoke.sh <release-tag>
+#
+# Useful overrides:
+#   MESH_RC_RELEASE_ASSET=<asset-name>
+#   MESH_RC_RELEASE_MODEL=<model-ref>
+#   MESH_RC_RELEASE_API_PORT=<port>
+#   MESH_RC_RELEASE_CONSOLE_PORT=<port>
+#   MESH_RC_RELEASE_AUDIT_DIR=<path>
+
+set -euo pipefail
+
+RELEASE_TAG="${1:?usage: $0 <release-tag>}"
+REPO="${MESH_RC_RELEASE_REPO:-Mesh-LLM/mesh-llm}"
+MODEL_REF="${MESH_RC_RELEASE_MODEL:-Qwen/Qwen2.5-0.5B-Instruct-GGUF:q4_k_m}"
+API_PORT="${MESH_RC_RELEASE_API_PORT:-19337}"
+CONSOLE_PORT="${MESH_RC_RELEASE_CONSOLE_PORT:-13131}"
+MAX_WAIT="${MESH_RC_RELEASE_MAX_WAIT:-240}"
+AUDIT="${MESH_RC_RELEASE_AUDIT_DIR:-$(mktemp -d /tmp/mesh-llm-rc-smoke.XXXXXX)}"
+HOME_DIR="$AUDIT/home"
+XDG_CACHE="$AUDIT/xdg-cache"
+XDG_DATA="$AUDIT/xdg-data"
+LOG="$AUDIT/mesh-llm.log"
+MESH_PID=""
+
+release_url() {
+    printf 'https://github.com/%s/releases/download/%s/%s\n' "$REPO" "$RELEASE_TAG" "$1"
+}
+
+canonical_arch() {
+    case "$(uname -m)" in
+        arm64|aarch64) printf 'aarch64\n' ;;
+        amd64|x86_64) printf 'x86_64\n' ;;
+        *) uname -m ;;
+    esac
+}
+
+release_target() {
+    case "$(uname -s)/$(canonical_arch)" in
+        Linux/aarch64) printf 'aarch64-unknown-linux-gnu\n' ;;
+        Linux/x86_64) printf 'x86_64-unknown-linux-gnu\n' ;;
+        Darwin/aarch64) printf 'aarch64-apple-darwin\n' ;;
+        *)
+            echo "unsupported smoke host: $(uname -s)/$(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+}
+
+archive_ext() {
+    case "$(uname -s)" in
+        Darwin) printf 'zip\n' ;;
+        *) printf 'tar.gz\n' ;;
+    esac
+}
+
+default_asset_name() {
+    printf 'mesh-llm-%s-%s.%s\n' "$RELEASE_TAG" "$(release_target)" "$(archive_ext)"
+}
+
+sha256_check() {
+    local sidecar="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c "$sidecar"
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 -c "$sidecar"
+    else
+        echo "sha256sum or shasum is required" >&2
+        exit 1
+    fi
+}
+
+extract_archive() {
+    local archive="$1"
+    case "$archive" in
+        *.tar.gz) tar -xzf "$archive" ;;
+        *.zip) unzip -q "$archive" ;;
+        *)
+            echo "unsupported release archive: $archive" >&2
+            exit 1
+            ;;
+    esac
+}
+
+mesh_env() {
+    HOME="$HOME_DIR" XDG_CACHE_HOME="$XDG_CACHE" XDG_DATA_HOME="$XDG_DATA" "$@"
+}
+
+cleanup() {
+    if [[ -n "$MESH_PID" ]]; then
+        kill "$MESH_PID" 2>/dev/null || true
+        pkill -P "$MESH_PID" 2>/dev/null || true
+        wait "$MESH_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+ASSET="${MESH_RC_RELEASE_ASSET:-$(default_asset_name)}"
+BINARY="$AUDIT/mesh-bundle/mesh-llm"
+
+mkdir -p "$HOME_DIR" "$XDG_CACHE" "$XDG_DATA"
+cd "$AUDIT"
+
+echo "=== RC release smoke ==="
+echo "  release: $RELEASE_TAG"
+echo "  asset:   $ASSET"
+echo "  audit:   $AUDIT"
+echo "  model:   $MODEL_REF"
+
+curl -fL -O "$(release_url "$ASSET")"
+curl -fL -O "$(release_url "$ASSET.sha256")"
+sha256_check "$ASSET.sha256"
+extract_archive "$ASSET"
+
+"$BINARY" --version
+
+echo "runtime list --available"
+mesh_env "$BINARY" runtime list --available --json | tee "$AUDIT/runtime-available.json"
+
+echo "runtime install"
+mesh_env "$BINARY" runtime install --json | tee "$AUDIT/runtime-install.json"
+
+echo "runtime list"
+mesh_env "$BINARY" runtime list | tee "$AUDIT/runtime-list.txt"
+
+echo "download $MODEL_REF"
+mesh_env "$BINARY" download "$MODEL_REF"
+
+MODEL_PATH="$(
+    find -L "$XDG_CACHE/huggingface/hub" -type f -name '*.gguf' | head -1
+)"
+if [[ -z "$MODEL_PATH" ]]; then
+    echo "download did not produce a GGUF under $XDG_CACHE/huggingface/hub" >&2
+    exit 1
+fi
+
+mesh_env "$BINARY" serve \
+    --log-format json \
+    --gguf "$MODEL_PATH" \
+    --port "$API_PORT" \
+    --console "$CONSOLE_PORT" \
+    >"$LOG" 2>&1 &
+MESH_PID=$!
+
+echo "waiting for /v1/models"
+MODEL_ID=""
+for second in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$MESH_PID" 2>/dev/null; then
+        echo "mesh-llm exited before readiness" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+    MODELS_JSON="$(curl -fsS "http://127.0.0.1:${API_PORT}/v1/models" 2>/dev/null || true)"
+    MODEL_ID="$(
+        printf '%s' "$MODELS_JSON" |
+            python3 -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0].get("id", "") if data else "")' 2>/dev/null ||
+            true
+    )"
+    if [[ -n "$MODEL_ID" ]]; then
+        echo "/v1/models ready with $MODEL_ID"
+        break
+    fi
+    if [[ "$second" -eq "$MAX_WAIT" ]]; then
+        echo "timed out waiting for /v1/models" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "checking /v1/chat/completions"
+CHAT_PAYLOAD="$(
+    python3 - "$MODEL_ID" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "model": sys.argv[1],
+    "messages": [{"role": "user", "content": "Reply with exactly: rc-ok"}],
+    "max_tokens": 16,
+    "temperature": 0,
+}))
+PY
+)"
+CHAT_RESPONSE="$(
+    curl -fsS "http://127.0.0.1:${API_PORT}/v1/chat/completions" \
+        -H 'content-type: application/json' \
+        -H 'authorization: Bearer mesh' \
+        -d "$CHAT_PAYLOAD"
+)"
+printf '%s' "$CHAT_RESPONSE" >"$AUDIT/chat-completions.json"
+printf '%s' "$CHAT_RESPONSE" |
+    python3 -c 'import json,sys; content=json.load(sys.stdin)["choices"][0]["message"]["content"]; raise SystemExit(0 if content.strip() else 1)'
+
+cleanup
+MESH_PID=""
+
+echo "verify no mesh-llm process remains"
+if pgrep -f "$BINARY" >/dev/null 2>&1; then
+    echo "mesh-llm process still running for $BINARY" >&2
+    exit 1
+fi
+
+echo "RC release smoke passed"

--- a/scripts/tests/test_build_ui.py
+++ b/scripts/tests/test_build_ui.py
@@ -12,6 +12,14 @@ SCRIPT = ROOT / "scripts" / "build-ui.sh"
 
 
 class BuildUiScriptTests(unittest.TestCase):
+    def test_ui_pnpm_workspace_names_root_package(self) -> None:
+        workspace = ROOT / "crates" / "mesh-llm-ui" / "pnpm-workspace.yaml"
+
+        contents = workspace.read_text(encoding="utf-8")
+
+        self.assertIn("packages:", contents)
+        self.assertRegex(contents, r"(?m)^\s*-\s*['\"]?\.[\"']?\s*$")
+
     def test_mixed_case_release_profile_uses_release_ui_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             ui_dir = Path(tmp) / "ui"

--- a/scripts/tests/test_rc_release_smoke.py
+++ b/scripts/tests/test_rc_release_smoke.py
@@ -31,6 +31,7 @@ class RcReleaseSmokeScriptTests(unittest.TestCase):
             "download",
             "/v1/models",
             "/v1/chat/completions",
+            'content.strip() == "rc-ok"',
             "verify no mesh-llm process remains",
         ):
             self.assertIn(marker, contents)

--- a/scripts/tests/test_rc_release_smoke.py
+++ b/scripts/tests/test_rc_release_smoke.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "rc-release-smoke.sh"
+
+
+class RcReleaseSmokeScriptTests(unittest.TestCase):
+    def test_script_parses_as_bash(self) -> None:
+        result = subprocess.run(
+            ["bash", "-n", str(SCRIPT)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_script_documents_required_green_path_steps(self) -> None:
+        contents = SCRIPT.read_text(encoding="utf-8")
+
+        for marker in (
+            "runtime list --available",
+            "runtime install",
+            "runtime list",
+            "download",
+            "/v1/models",
+            "/v1/chat/completions",
+            "verify no mesh-llm process remains",
+        ):
+            self.assertIn(marker, contents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_validate_release_native_runtime_matrix.py
+++ b/scripts/tests/test_validate_release_native_runtime_matrix.py
@@ -1,0 +1,77 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "validate-release-native-runtime-matrix.py"
+)
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("release_matrix_validator", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
+    def test_linux_aarch64_bundles_require_matching_runtime_entries(self):
+        validator = load_validator()
+        assets = [
+            "mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu.tar.gz",
+            "mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu-cuda-13.tar.gz",
+            "meshllm-native-runtime-linux-x86_64-cpu.tar.gz",
+        ]
+        manifest = {
+            "artifacts": [
+                {
+                    "id": "meshllm-native-runtime-linux-x86_64-cpu",
+                    "platform": {"os": "linux", "arch": "x86_64"},
+                    "backend": {"kind": "cpu"},
+                }
+            ]
+        }
+
+        violations = validator.find_matrix_violations(assets, manifest)
+
+        self.assertEqual(
+            violations,
+            [
+                "missing native runtime for binary target linux/aarch64/cpu",
+                "missing native runtime for binary target linux/aarch64/cuda13",
+            ],
+        )
+
+    def test_matching_linux_aarch64_cpu_and_cuda_entries_pass(self):
+        validator = load_validator()
+        assets = [
+            "mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu.tar.gz",
+            "mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu-cuda-13.tar.gz",
+        ]
+        manifest = {
+            "artifacts": [
+                {
+                    "id": "meshllm-native-runtime-linux-aarch64-cpu",
+                    "platform": {"os": "linux", "arch": "aarch64"},
+                    "backend": {"kind": "cpu"},
+                },
+                {
+                    "id": "meshllm-native-runtime-linux-aarch64-cuda13",
+                    "platform": {"os": "linux", "arch": "aarch64"},
+                    "backend": {
+                        "kind": "cuda",
+                        "cuda": {"toolkit_major": 13, "gpu_arches": []},
+                    },
+                },
+            ]
+        }
+
+        self.assertEqual(validator.find_matrix_violations(assets, manifest), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-release-native-runtime-matrix.py
+++ b/scripts/validate-release-native-runtime-matrix.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Validate release binary bundles against native-runtimes.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+TARGET_TRIPLES = {
+    "aarch64-apple-darwin": ("macos", "aarch64"),
+    "x86_64-apple-darwin": ("macos", "x86_64"),
+    "x86_64-unknown-linux-gnu": ("linux", "x86_64"),
+    "aarch64-unknown-linux-gnu": ("linux", "aarch64"),
+    "x86_64-pc-windows-msvc": ("windows", "x86_64"),
+}
+
+
+@dataclass(frozen=True, order=True)
+class RuntimeTarget:
+    os: str
+    arch: str
+    backend: str
+    cuda_major: int | None = None
+
+    def label(self) -> str:
+        if self.backend == "cuda" and self.cuda_major is not None:
+            return f"{self.os}/{self.arch}/cuda{self.cuda_major}"
+        return f"{self.os}/{self.arch}/{self.backend}"
+
+
+def default_backend(os_name: str, arch: str) -> str:
+    if os_name == "macos" and arch == "aarch64":
+        return "metal"
+    return "cpu"
+
+
+def binary_target_from_asset(asset_name: str) -> RuntimeTarget | None:
+    name = os.path.basename(asset_name)
+    if not name.startswith("mesh-llm-"):
+        return None
+    if name.endswith(".sha256"):
+        return None
+    if not (name.endswith(".tar.gz") or name.endswith(".zip")):
+        return None
+
+    for triple, (os_name, arch) in TARGET_TRIPLES.items():
+        marker = f"-{triple}"
+        if marker not in name:
+            continue
+        suffix = name.split(marker, 1)[1]
+        suffix = suffix.removesuffix(".tar.gz").removesuffix(".zip")
+        return target_from_suffix(os_name, arch, suffix)
+    return None
+
+
+def target_from_suffix(os_name: str, arch: str, suffix: str) -> RuntimeTarget:
+    if suffix == "":
+        return RuntimeTarget(os_name, arch, default_backend(os_name, arch))
+    if suffix.startswith("-cuda"):
+        match = re.fullmatch(r"-cuda(?:-(\d+))?", suffix)
+        if not match:
+            raise ValueError(f"unsupported CUDA release suffix: {suffix}")
+        major = int(match.group(1)) if match.group(1) else None
+        return RuntimeTarget(os_name, arch, "cuda", major)
+    return RuntimeTarget(os_name, arch, suffix.removeprefix("-"))
+
+
+def native_target_from_artifact(artifact: dict[str, Any]) -> RuntimeTarget | None:
+    platform = artifact.get("platform")
+    backend = artifact.get("backend")
+    if not isinstance(platform, dict) or not isinstance(backend, dict):
+        return None
+    os_name = platform.get("os")
+    arch = platform.get("arch")
+    kind = backend.get("kind")
+    if not all(isinstance(value, str) for value in (os_name, arch, kind)):
+        return None
+    cuda_major = None
+    if kind == "cuda":
+        cuda = backend.get("cuda")
+        if isinstance(cuda, dict) and isinstance(cuda.get("toolkit_major"), int):
+            cuda_major = cuda["toolkit_major"]
+    return RuntimeTarget(os_name, arch, kind, cuda_major)
+
+
+def native_target_matches(required: RuntimeTarget, candidate: RuntimeTarget) -> bool:
+    if (required.os, required.arch, required.backend) != (
+        candidate.os,
+        candidate.arch,
+        candidate.backend,
+    ):
+        return False
+    if required.backend == "cuda" and required.cuda_major is not None:
+        return candidate.cuda_major == required.cuda_major
+    return True
+
+
+def find_matrix_violations(
+    asset_names: list[str], manifest: dict[str, Any]
+) -> list[str]:
+    required_targets = {
+        target
+        for asset_name in asset_names
+        if (target := binary_target_from_asset(asset_name)) is not None
+    }
+    native_targets = [
+        target
+        for artifact in manifest.get("artifacts", [])
+        if isinstance(artifact, dict)
+        if (target := native_target_from_artifact(artifact)) is not None
+    ]
+    violations = []
+    for required in sorted(required_targets):
+        if not any(native_target_matches(required, candidate) for candidate in native_targets):
+            violations.append(
+                f"missing native runtime for binary target {required.label()}"
+            )
+    return violations
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate release binary bundle targets against native-runtimes.json."
+    )
+    parser.add_argument("--manifest", required=True, help="Path to native-runtimes.json")
+    parser.add_argument("assets", nargs="+", help="Release asset paths or names")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    with open(args.manifest, encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    violations = find_matrix_violations(args.assets, manifest)
+    if violations:
+        for violation in violations:
+            print(f"release matrix error: {violation}", file=sys.stderr)
+        return 1
+    print("release native runtime matrix is complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -10,9 +10,16 @@ Catalog id definition: a catalog id is the model id shown in `mesh-llm models re
 ```bash
 mesh-llm --help
 mesh-llm <command> --help
+mesh-llm serve --help
+mesh-llm client --help
+mesh-llm --help-advanced
 mesh-llm models --help
 mesh-llm models <subcommand> --help
 ```
+
+`serve --help` and `client --help` show concise runtime-entrypoint help for the
+most common serving and client-only options. Use `--help-advanced` when you need
+the complete runtime option surface.
 
 ## Check the running version
 
@@ -69,6 +76,11 @@ mesh-llm serve
 mesh-llm serve --model Qwen3-0.6B-Q4_K_M
 mesh-llm client --auto
 ```
+
+Use `mesh-llm serve --help` for the common serving flags, including `--model`,
+`--gguf`, `--auto`, `--join`, ports, and logging. Use
+`mesh-llm client --help` for client-only mesh operation when this machine should
+join or discover a mesh without serving a local model.
 
 Runtime switches:
 


### PR DESCRIPTION
## Summary

Fixes the RC4 release-readiness gaps found on Linux ARM64/Jetson-class hosts and tightens the release pipeline so RC5 fails before publishing an incomplete native-runtime matrix.

## What Changed

- Added Linux aarch64 native runtime release coverage:
  - CPU runtime on `ubuntu-24.04-arm`
  - CUDA 12 and CUDA 13 runtime packages for `aarch64-unknown-linux-gnu`
- Added release matrix validation so published binary bundles must have matching `native-runtimes.json` entries.
- Changed dynamic native-runtime startup to fail closed with actionable guidance instead of continuing into a Skippy FFI panic when no compatible runtime is available.
- Made `mesh-llm runtime doctor` a readiness gate by reporting unhealthy status, blockers, and install/list recommendations when no selected runtime exists.
- Fixed CUDA toolkit detection from `nvidia-smi` banner output, including `CUDA Version: 13.2`.
- Cleaned hardware-profile GPU labels so doctor no longer treats unrelated NVIDIA PCI bridge/probe rows as GPUs.
- Fixed CLI help surfaces for `mesh-llm serve --help` and `mesh-llm client --help`.
- Improved runtime/plugin CLI output:
  - status labels `skippy` as `Skippy`
  - `plugins info` can describe built-in runtime plugins
- Treats unsigned release-footer-shaped binary tails as missing/unsigned instead of invalid/corrupt.
- Fixed the UI package workspace metadata so pnpm handles the UI package consistently.
- Added `scripts/rc-release-smoke.sh` for the clean release path: download artifact, verify checksum, install runtime, download model, serve, call `/v1/chat/completions`, and clean up.

## Testing

- Added unit coverage for the native-runtime matrix validator.
- Added smoke-script tests.
- Added focused Rust tests for CLI help, doctor readiness, CUDA parsing, GPU label filtering, runtime status labels, plugin info, and release-footer handling.
- Verified `just build` on `mesh2.patio51.com` against this branch.
- Verified the built mesh2 CLI:
  - `mesh-llm 0.68.0+g6E8D33`
  - GPU discovery reports one CUDA GPU: `Orin` on `CUDA0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer help output for `serve` and `client` commands, with surface-specific usage and examples.
  * Expanded native release coverage for Linux aarch64 CPU and CUDA artifacts.
  * Added a release smoke test script for end-to-end validation.

* **Bug Fixes**
  * Improved runtime startup errors and guidance when a compatible native runtime is missing.
  * Made native runtime doctor output more actionable with status, blockers, and recommendations.
  * Refined hardware detection and plugin info display for more accurate results.

* **Chores**
  * Added release artifact matrix validation and supporting tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->