### PR TITLE
fix: RC5 release readiness corrections

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,155 @@ jobs:
             dist/native-runtimes/*.sha256
           if-no-files-found: error
 
+  build_native_runtime_linux_x86_64_cuda:
+    name: Build native runtime Linux x86_64 CUDA (${{ matrix.cuda_major }})
+    needs: metadata
+    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cuda_version: '12.9.2'
+            cuda_major: '12'
+            cuda_architectures: '75;80;86;87;89;90'
+          - cuda_version: '13.1.2'
+            cuda_major: '13'
+            cuda_architectures: '75;80;86;87;89;90;100;103;120;121'
+    container:
+      image: nvidia/cuda:${{ matrix.cuda_version }}-devel-ubuntu24.04
+    env:
+      LLAMA_STAGE_BACKEND: cuda
+      LLAMA_STAGE_CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
+      MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
+      MESH_LLM_CUDA_TOOLKIT_MAJOR: ${{ matrix.cuda_major }}
+    steps:
+      - name: Install base packages
+        run: |
+          for attempt in 1 2 3; do
+            apt-get -o Acquire::Retries=5 update &&
+              DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y --fix-missing ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential lld patchelf &&
+              break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          rm -rf /var/lib/apt/lists/*
+      - uses: actions/checkout@v5
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Package native runtime
+        run: |
+          scripts/package-native-runtime.sh \
+            --build \
+            --backend cuda \
+            --target x86_64-unknown-linux-gnu \
+            --out dist/native-runtimes
+      - name: Verify native runtime artifact
+        run: scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
+      - name: Upload native runtime
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-native-runtime-linux-x86_64-cuda-${{ matrix.cuda_major }}
+          path: |
+            dist/native-runtimes/*.tar.gz
+            dist/native-runtimes/*.sha256
+          if-no-files-found: error
+
+  build_native_runtime_linux_x86_64_rocm:
+    name: Build native runtime Linux x86_64 ROCm
+    needs: metadata
+    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
+    runs-on: ubuntu-24.04
+    container:
+      image: rocm/dev-ubuntu-24.04:7.0-complete
+    env:
+      LLAMA_STAGE_BACKEND: rocm
+      LLAMA_STAGE_AMDGPU_TARGETS: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201
+      MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
+    steps:
+      - name: Install base packages
+        run: |
+          for attempt in 1 2 3; do
+            apt-get -o Acquire::Retries=5 update &&
+              DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y --fix-missing ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential lld patchelf &&
+              break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          rm -rf /var/lib/apt/lists/*
+      - uses: actions/checkout@v5
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Package native runtime
+        run: |
+          scripts/package-native-runtime.sh \
+            --build \
+            --backend rocm \
+            --target x86_64-unknown-linux-gnu \
+            --out dist/native-runtimes
+      - name: Verify native runtime artifact
+        run: scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
+      - name: Upload native runtime
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-native-runtime-linux-x86_64-rocm
+          path: |
+            dist/native-runtimes/*.tar.gz
+            dist/native-runtimes/*.sha256
+          if-no-files-found: error
+
+  build_native_runtime_linux_x86_64_vulkan:
+    name: Build native runtime Linux x86_64 Vulkan
+    needs: metadata
+    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
+    runs-on: ubuntu-24.04
+    env:
+      LLAMA_STAGE_BACKEND: vulkan
+      MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl python3 glslc libvulkan-dev spirv-headers lld patchelf
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Package native runtime
+        run: |
+          scripts/package-native-runtime.sh \
+            --build \
+            --backend vulkan \
+            --target x86_64-unknown-linux-gnu \
+            --out dist/native-runtimes
+      - name: Verify native runtime artifact
+        run: scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
+      - name: Upload native runtime
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-native-runtime-linux-x86_64-vulkan
+          path: |
+            dist/native-runtimes/*.tar.gz
+            dist/native-runtimes/*.sha256
+          if-no-files-found: error
+
   build_swift_sdk_artifact:
     name: Build Swift SDK XCFramework
     needs: metadata
@@ -889,6 +1038,140 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  build_native_runtime_windows_cpu:
+    name: Build native runtime Windows x86_64 CPU
+    needs: metadata
+    runs-on: windows-2022
+    env:
+      LLAMA_STAGE_BACKEND: cpu
+      MESH_NATIVE_RUNTIME_TARGET: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Package native runtime
+        shell: bash
+        run: |
+          scripts/package-native-runtime.sh \
+            --build \
+            --backend cpu \
+            --target x86_64-pc-windows-msvc \
+            --out dist/native-runtimes
+      - name: Verify native runtime artifact
+        shell: bash
+        run: scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
+      - name: Upload native runtime
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-native-runtime-windows-x86_64-cpu
+          path: |
+            dist/native-runtimes/*.tar.gz
+            dist/native-runtimes/*.sha256
+          if-no-files-found: error
+
+  build_native_runtime_windows_gpu:
+    name: Build native runtime Windows x86_64 ${{ matrix.name }}
+    needs: metadata
+    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
+    runs-on: windows-2022
+    env:
+      ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
+      WINDOWS_CUDA_VERSION: ${{ vars.CUDA_VERSION || '12.9.2' }}
+      MESH_NATIVE_RUNTIME_TARGET: x86_64-pc-windows-msvc
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: CUDA
+            backend: cuda
+            cuda_architectures: '75;80;86;87;89;90'
+            artifact_name: release-native-runtime-windows-x86_64-cuda
+          - name: ROCm
+            backend: rocm
+            rocm_architectures: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201
+            artifact_name: release-native-runtime-windows-x86_64-rocm
+          - name: Vulkan
+            backend: vulkan
+            artifact_name: release-native-runtime-windows-x86_64-vulkan
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Cache Windows SDK installers
+        if: ${{ matrix.backend != 'cuda' }}
+        uses: actions/cache@v5
+        with:
+          path: ~/sdk-installer-cache/${{ matrix.backend }}
+          key: windows-sdk-installers-${{ matrix.backend }}-${{ env.ROCM_HIP_SDK_FILENAME }}-${{ hashFiles('scripts/install-windows-sdk.ps1') }}
+      - name: Install CUDA toolkit
+        if: ${{ matrix.backend == 'cuda' }}
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: ${{ env.WINDOWS_CUDA_VERSION }}
+          method: network
+          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "visual_studio_integration"]'
+          use-github-cache: true
+          use-local-cache: true
+          log-file-suffix: windows-cuda-native-runtime
+      - name: Verify CUDA toolkit
+        if: ${{ matrix.backend == 'cuda' }}
+        shell: pwsh
+        run: |
+          if (-not $env:CUDA_PATH -or -not (Test-Path $env:CUDA_PATH)) {
+            throw "CUDA_PATH was not configured by Jimver/cuda-toolkit."
+          }
+          & nvcc --version
+      - name: Install backend SDK
+        if: ${{ matrix.backend != 'cuda' }}
+        shell: pwsh
+        run: |
+          .\scripts\install-windows-sdk.ps1 `
+            -Backend "${{ matrix.backend }}" `
+            -RocmHipSdkFilename "$env:ROCM_HIP_SDK_FILENAME" `
+            -InstallerCacheDir "$HOME\sdk-installer-cache"
+      - name: Package native runtime
+        shell: bash
+        env:
+          LLAMA_STAGE_BACKEND: ${{ matrix.backend }}
+          LLAMA_STAGE_CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
+          LLAMA_STAGE_AMDGPU_TARGETS: ${{ matrix.rocm_architectures }}
+          MESH_LLM_CUDA_TOOLKIT_MAJOR: '12'
+        run: |
+          scripts/package-native-runtime.sh \
+            --build \
+            --backend "${{ matrix.backend }}" \
+            --target x86_64-pc-windows-msvc \
+            --out dist/native-runtimes
+      - name: Verify native runtime artifact
+        shell: bash
+        run: scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
+      - name: Upload native runtime
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: |
+            dist/native-runtimes/*.tar.gz
+            dist/native-runtimes/*.sha256
+          if-no-files-found: error
+
   publish:
     name: Publish GitHub release
     needs:
@@ -898,6 +1181,9 @@ jobs:
       - build_native_sdk_runtime
       - build_native_runtime
       - build_native_runtime_linux_aarch64_cuda
+      - build_native_runtime_linux_x86_64_cuda
+      - build_native_runtime_linux_x86_64_rocm
+      - build_native_runtime_linux_x86_64_vulkan
       - build_swift_sdk_artifact
       - build_linux_arm64
       - build_linux_aarch64_cuda
@@ -906,7 +1192,9 @@ jobs:
       - build_linux_vulkan
       - build_windows_cpu
       - build_windows_gpu
-    if: ${{ always() && needs.metadata.result == 'success' && needs.metadata.outputs.canary != 'true' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_native_sdk_runtime.result == 'success' && needs.build_native_runtime.result == 'success' && (needs.build_native_runtime_linux_aarch64_cuda.result == 'success' || needs.build_native_runtime_linux_aarch64_cuda.result == 'skipped') && needs.build_swift_sdk_artifact.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_aarch64_cuda.result == 'success' || needs.build_linux_aarch64_cuda.result == 'skipped') && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') && needs.build_windows_cpu.result == 'success' && (needs.build_windows_gpu.result == 'success' || needs.build_windows_gpu.result == 'skipped') }}
+      - build_native_runtime_windows_cpu
+      - build_native_runtime_windows_gpu
+    if: ${{ always() && needs.metadata.result == 'success' && needs.metadata.outputs.canary != 'true' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_native_sdk_runtime.result == 'success' && needs.build_native_runtime.result == 'success' && (needs.build_native_runtime_linux_aarch64_cuda.result == 'success' || needs.build_native_runtime_linux_aarch64_cuda.result == 'skipped') && (needs.build_native_runtime_linux_x86_64_cuda.result == 'success' || needs.build_native_runtime_linux_x86_64_cuda.result == 'skipped') && (needs.build_native_runtime_linux_x86_64_rocm.result == 'success' || needs.build_native_runtime_linux_x86_64_rocm.result == 'skipped') && (needs.build_native_runtime_linux_x86_64_vulkan.result == 'success' || needs.build_native_runtime_linux_x86_64_vulkan.result == 'skipped') && needs.build_swift_sdk_artifact.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_aarch64_cuda.result == 'success' || needs.build_linux_aarch64_cuda.result == 'skipped') && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') && needs.build_windows_cpu.result == 'success' && (needs.build_windows_gpu.result == 'success' || needs.build_windows_gpu.result == 'skipped') && needs.build_native_runtime_windows_cpu.result == 'success' && (needs.build_native_runtime_windows_gpu.result == 'success' || needs.build_native_runtime_windows_gpu.result == 'skipped') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -954,11 +1242,19 @@ jobs:
             "macos/aarch64/metal"
             "linux/x86_64/cpu"
             "linux/aarch64/cpu"
+            "windows/x86_64/cpu"
           )
           if [[ "$SKIP_GPU_BUNDLES" != "true" ]]; then
             required_native_targets+=(
               "linux/aarch64/cuda12"
               "linux/aarch64/cuda13"
+              "linux/x86_64/cuda12"
+              "linux/x86_64/cuda13"
+              "linux/x86_64/rocm"
+              "linux/x86_64/vulkan"
+              "windows/x86_64/cuda"
+              "windows/x86_64/rocm"
+              "windows/x86_64/vulkan"
             )
           fi
           validator_args=(--manifest release-artifacts/native-runtimes.json)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,8 @@ jobs:
       LLAMA_STAGE_BACKEND: ${{ matrix.backend }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -207,6 +209,8 @@ jobs:
       MESH_NATIVE_SDK_TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -278,6 +282,8 @@ jobs:
       MESH_NATIVE_RUNTIME_TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -350,6 +356,8 @@ jobs:
           done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: dtolnay/rust-toolchain@stable
@@ -412,6 +420,8 @@ jobs:
           done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: dtolnay/rust-toolchain@stable
@@ -463,6 +473,8 @@ jobs:
           done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: dtolnay/rust-toolchain@stable
@@ -499,6 +511,8 @@ jobs:
       MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl python3 glslc libvulkan-dev spirv-headers lld patchelf
@@ -533,6 +547,8 @@ jobs:
       LLAMA_STAGE_BACKEND: metal
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -615,6 +631,8 @@ jobs:
       MESH_RELEASE_ARCH: aarch64
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -681,6 +699,8 @@ jobs:
           done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: pnpm/action-setup@v4
@@ -746,6 +766,8 @@ jobs:
           done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: pnpm/action-setup@v4
@@ -808,6 +830,8 @@ jobs:
           done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: pnpm/action-setup@v4
@@ -854,6 +878,8 @@ jobs:
       LLAMA_STAGE_BACKEND: vulkan
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -899,6 +925,8 @@ jobs:
       LLAMA_STAGE_BACKEND: cpu
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -972,6 +1000,8 @@ jobs:
             artifact_name: release-windows-vulkan
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -991,12 +1021,6 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
-      - name: Cache Windows SDK installers
-        if: ${{ matrix.backend != 'cuda' }}
-        uses: actions/cache@v5
-        with:
-          path: ~/sdk-installer-cache/${{ matrix.backend }}
-          key: windows-sdk-installers-${{ matrix.backend }}-${{ env.ROCM_HIP_SDK_FILENAME }}-${{ hashFiles('scripts/install-windows-sdk.ps1') }}
       - name: Install CUDA toolkit
         if: ${{ matrix.backend == 'cuda' }}
         uses: Jimver/cuda-toolkit@v0.2.35
@@ -1053,6 +1077,8 @@ jobs:
       MESH_NATIVE_RUNTIME_TARGET: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
@@ -1100,7 +1126,7 @@ jobs:
           - name: CUDA
             backend: cuda
             cuda_architectures: '75;80;86;87;89;90'
-            artifact_name: release-native-runtime-windows-x86_64-cuda
+            artifact_name: release-native-runtime-windows-x86_64-cuda12
           - name: ROCm
             backend: rocm
             rocm_architectures: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201
@@ -1110,6 +1136,8 @@ jobs:
             artifact_name: release-native-runtime-windows-x86_64-vulkan
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
@@ -1121,12 +1149,6 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
-      - name: Cache Windows SDK installers
-        if: ${{ matrix.backend != 'cuda' }}
-        uses: actions/cache@v5
-        with:
-          path: ~/sdk-installer-cache/${{ matrix.backend }}
-          key: windows-sdk-installers-${{ matrix.backend }}-${{ env.ROCM_HIP_SDK_FILENAME }}-${{ hashFiles('scripts/install-windows-sdk.ps1') }}
       - name: Install CUDA toolkit
         if: ${{ matrix.backend == 'cuda' }}
         uses: Jimver/cuda-toolkit@v0.2.35
@@ -1205,6 +1227,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -1258,7 +1281,7 @@ jobs:
               "linux/x86_64/cuda13"
               "linux/x86_64/rocm"
               "linux/x86_64/vulkan"
-              "windows/x86_64/cuda"
+              "windows/x86_64/cuda12"
               "windows/x86_64/rocm"
               "windows/x86_64/vulkan"
             )
@@ -1320,6 +1343,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'
@@ -1338,6 +1363,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -702,8 +702,14 @@ jobs:
         run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Build aarch64 CUDA release bundle
         env:
+          MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE: ${{ runner.temp }}/mesh-release-attestation-private-key.json
+          MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE: ${{ runner.temp }}/mesh-release-attestation-public-key.json
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+          RELEASE_ATTESTATION_SIGNING_KEY: ${{ secrets.MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE }}
+          RELEASE_ATTESTATION_PUBLIC_KEY: ${{ secrets.MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE }}
         run: |
+          printf '%s' "$RELEASE_ATTESTATION_SIGNING_KEY" > "$MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE"
+          printf '%s' "$RELEASE_ATTESTATION_PUBLIC_KEY" > "$MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE"
           just --shell bash --shell-arg -c release-build-aarch64-cuda
           just --shell bash --shell-arg -c release-bundle-aarch64-cuda "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,12 +51,10 @@ Set or rotate the repository secrets from the generated files with:
 
 ```bash
 gh secret set MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE \
-  --repo Mesh-LLM/mesh-llm \
   --app actions \
   < /tmp/mesh-release-attestation/mesh-release-attestation-private-key.json
 
 gh secret set MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE \
-  --repo Mesh-LLM/mesh-llm \
   --app actions \
   < /tmp/mesh-release-attestation/mesh-release-attestation-public-key.json
 ```
@@ -72,7 +70,8 @@ cargo run -p xtask -- release-attestation inspect \
 ```
 
 The reported status must be `valid`. A `missing` status means the bundle was
-published without an embedded release-attestation footer.
+published without an embedded release-attestation footer. An `invalid` status
+means a footer was present, but signature verification failed.
 
 ## Build
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,57 @@ locally.
 - Node/npm installed for the UI build
 - `gh` CLI authenticated if publishing manually
 
+## Release Attestation Signing Keys
+
+The GitHub Actions release workflow stamps packaged `mesh-llm` executables when
+these repository Actions secrets are present:
+
+- `MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE`
+- `MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE`
+
+The secret values are the full JSON contents of the release-attestation private
+and public key files, not paths to files. Generate a production keypair with:
+
+```bash
+umask 077
+mkdir -p /tmp/mesh-release-attestation
+cargo run -q -p xtask -- release-attestation generate-keypair \
+  --private-key-out /tmp/mesh-release-attestation/mesh-release-attestation-private-key.json \
+  --public-key-out /tmp/mesh-release-attestation/mesh-release-attestation-public-key.json
+```
+
+Store the keypair in 1Password before adding or rotating GitHub secrets. The
+production release-attestation keypair lives in the `mesh-llm` vault as
+`GitHub Actions Release Attestation Signing Keys`, with fields named exactly
+after the GitHub Actions secrets above.
+
+Set or rotate the repository secrets from the generated files with:
+
+```bash
+gh secret set MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE \
+  --repo Mesh-LLM/mesh-llm \
+  --app actions \
+  < /tmp/mesh-release-attestation/mesh-release-attestation-private-key.json
+
+gh secret set MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE \
+  --repo Mesh-LLM/mesh-llm \
+  --app actions \
+  < /tmp/mesh-release-attestation/mesh-release-attestation-public-key.json
+```
+
+After publishing, verify at least one packaged release archive by extracting it
+and running:
+
+```bash
+cargo run -p xtask -- release-attestation inspect \
+  --binary /tmp/test-bundle/mesh-llm \
+  --public-key-file /tmp/mesh-release-attestation/mesh-release-attestation-public-key.json \
+  --json
+```
+
+The reported status must be `valid`. A `missing` status means the bundle was
+published without an embedded release-attestation footer.
+
 ## Build
 
 ```bash

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -1,8 +1,8 @@
 use mesh_llm_native_runtime::{
-    HostCudaProfile, HostGpuProfile, HostRocmProfile, HostRuntimeProfile, HostVulkanProfile,
-    NativeRuntimeBackendKind,
+    HostCudaProfile, HostGpuProbe, HostGpuProfile, HostRocmProfile, HostRuntimeProfile,
+    HostVulkanProfile, NativeRuntimeBackendKind,
 };
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
 
 pub fn host_runtime_profile() -> HostRuntimeProfile {
@@ -57,20 +57,202 @@ pub fn detected_native_runtime_flavors(
 }
 
 fn detect_gpus() -> Vec<HostGpuProfile> {
-    let labels = gpu_labels();
-    labels
+    let nvidia_gpus = detect_nvidia_gpu_profiles();
+    if !nvidia_gpus.is_empty() {
+        return nvidia_gpus;
+    }
+
+    gpu_labels()
         .into_iter()
         .enumerate()
-        .map(|(index, label)| HostGpuProfile {
-            display_name: label,
-            backend_device: None,
-            stable_id: Some(format!("detected-{index}")),
-            vram_bytes: None,
-            unified_memory: cfg!(target_os = "macos"),
-            cuda_sm: None,
-            rocm_gfx: None,
+        .map(|(index, label)| {
+            let backend_device = backend_device_from_label(&label, index);
+            HostGpuProfile {
+                display_name: label,
+                backend_device,
+                stable_id: Some(format!("detected-{index}")),
+                vram_bytes: None,
+                unified_memory: cfg!(target_os = "macos"),
+                probe: None,
+                cuda_sm: None,
+                rocm_gfx: None,
+            }
         })
         .collect()
+}
+
+fn backend_device_from_label(label: &str, index: usize) -> Option<String> {
+    let label = label.to_ascii_lowercase();
+    if label.contains("nvidia") || label.contains("cuda") {
+        Some(format!("CUDA{index}"))
+    } else if label.contains("amd") || label.contains("radeon") || label.contains("rocm") {
+        Some(format!("ROCm{index}"))
+    } else if cfg!(target_os = "macos") && label.contains("apple") {
+        Some(format!("MTL{index}"))
+    } else {
+        None
+    }
+}
+
+fn detect_nvidia_gpu_profiles() -> Vec<HostGpuProfile> {
+    let Some(nvidia_smi) = command_output("nvidia-smi", &["-L"]) else {
+        return Vec::new();
+    };
+    let lspci = command_output("lspci", &[]).unwrap_or_default();
+    let proc_entries = linux_nvidia_proc_information_entries();
+    let borrowed_entries: Vec<(&str, &str)> = proc_entries
+        .iter()
+        .map(|entry| (entry.path.as_str(), entry.info.as_str()))
+        .collect();
+    nvidia_gpu_profiles_from_probe_outputs(&nvidia_smi, &lspci, &borrowed_entries)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct NvidiaSmiGpu {
+    index: usize,
+    name: String,
+    vendor_uuid: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct NvidiaProcInformationEntry {
+    path: String,
+    info: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct NvidiaProcProbe {
+    pci_bdf: Option<String>,
+    vendor_uuid: Option<String>,
+    probe: HostGpuProbe,
+}
+
+fn nvidia_gpu_profiles_from_probe_outputs(
+    nvidia_smi_output: &str,
+    lspci_output: &str,
+    proc_entries: &[(&str, &str)],
+) -> Vec<HostGpuProfile> {
+    let mut proc_probes = proc_entries
+        .iter()
+        .map(|(path, info)| nvidia_proc_probe(path, info))
+        .collect::<Vec<_>>();
+
+    parse_nvidia_smi_list(nvidia_smi_output)
+        .into_iter()
+        .map(|gpu| {
+            let pci_bdf = nvidia_lspci_bdf_for_name(lspci_output, &gpu.name);
+            let probe = take_matching_nvidia_probe(
+                &mut proc_probes,
+                gpu.vendor_uuid.as_deref(),
+                pci_bdf.as_deref(),
+            );
+            HostGpuProfile {
+                display_name: gpu.name,
+                backend_device: Some(format!("CUDA{}", gpu.index)),
+                stable_id: gpu
+                    .vendor_uuid
+                    .as_ref()
+                    .map(|uuid| format!("uuid:{uuid}"))
+                    .or_else(|| pci_bdf.as_ref().map(|bdf| format!("pci:{bdf}"))),
+                vram_bytes: None,
+                unified_memory: false,
+                probe,
+                cuda_sm: None,
+                rocm_gfx: None,
+            }
+        })
+        .collect()
+}
+
+fn parse_nvidia_smi_list(output: &str) -> Vec<NvidiaSmiGpu> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let body = line.strip_prefix("GPU ")?;
+            let (index, rest) = body.split_once(':')?;
+            let index = index.trim().parse::<usize>().ok()?;
+            let rest = rest.trim();
+            let (name, vendor_uuid) = match rest.rsplit_once(" (UUID: ") {
+                Some((name, uuid)) => (name.trim(), uuid.strip_suffix(')').map(str::trim)),
+                None => (rest, None),
+            };
+            (!name.is_empty()).then(|| NvidiaSmiGpu {
+                index,
+                name: name.to_string(),
+                vendor_uuid: vendor_uuid.map(ToOwned::to_owned),
+            })
+        })
+        .collect()
+}
+
+fn nvidia_lspci_bdf_for_name(output: &str, name: &str) -> Option<String> {
+    let name = name.to_ascii_lowercase();
+    output.lines().find_map(|line| {
+        let line = line.trim();
+        if !looks_like_display_controller(line) {
+            return None;
+        }
+        let lower = line.to_ascii_lowercase();
+        if !name
+            .split_whitespace()
+            .filter(|token| *token != "nvidia" && *token != "geforce")
+            .all(|token| lower.contains(token))
+        {
+            return None;
+        }
+        line.split_whitespace().next().map(normalize_pci_bdf)
+    })
+}
+
+fn normalize_pci_bdf(bdf: &str) -> String {
+    if bdf.matches(':').count() == 1 {
+        format!("0000:{bdf}")
+    } else {
+        bdf.to_ascii_lowercase()
+    }
+}
+
+fn nvidia_proc_probe(path: &str, info: &str) -> NvidiaProcProbe {
+    let fields = nvidia_proc_fields(info);
+    NvidiaProcProbe {
+        pci_bdf: fields
+            .get("Bus Location")
+            .map(String::as_str)
+            .map(normalize_pci_bdf),
+        vendor_uuid: fields.get("GPU UUID").cloned(),
+        probe: HostGpuProbe {
+            source: "linux_nvidia_proc".to_string(),
+            path: Some(path.to_string()),
+            fields,
+            raw_lines: info.lines().map(str::to_string).collect(),
+        },
+    }
+}
+
+fn nvidia_proc_fields(info: &str) -> BTreeMap<String, String> {
+    info.lines()
+        .filter_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            let key = key.trim();
+            if key.is_empty() {
+                return None;
+            }
+            Some((key.to_string(), value.trim().to_string()))
+        })
+        .collect()
+}
+
+fn take_matching_nvidia_probe(
+    probes: &mut Vec<NvidiaProcProbe>,
+    vendor_uuid: Option<&str>,
+    pci_bdf: Option<&str>,
+) -> Option<HostGpuProbe> {
+    let index = probes.iter().position(|probe| {
+        vendor_uuid.is_some_and(|uuid| probe.vendor_uuid.as_deref() == Some(uuid))
+            || pci_bdf.is_some_and(|bdf| probe.pci_bdf.as_deref() == Some(bdf))
+    })?;
+    Some(probes.remove(index).probe)
 }
 
 fn detect_cuda_profile(gpus: &[HostGpuProfile]) -> Option<HostCudaProfile> {
@@ -179,7 +361,6 @@ fn leading_major_version(value: &str) -> Option<u32> {
 
 fn gpu_labels() -> Vec<String> {
     let mut labels = Vec::new();
-    append_command_lines(&mut labels, "nvidia-smi", &["-L"]);
     append_command_lines(&mut labels, "rocminfo", &[]);
     append_command_lines(&mut labels, "vulkaninfo", &["--summary"]);
     append_platform_gpu_labels(&mut labels);
@@ -191,21 +372,29 @@ fn gpu_labels() -> Vec<String> {
 #[cfg(target_os = "linux")]
 fn append_platform_gpu_labels(labels: &mut Vec<String>) {
     append_command_lines(labels, "lspci", &[]);
-    append_linux_nvidia_proc_labels(labels);
 }
 
 #[cfg(target_os = "linux")]
-fn append_linux_nvidia_proc_labels(labels: &mut Vec<String>) {
+fn linux_nvidia_proc_information_entries() -> Vec<NvidiaProcInformationEntry> {
     let Ok(entries) = std::fs::read_dir("/proc/driver/nvidia/gpus") else {
-        return;
+        return Vec::new();
     };
-    for entry in entries.flatten() {
-        let path = entry.path().join("information");
-        let Ok(info) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        labels.extend(info.lines().map(str::to_string));
-    }
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path().join("information");
+            let info = std::fs::read_to_string(&path).ok()?;
+            Some(NvidiaProcInformationEntry {
+                path: path.display().to_string(),
+                info,
+            })
+        })
+        .collect()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn linux_nvidia_proc_information_entries() -> Vec<NvidiaProcInformationEntry> {
+    Vec::new()
 }
 
 #[cfg(target_os = "windows")]
@@ -371,6 +560,7 @@ mod tests {
             stable_id: None,
             vram_bytes: None,
             unified_memory: false,
+            probe: None,
             cuda_sm: None,
             rocm_gfx: None,
         }
@@ -455,5 +645,77 @@ deviceName         = AMD Radeon PRO W7900
                     .to_string()
             ]
         );
+    }
+
+    #[test]
+    fn nvidia_proc_details_are_nested_under_matching_gpus() {
+        let nvidia_smi = "\
+GPU 0: NVIDIA GeForce RTX 5090 (UUID: GPU-80ded6bd-1a89-2628-3d94-902187dbab1d)
+GPU 1: NVIDIA GeForce RTX 3080 (UUID: GPU-6b7fe24c-5f15-4ac5-88d6-c8934135a4ea)
+";
+        let lspci = "\
+01:00.0 VGA compatible controller: NVIDIA Corporation GB202 [GeForce RTX 5090] (rev a1)
+06:00.0 VGA compatible controller: NVIDIA Corporation GA102 [GeForce RTX 3080] (rev a1)
+";
+        let proc_entries = vec![
+            (
+                "/proc/driver/nvidia/gpus/0000:01:00.0/information",
+                "\
+Model: \t\t NVIDIA GeForce RTX 5090
+IRQ:   \t\t 16
+GPU UUID: \t GPU-80ded6bd-1a89-2628-3d94-902187dbab1d
+Video BIOS: \t 98.02.2e.40.7f
+Bus Type: \t PCIe
+DMA Size: \t 52 bits
+DMA Mask: \t 0xfffffffffffff
+Bus Location: \t 0000:01:00.0
+Device Minor: \t 0
+GPU Firmware: \t 610.43.02
+GPU Excluded:\t No
+",
+            ),
+            (
+                "/proc/driver/nvidia/gpus/0000:06:00.0/information",
+                "\
+Model: \t\t NVIDIA GeForce RTX 3080
+IRQ:   \t\t 184
+GPU UUID: \t GPU-6b7fe24c-5f15-4ac5-88d6-c8934135a4ea
+Video BIOS: \t 94.02.42.80.31
+Bus Type: \t PCIe
+DMA Size: \t 47 bits
+DMA Mask: \t 0x7fffffffffff
+Bus Location: \t 0000:06:00.0
+Device Minor: \t 1
+GPU Firmware: \t 610.43.02
+GPU Excluded:\t No
+",
+            ),
+        ];
+
+        let gpus = nvidia_gpu_profiles_from_probe_outputs(nvidia_smi, lspci, &proc_entries);
+
+        assert_eq!(gpus.len(), 2);
+        assert_eq!(gpus[0].display_name, "NVIDIA GeForce RTX 5090");
+        assert_eq!(gpus[0].backend_device.as_deref(), Some("CUDA0"));
+        assert_eq!(
+            gpus[0].stable_id.as_deref(),
+            Some("uuid:GPU-80ded6bd-1a89-2628-3d94-902187dbab1d")
+        );
+        let probe = gpus[0].probe.as_ref().expect("RTX 5090 probe details");
+        assert_eq!(probe.source, "linux_nvidia_proc");
+        assert_eq!(
+            probe.path.as_deref(),
+            Some("/proc/driver/nvidia/gpus/0000:01:00.0/information")
+        );
+        assert_eq!(probe.fields.get("IRQ").map(String::as_str), Some("16"));
+        assert_eq!(
+            probe.fields.get("DMA Mask").map(String::as_str),
+            Some("0xfffffffffffff")
+        );
+
+        let names: Vec<&str> = gpus.iter().map(|gpu| gpu.display_name.as_str()).collect();
+        assert!(!names.iter().any(|name| name.contains("DMA Mask")));
+        assert!(!names.iter().any(|name| name.contains("IRQ")));
+        assert!(!names.iter().any(|name| name.contains("Bus Location")));
     }
 }

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -1,6 +1,7 @@
+use mesh_llm_native_runtime::host::HostGpuProbe;
 use mesh_llm_native_runtime::{
-    HostCudaProfile, HostGpuProbe, HostGpuProfile, HostRocmProfile, HostRuntimeProfile,
-    HostVulkanProfile, NativeRuntimeBackendKind,
+    HostCudaProfile, HostGpuProfile, HostRocmProfile, HostRuntimeProfile, HostVulkanProfile,
+    NativeRuntimeBackendKind,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
@@ -57,11 +58,23 @@ pub fn detected_native_runtime_flavors(
 }
 
 fn detect_gpus() -> Vec<HostGpuProfile> {
-    let nvidia_gpus = detect_nvidia_gpu_profiles();
-    if !nvidia_gpus.is_empty() {
-        return nvidia_gpus;
+    merge_nvidia_and_fallback_gpus(detect_nvidia_gpu_profiles(), fallback_gpu_profiles())
+}
+
+fn merge_nvidia_and_fallback_gpus(
+    mut nvidia_gpus: Vec<HostGpuProfile>,
+    mut fallback_gpus: Vec<HostGpuProfile>,
+) -> Vec<HostGpuProfile> {
+    if nvidia_gpus.is_empty() {
+        return fallback_gpus;
     }
 
+    fallback_gpus.retain(|gpu| !looks_like_nvidia_gpu_label(&gpu.display_name));
+    nvidia_gpus.extend(fallback_gpus);
+    nvidia_gpus
+}
+
+fn fallback_gpu_profiles() -> Vec<HostGpuProfile> {
     gpu_labels()
         .into_iter()
         .enumerate()
@@ -81,9 +94,14 @@ fn detect_gpus() -> Vec<HostGpuProfile> {
         .collect()
 }
 
+fn looks_like_nvidia_gpu_label(label: &str) -> bool {
+    let label = label.to_ascii_lowercase();
+    label.contains("nvidia") || label.contains("cuda")
+}
+
 fn backend_device_from_label(label: &str, index: usize) -> Option<String> {
     let label = label.to_ascii_lowercase();
-    if label.contains("nvidia") || label.contains("cuda") {
+    if looks_like_nvidia_gpu_label(&label) {
         Some(format!("CUDA{index}"))
     } else if label.contains("amd") || label.contains("radeon") || label.contains("rocm") {
         Some(format!("ROCm{index}"))
@@ -645,6 +663,28 @@ deviceName         = AMD Radeon PRO W7900
                     .to_string()
             ]
         );
+    }
+
+    #[test]
+    fn nvidia_probe_results_merge_with_fallback_labels() {
+        let nvidia_smi = "\
+GPU 0: NVIDIA GeForce RTX 5090 (UUID: GPU-80ded6bd-1a89-2628-3d94-902187dbab1d)
+";
+        let lspci = "\
+01:00.0 VGA compatible controller: NVIDIA Corporation GB202 [GeForce RTX 5090] (rev a1)
+";
+        let nvidia_gpus = nvidia_gpu_profiles_from_probe_outputs(nvidia_smi, lspci, &[]);
+        let fallback_gpus = vec![
+            profile("NVIDIA Corporation GB202 [GeForce RTX 5090]"),
+            profile("AMD Radeon PRO W7900"),
+        ];
+        let merged = merge_nvidia_and_fallback_gpus(nvidia_gpus, fallback_gpus);
+
+        let names = merged
+            .iter()
+            .map(|gpu| gpu.display_name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["NVIDIA GeForce RTX 5090", "AMD Radeon PRO W7900"]);
     }
 
     #[test]

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -77,39 +77,26 @@ fn merge_nvidia_and_fallback_gpus(
 fn fallback_gpu_profiles() -> Vec<HostGpuProfile> {
     gpu_labels()
         .into_iter()
-        .enumerate()
-        .map(|(index, label)| {
-            let backend_device = backend_device_from_label(&label, index);
-            HostGpuProfile {
-                display_name: label,
-                backend_device,
-                stable_id: Some(format!("detected-{index}")),
-                vram_bytes: None,
-                unified_memory: cfg!(target_os = "macos"),
-                probe: None,
-                cuda_sm: None,
-                rocm_gfx: None,
-            }
-        })
+        .map(fallback_gpu_profile_from_label)
         .collect()
+}
+
+fn fallback_gpu_profile_from_label(label: String) -> HostGpuProfile {
+    HostGpuProfile {
+        display_name: label,
+        backend_device: None,
+        stable_id: None,
+        vram_bytes: None,
+        unified_memory: cfg!(target_os = "macos"),
+        probe: None,
+        cuda_sm: None,
+        rocm_gfx: None,
+    }
 }
 
 fn looks_like_nvidia_gpu_label(label: &str) -> bool {
     let label = label.to_ascii_lowercase();
     label.contains("nvidia") || label.contains("cuda")
-}
-
-fn backend_device_from_label(label: &str, index: usize) -> Option<String> {
-    let label = label.to_ascii_lowercase();
-    if looks_like_nvidia_gpu_label(&label) {
-        Some(format!("CUDA{index}"))
-    } else if label.contains("amd") || label.contains("radeon") || label.contains("rocm") {
-        Some(format!("ROCm{index}"))
-    } else if cfg!(target_os = "macos") && label.contains("apple") {
-        Some(format!("MTL{index}"))
-    } else {
-        None
-    }
 }
 
 fn detect_nvidia_gpu_profiles() -> Vec<HostGpuProfile> {
@@ -603,6 +590,19 @@ mod tests {
             detected_native_runtime_flavors(&[profile("AMD Radeon PRO W7900")], None, None, None);
 
         assert!(flavors.contains(&NativeRuntimeBackendKind::Rocm));
+    }
+
+    #[test]
+    fn fallback_profiles_do_not_synthesize_backend_ordinals() {
+        let gpu = fallback_gpu_profile_from_label("AMD Radeon PRO W7900".to_string());
+
+        assert_eq!(gpu.display_name, "AMD Radeon PRO W7900");
+        assert_eq!(gpu.backend_device, None);
+        assert_eq!(gpu.stable_id, None);
+        assert!(
+            detected_native_runtime_flavors(&[gpu], None, None, None)
+                .contains(&NativeRuntimeBackendKind::Rocm)
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-native-runtime/src/host.rs
+++ b/crates/mesh-llm-native-runtime/src/host.rs
@@ -1,6 +1,17 @@
 use crate::NativeRuntimeBackendKind;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HostGpuProbe {
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_lines: Vec<String>,
+}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct HostGpuProfile {
@@ -9,6 +20,8 @@ pub struct HostGpuProfile {
     pub stable_id: Option<String>,
     pub vram_bytes: Option<u64>,
     pub unified_memory: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probe: Option<HostGpuProbe>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cuda_sm: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/mesh-llm-native-runtime/src/lib.rs
+++ b/crates/mesh-llm-native-runtime/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod cache;
 mod flavor;
-mod host;
+pub mod host;
 mod load_plan;
 mod manifest;
 mod resolver;
@@ -16,8 +16,7 @@ pub use flavor::{
     NativeRuntimeFlavorParseError, RocmRuntimeRequirements, VulkanRuntimeRequirements,
 };
 pub use host::{
-    HostCudaProfile, HostGpuProbe, HostGpuProfile, HostRocmProfile, HostRuntimeProfile,
-    HostVulkanProfile,
+    HostCudaProfile, HostGpuProfile, HostRocmProfile, HostRuntimeProfile, HostVulkanProfile,
 };
 pub use load_plan::NativeRuntimeLoadPlan;
 pub use manifest::{

--- a/crates/mesh-llm-native-runtime/src/lib.rs
+++ b/crates/mesh-llm-native-runtime/src/lib.rs
@@ -16,7 +16,8 @@ pub use flavor::{
     NativeRuntimeFlavorParseError, RocmRuntimeRequirements, VulkanRuntimeRequirements,
 };
 pub use host::{
-    HostCudaProfile, HostGpuProfile, HostRocmProfile, HostRuntimeProfile, HostVulkanProfile,
+    HostCudaProfile, HostGpuProbe, HostGpuProfile, HostRocmProfile, HostRuntimeProfile,
+    HostVulkanProfile,
 };
 pub use load_plan::NativeRuntimeLoadPlan;
 pub use manifest::{

--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -161,8 +161,19 @@ sha256_file() {
     fi
 }
 
+python_bin() {
+    if command -v python3 >/dev/null 2>&1; then
+        printf 'python3\n'
+    elif command -v python >/dev/null 2>&1; then
+        printf 'python\n'
+    else
+        echo "python3 or python is required to package native runtimes" >&2
+        exit 1
+    fi
+}
+
 workspace_version() {
-    python3 - "$REPO_ROOT/Cargo.toml" <<'PY'
+    "$(python_bin)" - "$REPO_ROOT/Cargo.toml" <<'PY'
 import re
 import sys
 
@@ -184,7 +195,7 @@ PY
 }
 
 skippy_abi_version() {
-    python3 - "$REPO_ROOT/crates/skippy-ffi/src/lib.rs" <<'PY'
+    "$(python_bin)" - "$REPO_ROOT/crates/skippy-ffi/src/lib.rs" <<'PY'
 import re
 import sys
 
@@ -371,7 +382,7 @@ if [[ -f "$LLAMA_WORKDIR/.mesh-llm-patch-digest" ]]; then
     patch_digest="$(tr -d '[:space:]' < "$LLAMA_WORKDIR/.mesh-llm-patch-digest")"
 fi
 
-python3 - "$stage_dir/manifest.json" "$primary_library" "${library_paths[@]}" <<PY
+"$(python_bin)" - "$stage_dir/manifest.json" "$primary_library" "${library_paths[@]}" <<PY
 import json
 import os
 import sys
@@ -381,24 +392,23 @@ primary_library = sys.argv[2]
 library_paths = sys.argv[3:]
 backend = "$BACKEND"
 kind = {"hip": "rocm", "cuda-blackwell": "cuda"}.get(backend, backend)
-cuda_arches = [
-    value.strip()
-    for value in (
-        os.environ.get("LLAMA_STAGE_CUDA_ARCHITECTURES")
-        or os.environ.get("SKIPPY_CUDA_ARCHITECTURES")
-        or ("sm_120" if backend == "cuda-blackwell" else "")
-    ).split(",")
-    if value.strip()
-]
-rocm_arches = [
-    value.strip()
-    for value in (
-        os.environ.get("LLAMA_STAGE_AMDGPU_TARGETS")
-        or os.environ.get("SKIPPY_AMDGPU_TARGETS")
-        or ""
-    ).split(",")
-    if value.strip()
-]
+
+def split_arches(raw):
+    values = []
+    for comma_part in raw.split(","):
+        values.extend(part.strip() for part in comma_part.split(";"))
+    return [value for value in values if value]
+
+cuda_arches = split_arches(
+    os.environ.get("LLAMA_STAGE_CUDA_ARCHITECTURES")
+    or os.environ.get("SKIPPY_CUDA_ARCHITECTURES")
+    or ("sm_120" if backend == "cuda-blackwell" else "")
+)
+rocm_arches = split_arches(
+    os.environ.get("LLAMA_STAGE_AMDGPU_TARGETS")
+    or os.environ.get("SKIPPY_AMDGPU_TARGETS")
+    or ""
+)
 backend_manifest = {"kind": kind}
 if kind == "cuda":
     backend_manifest["cuda"] = {

--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -162,14 +162,16 @@ sha256_file() {
 }
 
 python_bin() {
-    if command -v python3 >/dev/null 2>&1; then
-        printf 'python3\n'
-    elif command -v python >/dev/null 2>&1; then
-        printf 'python\n'
-    else
-        echo "python3 or python is required to package native runtimes" >&2
-        exit 1
-    fi
+    local candidate
+    for candidate in python3 python; do
+        if command -v "$candidate" >/dev/null 2>&1 &&
+            "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' >/dev/null 2>&1; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    echo "Python 3.9 or newer is required to package native runtimes" >&2
+    exit 1
 }
 
 workspace_version() {

--- a/scripts/rc-release-smoke.sh
+++ b/scripts/rc-release-smoke.sh
@@ -89,12 +89,96 @@ mesh_env() {
     HOME="$HOME_DIR" XDG_CACHE_HOME="$XDG_CACHE" XDG_DATA_HOME="$XDG_DATA" "$@"
 }
 
+descendant_pids() {
+    local pid="$1"
+    local children
+    children="$(pgrep -P "$pid" 2>/dev/null || true)"
+    for child in $children; do
+        descendant_pids "$child"
+        printf '%s\n' "$child"
+    done
+}
+
+kill_pids() {
+    local signal="$1"
+    shift
+    local pid
+    for pid in "$@"; do
+        [[ -n "$pid" ]] || continue
+        [[ "$pid" != "$$" ]] || continue
+        kill "-$signal" "$pid" 2>/dev/null || true
+    done
+}
+
+mesh_bundle_pids() {
+    [[ -n "${BINARY:-}" ]] || return 0
+    while IFS= read -r pid; do
+        [[ "$pid" != "$$" ]] || continue
+        printf '%s\n' "$pid"
+    done < <(pgrep -f "$BINARY" 2>/dev/null || true)
+}
+
+wait_for_no_mesh_bundle_processes() {
+    local max_wait="$1"
+    local second
+    for second in $(seq 1 "$max_wait"); do
+        if [[ -z "$(mesh_bundle_pids)" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+kill_mesh_bundle_processes() {
+    local pids
+    pids="$(mesh_bundle_pids | sort -u || true)"
+    if [[ -z "$pids" ]]; then
+        return 0
+    fi
+    # The blobstore plugin is another invocation of the same extracted binary.
+    # Sweep by this audit-local path so a reparented plugin cannot survive.
+    kill_pids TERM $pids
+    if ! wait_for_no_mesh_bundle_processes 5; then
+        pids="$(mesh_bundle_pids | sort -u || true)"
+        if [[ -n "$pids" ]]; then
+            kill_pids KILL $pids
+        fi
+    fi
+}
+
+kill_tree() {
+    local pid="${1:-}"
+    [[ -n "$pid" ]] || return 0
+
+    local children
+    children="$(descendant_pids "$pid" | sort -u || true)"
+    if [[ -n "$children" ]]; then
+        kill_pids TERM $children
+    fi
+    kill_pids TERM "$pid"
+
+    local second
+    for second in $(seq 1 10); do
+        if ! kill -0 "$pid" 2>/dev/null && [[ -z "$(mesh_bundle_pids)" ]]; then
+            break
+        fi
+        sleep 1
+    done
+
+    children="$(descendant_pids "$pid" | sort -u || true)"
+    if [[ -n "$children" ]]; then
+        kill_pids KILL $children
+    fi
+    kill_pids KILL "$pid"
+    wait "$pid" 2>/dev/null || true
+}
+
 cleanup() {
     if [[ -n "$MESH_PID" ]]; then
-        kill "$MESH_PID" 2>/dev/null || true
-        pkill -P "$MESH_PID" 2>/dev/null || true
-        wait "$MESH_PID" 2>/dev/null || true
+        kill_tree "$MESH_PID"
     fi
+    kill_mesh_bundle_processes
 }
 trap cleanup EXIT
 
@@ -199,8 +283,11 @@ cleanup
 MESH_PID=""
 
 echo "verify no mesh-llm process remains"
-if pgrep -f "$BINARY" >/dev/null 2>&1; then
+if ! wait_for_no_mesh_bundle_processes 10; then
     echo "mesh-llm process still running for $BINARY" >&2
+    pgrep -af "$BINARY" >&2 || true
+    lsof -nP -iTCP:"$API_PORT" -sTCP:LISTEN >&2 || true
+    lsof -nP -iTCP:"$CONSOLE_PORT" -sTCP:LISTEN >&2 || true
     exit 1
 fi
 

--- a/scripts/rc-release-smoke.sh
+++ b/scripts/rc-release-smoke.sh
@@ -110,12 +110,18 @@ kill_pids() {
     done
 }
 
+escape_ere() {
+    printf '%s' "$1" | sed 's/[][(){}.^$*+?|\\]/\\&/g'
+}
+
 mesh_bundle_pids() {
     [[ -n "${BINARY:-}" ]] || return 0
+    local pattern
+    pattern="$(escape_ere "$BINARY")"
     while IFS= read -r pid; do
         [[ "$pid" != "$$" ]] || continue
         printf '%s\n' "$pid"
-    done < <(pgrep -f "$BINARY" 2>/dev/null || true)
+    done < <(pgrep -f "$pattern" 2>/dev/null || true)
 }
 
 wait_for_no_mesh_bundle_processes() {
@@ -285,7 +291,7 @@ MESH_PID=""
 echo "verify no mesh-llm process remains"
 if ! wait_for_no_mesh_bundle_processes 10; then
     echo "mesh-llm process still running for $BINARY" >&2
-    pgrep -af "$BINARY" >&2 || true
+    pgrep -af "$(escape_ere "$BINARY")" >&2 || true
     lsof -nP -iTCP:"$API_PORT" -sTCP:LISTEN >&2 || true
     lsof -nP -iTCP:"$CONSOLE_PORT" -sTCP:LISTEN >&2 || true
     exit 1

--- a/scripts/tests/test_validate_release_native_runtime_matrix.py
+++ b/scripts/tests/test_validate_release_native_runtime_matrix.py
@@ -74,7 +74,7 @@ class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
 
         self.assertEqual(validator.find_matrix_violations(assets, manifest), [])
 
-    def test_explicit_release_native_targets_ignore_static_gpu_bundles(self):
+    def test_explicit_release_native_targets_cover_all_release_bundles(self):
         validator = load_validator()
         assets = [
             "mesh-llm-v0.72.0-rc5-x86_64-unknown-linux-gnu.tar.gz",
@@ -123,6 +123,55 @@ class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
                         "cuda": {"toolkit_major": 13, "gpu_arches": []},
                     },
                 },
+                {
+                    "id": "meshllm-native-runtime-linux-x86_64-cuda12",
+                    "platform": {"os": "linux", "arch": "x86_64"},
+                    "backend": {
+                        "kind": "cuda",
+                        "cuda": {"toolkit_major": 12, "gpu_arches": []},
+                    },
+                },
+                {
+                    "id": "meshllm-native-runtime-linux-x86_64-cuda13",
+                    "platform": {"os": "linux", "arch": "x86_64"},
+                    "backend": {
+                        "kind": "cuda",
+                        "cuda": {"toolkit_major": 13, "gpu_arches": []},
+                    },
+                },
+                {
+                    "id": "meshllm-native-runtime-linux-x86_64-rocm",
+                    "platform": {"os": "linux", "arch": "x86_64"},
+                    "backend": {"kind": "rocm"},
+                },
+                {
+                    "id": "meshllm-native-runtime-linux-x86_64-vulkan",
+                    "platform": {"os": "linux", "arch": "x86_64"},
+                    "backend": {"kind": "vulkan"},
+                },
+                {
+                    "id": "meshllm-native-runtime-windows-x86_64-cpu",
+                    "platform": {"os": "windows", "arch": "x86_64"},
+                    "backend": {"kind": "cpu"},
+                },
+                {
+                    "id": "meshllm-native-runtime-windows-x86_64-cuda12",
+                    "platform": {"os": "windows", "arch": "x86_64"},
+                    "backend": {
+                        "kind": "cuda",
+                        "cuda": {"toolkit_major": 12, "gpu_arches": []},
+                    },
+                },
+                {
+                    "id": "meshllm-native-runtime-windows-x86_64-rocm",
+                    "platform": {"os": "windows", "arch": "x86_64"},
+                    "backend": {"kind": "rocm"},
+                },
+                {
+                    "id": "meshllm-native-runtime-windows-x86_64-vulkan",
+                    "platform": {"os": "windows", "arch": "x86_64"},
+                    "backend": {"kind": "vulkan"},
+                },
             ]
         }
         required_targets = {
@@ -131,6 +180,14 @@ class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
             validator.target_from_label("linux/aarch64/cpu"),
             validator.target_from_label("linux/aarch64/cuda12"),
             validator.target_from_label("linux/aarch64/cuda13"),
+            validator.target_from_label("linux/x86_64/cuda12"),
+            validator.target_from_label("linux/x86_64/cuda13"),
+            validator.target_from_label("linux/x86_64/rocm"),
+            validator.target_from_label("linux/x86_64/vulkan"),
+            validator.target_from_label("windows/x86_64/cpu"),
+            validator.target_from_label("windows/x86_64/cuda"),
+            validator.target_from_label("windows/x86_64/rocm"),
+            validator.target_from_label("windows/x86_64/vulkan"),
         }
 
         violations = validator.find_matrix_violations(

--- a/scripts/tests/test_validate_release_native_runtime_matrix.py
+++ b/scripts/tests/test_validate_release_native_runtime_matrix.py
@@ -185,7 +185,7 @@ class ReleaseNativeRuntimeMatrixTests(unittest.TestCase):
             validator.target_from_label("linux/x86_64/rocm"),
             validator.target_from_label("linux/x86_64/vulkan"),
             validator.target_from_label("windows/x86_64/cpu"),
-            validator.target_from_label("windows/x86_64/cuda"),
+            validator.target_from_label("windows/x86_64/cuda12"),
             validator.target_from_label("windows/x86_64/rocm"),
             validator.target_from_label("windows/x86_64/vulkan"),
         }

--- a/scripts/verify-native-runtime-package.sh
+++ b/scripts/verify-native-runtime-package.sh
@@ -29,6 +29,17 @@ sha256_file() {
     fi
 }
 
+python_bin() {
+    if command -v python3 >/dev/null 2>&1; then
+        printf 'python3\n'
+    elif command -v python >/dev/null 2>&1; then
+        printf 'python\n'
+    else
+        echo "python3 or python is required to verify native runtimes" >&2
+        exit 1
+    fi
+}
+
 verify_sidecar_checksum() {
     local archive="$1"
     local sidecar="$archive.sha256"
@@ -83,7 +94,7 @@ verify_artifact_dir() {
         echo "missing manifest: $manifest" >&2
         exit 1
     fi
-    python3 - "$artifact_dir" "$manifest" <<'PY'
+    "$(python_bin)" - "$artifact_dir" "$manifest" <<'PY'
 import hashlib
 import json
 import os
@@ -152,7 +163,7 @@ verify_macos_runtime_paths() {
         echo "otool is required to verify macOS native runtime dylibs" >&2
         exit 1
     fi
-    python3 - "$artifact_dir" "$manifest" <<'PY'
+    "$(python_bin)" - "$artifact_dir" "$manifest" <<'PY'
 import json
 import os
 import subprocess
@@ -194,7 +205,7 @@ PY
 verify_linux_runtime_paths() {
     local artifact_dir="$1"
     local manifest="$2"
-    if ! python3 - "$manifest" <<'PY'
+    if ! "$(python_bin)" - "$manifest" <<'PY'
 import json
 import sys
 
@@ -209,7 +220,7 @@ PY
         echo "readelf is required to verify Linux native runtime shared libraries" >&2
         exit 1
     fi
-    python3 - "$artifact_dir" "$manifest" <<'PY'
+    "$(python_bin)" - "$artifact_dir" "$manifest" <<'PY'
 import json
 import os
 import platform

--- a/scripts/verify-native-runtime-package.sh
+++ b/scripts/verify-native-runtime-package.sh
@@ -30,14 +30,16 @@ sha256_file() {
 }
 
 python_bin() {
-    if command -v python3 >/dev/null 2>&1; then
-        printf 'python3\n'
-    elif command -v python >/dev/null 2>&1; then
-        printf 'python\n'
-    else
-        echo "python3 or python is required to verify native runtimes" >&2
-        exit 1
-    fi
+    local candidate
+    for candidate in python3 python; do
+        if command -v "$candidate" >/dev/null 2>&1 &&
+            "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' >/dev/null 2>&1; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    echo "Python 3.9 or newer is required to verify native runtimes" >&2
+    exit 1
 }
 
 verify_sidecar_checksum() {

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -2314,6 +2314,8 @@ fn check_publish_workflow_invariants(repo_root: &Path) -> DynResult<()> {
           runs-on: ubuntu-24.04
           steps:
             - uses: actions/checkout@v5
+              with:
+                persist-credentials: false
             - uses: dtolnay/rust-toolchain@stable
             - name: Prepare dispatched release version
               if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

This PR bundles the RC5 release-readiness fixes found across the open testing threads:

- closes the native-runtime matrix gaps exposed by clean `runtime install` testing;
- makes release packaging/signing metadata more explicit and verifiable;
- hardens the RC smoke script around real published artifacts and native-runtime selection;
- reshapes `doctor --json` GPU diagnostics so detailed `/proc` probe data remains available without being reported as fake GPU rows.

## Findings From Testing Threads

### mesh1 RC4 readiness thread

The earlier mesh1 audit showed that a published bundle could serve a model, but a clean `mesh-llm runtime install` path could still fail because release native-runtime artifacts were missing for the host. It also showed that `doctor --json` was not enough as a readiness gate when the selected runtime could be absent or wrong.

This PR carries that lesson into the release workflow by validating explicit native-runtime targets and making the smoke path check the runtime-install surface separately from bundle execution.

### carrack RC5 release audit

Carrack detected `cpu, cuda, vulkan`, but RC5’s published `native-runtimes.json` only offered an x86_64 CPU runtime for that host. The CUDA runtimes present in the manifest were Linux aarch64 targets, so they were correctly rejected as `arch_mismatch`; the resolver then selected CPU.

This PR adds native-runtime jobs for the missing published-platform targets, including the carrack-critical Linux x86_64 CUDA 12/13 runtimes, plus Linux x86_64 ROCm/Vulkan and Windows x86_64 CPU/CUDA/ROCm/Vulkan runtimes.

### release matrix / Actions artifact audit

The RC5 matrix published binary bundles for more platform/backend combinations than it published native-runtime artifacts for. The release validator did not require those runtime artifacts, so the gap reached the prerelease manifest.

This PR updates the workflow and matrix validation so `native-runtimes.json` generation is driven by the intended explicit target list rather than accidentally passing with only a subset of runtime artifacts.

### carrack doctor GPU diagnostics thread

On carrack, `doctor --json` previously reported 25 `host.gpus` rows. Many of those rows were useful raw NVIDIA probe details such as DMA masks, IRQs, BIOS versions, bus locations, and device minors, but they were incorrectly shaped as separate GPUs with `detected-*` stable IDs.

This PR preserves the useful probe information by nesting it under the matching real GPU entry. `host.gpus` now reports the two actual carrack devices, each with a `probe` object containing the `/proc/driver/nvidia/gpus/*/information` fields and raw lines.

## What Changed

- Added Linux x86_64 CUDA 12/13 native-runtime release jobs.
- Added Linux x86_64 ROCm and Vulkan native-runtime release jobs.
- Added Windows x86_64 CPU/CUDA/ROCm/Vulkan native-runtime release jobs.
- Updated required native-runtime targets and validation tests so missing runtime artifacts fail release validation.
- Updated native-runtime packaging verification and smoke scripts around manifest/runtime-install expectations.
- Added signing/attestation release notes and packaging metadata support.
- Added `HostGpuProbe` and nested NVIDIA `/proc` probe details under `HostGpuProfile`.
- Added a carrack-shaped unit test proving NVIDIA proc details are nested under two real GPUs rather than emitted as 25 top-level GPU rows.

## Validation

Local validation run before pushing:

```text
cargo test -p mesh-llm-hardware-profile --lib
cargo test -p mesh-llm-native-runtime --lib
cargo check -p mesh-llm-native-runtime
cargo check -p mesh-llm-hardware-profile
cargo check -p mesh-llm
cargo clippy -p mesh-llm-native-runtime --all-targets -- -D warnings
cargo clippy -p mesh-llm-hardware-profile --all-targets -- -D warnings
cargo clippy -p mesh-llm --all-targets -- -D warnings
cargo fmt --all --check
```

Carrack validation after pulling this branch:

```text
cd /home/ndizazzo/dev/mesh/mesh-llm
just build
cargo test -p mesh-llm-hardware-profile --lib nvidia_proc_details_are_nested_under_matching_gpus
```

Carrack doctor verification from `target/debug/mesh-llm doctor --json`:

```text
gpu_count: 2
NVIDIA GeForce RTX 5090 -> CUDA0, probe source linux_nvidia_proc, IRQ 16, DMA Mask 0xfffffffffffff, Bus Location 0000:01:00.0
NVIDIA GeForce RTX 3080 -> CUDA1, probe source linux_nvidia_proc, IRQ 184, DMA Mask 0x7fffffffffff, Bus Location 0000:06:00.0
bad top-level DMA/IRQ/Bus Location/Video BIOS rows: none
```

Saved carrack artifacts:

```text
/tmp/mesh-llm-doctor-gpu-fix-build.log
/tmp/mesh-llm-doctor-gpu-fix.json
```

Note: the carrack doctor run still reports `healthy: false` in this branch checkout because that local cache does not currently have a compatible native runtime selected. The GPU diagnostics shape is fixed independently and verified from the built binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded native runtime release coverage with additional Linux x86_64 (CUDA/ROCm/Vulkan) and Windows x86_64 (CPU plus CUDA/ROCm/Vulkan) builds.
  * Added release attestation signing keys and conditional attestation stamping support for packaged executables.
* **Bug Fixes**
  * Improved GPU hardware discovery by combining NVIDIA probe results with fallback GPU profiles without losing non-NVIDIA devices.
  * Added stricter, time-bounded release smoke cleanup/verification to ensure no lingering bundle processes remain.
* **Documentation**
  * Documented how to generate, store, and verify attestation signing keys in RELEASE.md.
* **Chores / Tests**
  * Hardened release workflow and packaging scripts (checkout credential handling, Python selection, manifest/architecture parsing, expanded matrix validation tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->