### PR TITLE
fix: incorrect feature flag gating for chat system prompt

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/api/chat-session.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/api/chat-session.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type 
 import { CHAT_HARNESS } from '@/features/app-tabs/data'
 import type { ChatHarnessData, ThreadMessage } from '@/features/app-tabs/types'
 import { useDataMode } from '@/lib/data-mode'
-import { useBooleanFeatureFlag } from '@/lib/feature-flags'
 import { useMeshChat } from '@/features/chat/api/use-chat'
 import { usePersistentChatSystemPrompt } from '@/features/chat/api/system-prompt'
 import { useChatMessages } from '@/features/chat/api/use-chat-messages'
@@ -265,9 +264,7 @@ export function ChatSessionProvider({ children, data = CHAT_HARNESS }: ChatSessi
   const visibleLaneId = selectedLaneId ?? activeLaneId
   const [sessionModel, setSessionModel] = useState('auto')
   const [messageModels, setMessageModels] = useState<Record<string, string>>({})
-  const systemPromptButtonEnabled = useBooleanFeatureFlag('chat/systemPromptButton')
   const { systemPrompt, setSystemPrompt } = usePersistentChatSystemPrompt()
-  const effectiveSystemPrompt = systemPromptButtonEnabled ? systemPrompt : ''
   const [responseMetadataByConversation, setResponseMetadataByConversation] = useState<
     Record<string, Record<string, ThreadMessageMetadata>>
   >({})
@@ -288,7 +285,7 @@ export function ChatSessionProvider({ children, data = CHAT_HARNESS }: ChatSessi
     responseMetadataByConversation,
     setResponseMetadataByConversation,
     sessionModel,
-    systemPrompt: effectiveSystemPrompt,
+    systemPrompt,
     updateThread
   })
   const secondaryLane = useChatLane({
@@ -299,7 +296,7 @@ export function ChatSessionProvider({ children, data = CHAT_HARNESS }: ChatSessi
     responseMetadataByConversation,
     setResponseMetadataByConversation,
     sessionModel,
-    systemPrompt: effectiveSystemPrompt,
+    systemPrompt,
     updateThread
   })
   const activeLane = visibleLaneId === 'primary' ? primaryLane : secondaryLane

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
@@ -4,6 +4,7 @@ import type { MultimodalContent } from '@tanstack/ai-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CHAT_HARNESS } from '@/features/app-tabs/data'
 import { APP_STORAGE_KEYS } from '@/features/app-tabs/data'
+import { DEFAULT_SYSTEM_PROMPT } from '@/constants/system-prompt'
 import { ChatSessionProvider } from '@/features/chat/api/chat-session'
 import { loadChatState, saveChatState, trimThreadMessages } from '@/features/chat/api/chat-storage'
 import { ChatLayout } from '@/features/chat/layouts/ChatLayout'
@@ -588,6 +589,25 @@ describe('ChatPage', () => {
     expect(screen.queryByRole('button', { name: 'System prompt' })).not.toBeInTheDocument()
   })
 
+  it('sends the default system prompt while the editor feature flag is disabled', async () => {
+    const user = userEvent.setup()
+
+    renderChatPage()
+
+    expect(screen.queryByRole('button', { name: 'System prompt' })).not.toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('Prompt'), 'Tell me about mesh-llm')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(chatMock.sendCalls[0]).toMatchObject({
+        content: 'Tell me about mesh-llm',
+        model: 'mesh',
+        systemPrompt: DEFAULT_SYSTEM_PROMPT
+      })
+    })
+  })
+
   it('opens, saves, prefills, and sends the chat-wide system prompt for new chats', async () => {
     const user = userEvent.setup()
 
@@ -628,7 +648,7 @@ describe('ChatPage', () => {
     })
   })
 
-  it('does not send a persisted system prompt while the feature flag is disabled', async () => {
+  it('sends a persisted system prompt while the editor feature flag is disabled', async () => {
     const user = userEvent.setup()
     window.localStorage.setItem(APP_STORAGE_KEYS.chatSystemPrompt, 'Hidden saved instruction')
 
@@ -643,7 +663,7 @@ describe('ChatPage', () => {
       expect(chatMock.sendCalls[0]).toMatchObject({
         content: 'Route without hidden instructions',
         model: 'mesh',
-        systemPrompt: ''
+        systemPrompt: 'Hidden saved instruction'
       })
     })
   })


### PR DESCRIPTION
## Summary
- Always pass the resolved chat system prompt into chat lanes, independent of the system prompt editor rollout flag.
- Keep the composer system prompt control feature flagged while ensuring the bundled default and persisted prompt still apply to requests.
- Update chat page coverage for hidden editor/default prompt and hidden editor/persisted prompt behavior.

## Root Cause
The chat session provider used `chat/systemPromptButton` to gate the effective prompt sent to `useMeshChat`. That made the prompt apply only after enabling the debug rollout flag and saving through the editor, even though the control visibility should be the only feature-flagged behavior.

## Validation
- `npm test -- --run src/features/chat/pages/ChatPage.test.tsx src/features/chat/api/use-chat.test.tsx src/features/chat/api/build-input.test.ts src/features/chat/api/mesh-connection.test.ts`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat messages now consistently include the saved system prompt when sending messages, even if the editor feature is disabled.
  * First-time message submissions now use the default system prompt when no custom prompt has been saved.
* **Tests**
  * Updated chat page coverage to reflect the new system prompt behavior and verify the sent message payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->