### PR TITLE
fix(ci): nightly stability run

### DIFF
--- a/scripts/qa-nightly-stability.py
+++ b/scripts/qa-nightly-stability.py
@@ -384,6 +384,8 @@ def run_models_probe(base_url: str, timeout: float) -> ProbeResult:
 
 def run_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> ProbeResult:
     started = time.monotonic()
+    actual_model = None
+    tok_per_sec = None
     try:
         response, status_code = post_json(
             base_url,
@@ -404,13 +406,15 @@ def run_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> P
     except Exception as exc:
         return _probe_result(
             model, attempt, "chat", False, str(exc), started,
-            actual_model=actual_model,  # type: ignore[union-attr]
-            tok_per_sec=tok_per_sec,  # type: ignore[union-attr]
+            actual_model=actual_model,
+            tok_per_sec=tok_per_sec,
         )
 
 
 def run_stream_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> ProbeResult:
     started = time.monotonic()
+    actual_model = None
+    tok_per_sec = None
     try:
         chunks, status_code, ttft_ms = post_json_stream(
             base_url,
@@ -420,7 +424,6 @@ def run_stream_chat_probe(base_url: str, model: str, attempt: int, timeout: floa
         )
         # Extract model name and usage from stream chunks (before sentinel
         # validation so these are available even on failure).
-        actual_model = None
         completion_tokens = 0
         for chunk in chunks:
             if not actual_model and chunk.get("model"):
@@ -451,8 +454,8 @@ def run_stream_chat_probe(base_url: str, model: str, attempt: int, timeout: floa
             False,
             str(exc),
             started,
-            actual_model=actual_model,  # type: ignore[union-attr]
-            tok_per_sec=tok_per_sec,  # type: ignore[union-attr]
+            actual_model=actual_model,
+            tok_per_sec=tok_per_sec,
         )
 
 

--- a/scripts/qa-nightly-stability.py
+++ b/scripts/qa-nightly-stability.py
@@ -372,6 +372,7 @@ def run_surface_probes(
 
 def run_models_probe(base_url: str, timeout: float) -> ProbeResult:
     started = time.monotonic()
+    status_code = None
     try:
         response, status_code = get_json(base_url, "/models", timeout)
         data = response.get("data")
@@ -379,11 +380,12 @@ def run_models_probe(base_url: str, timeout: float) -> ProbeResult:
             raise ValueError("models response did not contain any models")
         return _probe_result(None, None, "models", True, f"{len(data)} models", started, status_code)
     except Exception as exc:
-        return _probe_result(None, None, "models", False, str(exc), started)
+        return _probe_result(None, None, "models", False, str(exc), started, status_code)
 
 
 def run_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> ProbeResult:
     started = time.monotonic()
+    status_code = None
     actual_model = None
     tok_per_sec = None
     try:
@@ -406,6 +408,7 @@ def run_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> P
     except Exception as exc:
         return _probe_result(
             model, attempt, "chat", False, str(exc), started,
+            status_code,
             actual_model=actual_model,
             tok_per_sec=tok_per_sec,
         )
@@ -413,6 +416,8 @@ def run_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> P
 
 def run_stream_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> ProbeResult:
     started = time.monotonic()
+    status_code = None
+    ttft_ms = None
     actual_model = None
     tok_per_sec = None
     try:
@@ -454,6 +459,8 @@ def run_stream_chat_probe(base_url: str, model: str, attempt: int, timeout: floa
             False,
             str(exc),
             started,
+            status_code,
+            ttft_ms,
             actual_model=actual_model,
             tok_per_sec=tok_per_sec,
         )

--- a/scripts/tests/test_qa_nightly_stability.py
+++ b/scripts/tests/test_qa_nightly_stability.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -13,8 +14,8 @@ SCRIPT = ROOT / "scripts" / "qa-nightly-stability.py"
 
 def load_module():
     spec = importlib.util.spec_from_file_location("qa_nightly_stability", SCRIPT)
-    module = importlib.util.module_from_spec(spec)
     assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
@@ -40,6 +41,8 @@ class NightlyStabilityHarnessTests(unittest.TestCase):
             agent_smokes=["opencode", "pi", "goose"],
             skip_streaming=False,
             timeout=120.0,
+            mesh_binary=None,
+            release_attestation_expected_status=None,
         )
 
         self.assertEqual(plan["name"], "nightly-stability")
@@ -64,6 +67,8 @@ class NightlyStabilityHarnessTests(unittest.TestCase):
             agent_smokes=[],
             skip_streaming=True,
             timeout=30.0,
+            mesh_binary=None,
+            release_attestation_expected_status=None,
         )
         command = plan["steps"][1]["command"]
         self.assertIn("--skip-streaming", command)
@@ -159,6 +164,38 @@ class NightlyStabilityHarnessTests(unittest.TestCase):
         self.assertEqual(summary["failed"], 1)
         self.assertEqual(summary["total"], 2)
 
+    def test_chat_probe_reports_http_failure_without_crashing(self) -> None:
+        with mock.patch.object(
+            self.harness,
+            "post_json",
+            side_effect=RuntimeError("HTTP 403: error code: 1010"),
+        ):
+            result = self.harness.run_chat_probe("https://meshllm.cloud/v1", "auto", 1, 1.0)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.model, "auto")
+        self.assertEqual(result.attempt, 1)
+        self.assertEqual(result.phase, "chat")
+        self.assertIn("HTTP 403", result.detail)
+        self.assertIsNone(result.actual_model)
+        self.assertIsNone(result.tok_per_sec)
+
+    def test_stream_chat_probe_reports_http_failure_without_crashing(self) -> None:
+        with mock.patch.object(
+            self.harness,
+            "post_json_stream",
+            side_effect=RuntimeError("HTTP 403: error code: 1010"),
+        ):
+            result = self.harness.run_stream_chat_probe("https://meshllm.cloud/v1", "mesh", 1, 1.0)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.model, "mesh")
+        self.assertEqual(result.attempt, 1)
+        self.assertEqual(result.phase, "stream_chat")
+        self.assertIn("HTTP 403", result.detail)
+        self.assertIsNone(result.actual_model)
+        self.assertIsNone(result.tok_per_sec)
+
     def test_write_evidence_outputs_machine_readable_files(self) -> None:
         rows = [
             self.harness.CommandResult(
@@ -177,6 +214,8 @@ class NightlyStabilityHarnessTests(unittest.TestCase):
             agent_smokes=[],
             skip_streaming=False,
             timeout=30.0,
+            mesh_binary=None,
+            release_attestation_expected_status=None,
         )
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp)
@@ -230,7 +269,7 @@ class NightlyStabilityHarnessTests(unittest.TestCase):
                 "elapsed_ms": 10,
             },
         }
-        rendered = self.harness.render_summary_markdown(summary, [], [])
+        rendered = self.harness.render_summary_markdown(summary, [], [], None)
 
         self.assertIn("## Timing Snapshot", rendered)
         self.assertIn("| OpenAI surface probes | 1 | 0 | 0 | 10 |", rendered)

--- a/scripts/tests/test_qa_nightly_stability.py
+++ b/scripts/tests/test_qa_nightly_stability.py
@@ -180,6 +180,22 @@ class NightlyStabilityHarnessTests(unittest.TestCase):
         self.assertIsNone(result.actual_model)
         self.assertIsNone(result.tok_per_sec)
 
+    def test_chat_probe_reports_validation_failure_with_response_metadata(self) -> None:
+        response = {
+            "model": "auto-resolved",
+            "usage": {"completion_tokens": 8},
+            "choices": [{"message": {"content": "WRONG"}}],
+        }
+        with mock.patch.object(self.harness, "post_json", return_value=(response, 202)):
+            result = self.harness.run_chat_probe("https://meshllm.cloud/v1", "auto", 1, 1.0)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.status_code, 202)
+        self.assertIsNone(result.ttft_ms)
+        self.assertEqual(result.actual_model, "auto-resolved")
+        self.assertIsNotNone(result.tok_per_sec)
+        self.assertIn("expected exactly STABILITY_OK", result.detail)
+
     def test_stream_chat_probe_reports_http_failure_without_crashing(self) -> None:
         with mock.patch.object(
             self.harness,
@@ -195,6 +211,21 @@ class NightlyStabilityHarnessTests(unittest.TestCase):
         self.assertIn("HTTP 403", result.detail)
         self.assertIsNone(result.actual_model)
         self.assertIsNone(result.tok_per_sec)
+
+    def test_stream_chat_probe_reports_validation_failure_with_response_metadata(self) -> None:
+        chunks = [
+            {"model": "mesh-resolved", "choices": [{"delta": {"content": "WRONG"}}]},
+            {"usage": {"completion_tokens": 7}},
+        ]
+        with mock.patch.object(self.harness, "post_json_stream", return_value=(chunks, 206, 123)):
+            result = self.harness.run_stream_chat_probe("https://meshllm.cloud/v1", "mesh", 1, 1.0)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.status_code, 206)
+        self.assertEqual(result.ttft_ms, 123)
+        self.assertEqual(result.actual_model, "mesh-resolved")
+        self.assertIsNotNone(result.tok_per_sec)
+        self.assertIn("expected exactly STREAM_OK", result.detail)
 
     def test_write_evidence_outputs_machine_readable_files(self) -> None:
         rows = [


### PR DESCRIPTION
CI nightly stability runs were failing - this fixes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly QA probe stability when HTTP requests fail, ensuring failures are reported cleanly instead of interrupting the run.
  * Streaming and non-streaming probe results now consistently include available model and throughput details, with missing values clearly set when errors occur.
* **Tests**
  * Added additional nightly QA coverage for HTTP failure scenarios to verify correct probe status and error details are captured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->