### PR TITLE
fix: validate release native runtimes from explicit matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -943,14 +943,30 @@ jobs:
       - name: Generate native runtime release manifest
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+          SKIP_GPU_BUNDLES: ${{ needs.metadata.outputs.skip_gpu_bundles }}
         run: |
           scripts/generate-native-runtime-release-manifest.sh \
             --tag "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --out release-artifacts/native-runtimes.json \
             release-artifacts/meshllm-native-runtime-*.tar.gz
+          required_native_targets=(
+            "macos/aarch64/metal"
+            "linux/x86_64/cpu"
+            "linux/aarch64/cpu"
+          )
+          if [[ "$SKIP_GPU_BUNDLES" != "true" ]]; then
+            required_native_targets+=(
+              "linux/aarch64/cuda12"
+              "linux/aarch64/cuda13"
+            )
+          fi
+          validator_args=(--manifest release-artifacts/native-runtimes.json)
+          for target in "${required_native_targets[@]}"; do
+            validator_args+=(--required-target "$target")
+          done
           scripts/validate-release-native-runtime-matrix.py \
-            --manifest release-artifacts/native-runtimes.json \
+            "${validator_args[@]}" \
             release-artifacts/*
           shasum -a 256 release-artifacts/native-runtimes.json | awk '{print $1 "  native-runtimes.json"}' > release-artifacts/native-runtimes.json.sha256
 

--- a/scripts/tests/test_validate_release_native_runtime_matrix.py
+++ b/scripts/tests/test_validate_release_native_runtime_matrix.py
@@ -1,6 +1,8 @@
 import importlib.util
+import json
 import pathlib
 import sys
+import tempfile
 import unittest
 
 
@@ -161,6 +163,40 @@ class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
             violations,
             ["missing native runtime for binary target linux/aarch64/cpu"],
         )
+
+    def test_explicit_empty_required_targets_disable_asset_inference(self):
+        validator = load_validator()
+        assets = ["mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu.tar.gz"]
+
+        violations = validator.find_matrix_violations(assets, {}, set())
+
+        self.assertEqual(violations, [])
+
+    def test_cli_accepts_explicit_targets_without_asset_arguments(self):
+        validator = load_validator()
+        manifest = {
+            "artifacts": [
+                {
+                    "id": "meshllm-native-runtime-linux-x86_64-cpu",
+                    "platform": {"os": "linux", "arch": "x86_64"},
+                    "backend": {"kind": "cpu"},
+                }
+            ]
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as handle:
+            json.dump(manifest, handle)
+            handle.flush()
+
+            result = validator.main(
+                [
+                    "--manifest",
+                    handle.name,
+                    "--required-target",
+                    "linux/x86_64/cpu",
+                ]
+            )
+
+        self.assertEqual(result, 0)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_validate_release_native_runtime_matrix.py
+++ b/scripts/tests/test_validate_release_native_runtime_matrix.py
@@ -19,7 +19,7 @@ def load_validator():
 
 
 class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
-    def test_linux_aarch64_bundles_require_matching_runtime_entries(self):
+    def test_binary_asset_inference_requires_matching_runtime_entries(self):
         validator = load_validator()
         assets = [
             "mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu.tar.gz",
@@ -71,6 +71,96 @@ class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
         }
 
         self.assertEqual(validator.find_matrix_violations(assets, manifest), [])
+
+    def test_explicit_release_native_targets_ignore_static_gpu_bundles(self):
+        validator = load_validator()
+        assets = [
+            "mesh-llm-v0.72.0-rc5-x86_64-unknown-linux-gnu.tar.gz",
+            "mesh-llm-v0.72.0-rc5-x86_64-unknown-linux-gnu-cuda-12.tar.gz",
+            "mesh-llm-v0.72.0-rc5-x86_64-unknown-linux-gnu-cuda-13.tar.gz",
+            "mesh-llm-v0.72.0-rc5-x86_64-unknown-linux-gnu-rocm.tar.gz",
+            "mesh-llm-v0.72.0-rc5-x86_64-unknown-linux-gnu-vulkan.tar.gz",
+            "mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu.tar.gz",
+            "mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu-cuda-12.tar.gz",
+            "mesh-llm-v0.72.0-rc5-aarch64-unknown-linux-gnu-cuda-13.tar.gz",
+            "mesh-llm-v0.72.0-rc5-x86_64-pc-windows-msvc.zip",
+            "mesh-llm-v0.72.0-rc5-x86_64-pc-windows-msvc-cuda.zip",
+            "mesh-llm-v0.72.0-rc5-x86_64-pc-windows-msvc-rocm.zip",
+            "mesh-llm-v0.72.0-rc5-x86_64-pc-windows-msvc-vulkan.zip",
+        ]
+        manifest = {
+            "artifacts": [
+                {
+                    "id": "meshllm-native-runtime-darwin-aarch64-metal",
+                    "platform": {"os": "macos", "arch": "aarch64"},
+                    "backend": {"kind": "metal"},
+                },
+                {
+                    "id": "meshllm-native-runtime-linux-x86_64-cpu",
+                    "platform": {"os": "linux", "arch": "x86_64"},
+                    "backend": {"kind": "cpu"},
+                },
+                {
+                    "id": "meshllm-native-runtime-linux-aarch64-cpu",
+                    "platform": {"os": "linux", "arch": "aarch64"},
+                    "backend": {"kind": "cpu"},
+                },
+                {
+                    "id": "meshllm-native-runtime-linux-aarch64-cuda12",
+                    "platform": {"os": "linux", "arch": "aarch64"},
+                    "backend": {
+                        "kind": "cuda",
+                        "cuda": {"toolkit_major": 12, "gpu_arches": []},
+                    },
+                },
+                {
+                    "id": "meshllm-native-runtime-linux-aarch64-cuda13",
+                    "platform": {"os": "linux", "arch": "aarch64"},
+                    "backend": {
+                        "kind": "cuda",
+                        "cuda": {"toolkit_major": 13, "gpu_arches": []},
+                    },
+                },
+            ]
+        }
+        required_targets = {
+            validator.target_from_label("macos/aarch64/metal"),
+            validator.target_from_label("linux/x86_64/cpu"),
+            validator.target_from_label("linux/aarch64/cpu"),
+            validator.target_from_label("linux/aarch64/cuda12"),
+            validator.target_from_label("linux/aarch64/cuda13"),
+        }
+
+        violations = validator.find_matrix_violations(
+            assets,
+            manifest,
+            required_targets,
+        )
+
+        self.assertEqual(violations, [])
+
+    def test_explicit_release_native_targets_still_require_configured_entries(self):
+        validator = load_validator()
+        manifest = {
+            "artifacts": [
+                {
+                    "id": "meshllm-native-runtime-linux-x86_64-cpu",
+                    "platform": {"os": "linux", "arch": "x86_64"},
+                    "backend": {"kind": "cpu"},
+                }
+            ]
+        }
+        required_targets = {
+            validator.target_from_label("linux/x86_64/cpu"),
+            validator.target_from_label("linux/aarch64/cpu"),
+        }
+
+        violations = validator.find_matrix_violations([], manifest, required_targets)
+
+        self.assertEqual(
+            violations,
+            ["missing native runtime for binary target linux/aarch64/cpu"],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_validate_release_native_runtime_matrix.py
+++ b/scripts/tests/test_validate_release_native_runtime_matrix.py
@@ -183,14 +183,13 @@ class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
                 }
             ]
         }
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as handle:
-            json.dump(manifest, handle)
-            handle.flush()
-
+        with tempfile.TemporaryDirectory() as directory:
+            manifest_path = pathlib.Path(directory) / "native-runtimes.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
             result = validator.main(
                 [
                     "--manifest",
-                    handle.name,
+                    str(manifest_path),
                     "--required-target",
                     "linux/x86_64/cpu",
                 ]

--- a/scripts/validate-release-native-runtime-matrix.py
+++ b/scripts/validate-release-native-runtime-matrix.py
@@ -101,14 +101,31 @@ def native_target_matches(required: RuntimeTarget, candidate: RuntimeTarget) -> 
     return True
 
 
-def find_matrix_violations(
-    asset_names: list[str], manifest: dict[str, Any]
-) -> list[str]:
-    required_targets = {
+def target_from_label(label: str) -> RuntimeTarget:
+    parts = label.split("/")
+    if len(parts) != 3:
+        raise ValueError(f"expected target label as os/arch/backend, got {label!r}")
+    os_name, arch, backend = parts
+    match = re.fullmatch(r"cuda(\d+)", backend)
+    if match:
+        return RuntimeTarget(os_name, arch, "cuda", int(match.group(1)))
+    return RuntimeTarget(os_name, arch, backend)
+
+
+def required_targets_from_assets(asset_names: list[str]) -> set[RuntimeTarget]:
+    return {
         target
         for asset_name in asset_names
         if (target := binary_target_from_asset(asset_name)) is not None
     }
+
+
+def find_matrix_violations(
+    asset_names: list[str],
+    manifest: dict[str, Any],
+    required_targets: set[RuntimeTarget] | None = None,
+) -> list[str]:
+    required_targets = required_targets or required_targets_from_assets(asset_names)
     native_targets = [
         target
         for artifact in manifest.get("artifacts", [])
@@ -129,6 +146,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         description="Validate release binary bundle targets against native-runtimes.json."
     )
     parser.add_argument("--manifest", required=True, help="Path to native-runtimes.json")
+    parser.add_argument(
+        "--required-target",
+        action="append",
+        default=[],
+        help=(
+            "Native runtime target that must be present in the manifest, "
+            "formatted as os/arch/backend, for example linux/aarch64/cuda13. "
+            "When omitted, targets are inferred from release binary asset names."
+        ),
+    )
     parser.add_argument("assets", nargs="+", help="Release asset paths or names")
     return parser.parse_args(argv)
 
@@ -137,7 +164,14 @@ def main(argv: list[str]) -> int:
     args = parse_args(argv)
     with open(args.manifest, encoding="utf-8") as handle:
         manifest = json.load(handle)
-    violations = find_matrix_violations(args.assets, manifest)
+    try:
+        required_targets = {
+            target_from_label(label) for label in args.required_target
+        } or None
+    except ValueError as error:
+        print(f"release matrix error: {error}", file=sys.stderr)
+        return 2
+    violations = find_matrix_violations(args.assets, manifest, required_targets)
     if violations:
         for violation in violations:
             print(f"release matrix error: {violation}", file=sys.stderr)

--- a/scripts/validate-release-native-runtime-matrix.py
+++ b/scripts/validate-release-native-runtime-matrix.py
@@ -125,7 +125,8 @@ def find_matrix_violations(
     manifest: dict[str, Any],
     required_targets: set[RuntimeTarget] | None = None,
 ) -> list[str]:
-    required_targets = required_targets or required_targets_from_assets(asset_names)
+    if required_targets is None:
+        required_targets = required_targets_from_assets(asset_names)
     native_targets = [
         target
         for artifact in manifest.get("artifacts", [])
@@ -156,12 +157,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "When omitted, targets are inferred from release binary asset names."
         ),
     )
-    parser.add_argument("assets", nargs="+", help="Release asset paths or names")
+    parser.add_argument("assets", nargs="*", help="Release asset paths or names")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
+    if not args.required_target and not args.assets:
+        print(
+            "release matrix error: assets are required unless --required-target is provided",
+            file=sys.stderr,
+        )
+        return 2
     with open(args.manifest, encoding="utf-8") as handle:
         manifest = json.load(handle)
     try:


### PR DESCRIPTION
## Summary
- teach the release native-runtime validator to accept an explicit required target matrix
- update the release workflow to validate only the native runtime lanes the workflow actually builds
- keep the old asset-inference validator behavior available for direct CLI use

## Validation
- `python3 -m unittest scripts.tests.test_validate_release_native_runtime_matrix`
- `git diff --check`
- `actionlint .github/workflows/release.yml`
- simulated the failed RC5 release manifest step with representative release artifacts: legacy asset inference reproduced the missing linux/windows native-runtime errors, while the explicit release matrix passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native runtime validation now accepts an explicitly provided set of required targets (CPU and optional GPU/CUDA targets), and can validate using those targets instead of inferring from assets.
  * The release workflow now respects the GPU-bundle skip setting when running native runtime validation.

* **Bug Fixes**
  * Improved detection of missing native runtime entries when required targets are explicitly specified.
  * Invalid required-target labels now produce clearer errors and a nonzero exit code.

* **Tests**
  * Expanded coverage for explicit required-target behavior and CLI argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->