### PR TITLE
chore: Use self-hosted runners via repo action variable toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+# Set USE_SELF_HOSTED=true to route CUDA CI to the dedicated NVIDIA runner;
+# unset or false uses GitHub-hosted runners.
+
 on:
   workflow_dispatch:
   push:
@@ -807,7 +810,7 @@ jobs:
     needs: changes
     if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.backend_changed == 'true' || needs.changes.outputs.benchmarks == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Linux CUDA slim
-    runs-on: [self-hosted, Linux, X64, amd64, gpu-nvidia]
+    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && '["self-hosted","Linux","X64","amd64","gpu-nvidia"]' || '["ubuntu-24.04"]') }}
     permissions:
       contents: read
     container:

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -1,5 +1,8 @@
 name: PR Builds
 
+# Set USE_SELF_HOSTED=true to route CUDA matrix rows to the dedicated NVIDIA
+# runner; unset or false uses GitHub-hosted runners.
+
 on:
   workflow_dispatch:
   pull_request:
@@ -280,7 +283,7 @@ jobs:
     needs: changes
     if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.backend_changed == 'true' || needs.changes.outputs.benchmarks == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Linux ${{ matrix.name }}
-    runs-on: ${{ fromJson(matrix.runs_on) }}
+    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && matrix.self_hosted_runs_on || matrix.runs_on) }}
     container:
       image: ${{ matrix.container }}
     defaults:
@@ -294,7 +297,8 @@ jobs:
             backend: cuda
             container: nvidia/cuda:${{ vars.CUDA_VERSION || '12.6.3' }}-devel-ubuntu22.04
             cache_key: linux-cuda-slim
-            runs_on: '["self-hosted","Linux","X64","amd64","gpu-nvidia"]'
+            runs_on: '["ubuntu-24.04"]'
+            self_hosted_runs_on: '["self-hosted","Linux","X64","amd64","gpu-nvidia"]'
           - name: ROCm slim
             backend: rocm
             container: rocm/dev-ubuntu-24.04:7.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# Set USE_SELF_HOSTED=true to route x86_64 CUDA release jobs and ARM64 smoke
+# validation to self-hosted runners; unset or false uses GitHub-hosted runners.
+
 on:
   push:
     tags: ['v*']
@@ -388,11 +391,7 @@ jobs:
     name: Build native runtime Linux x86_64 CUDA (${{ matrix.cuda_major }})
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
-    # Carrack is the dedicated Linux x64 NVIDIA host. Match it by labels, not
-    # runner name. Keep ARM64 artifact
-    # compilation on GitHub-hosted ARM runners; CM-class ARM64 runners are
-    # smoke/test-only below.
-    runs-on: [self-hosted, Linux, X64, amd64, gpu-nvidia]
+    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && '["self-hosted","Linux","X64","amd64","gpu-nvidia"]' || '["ubuntu-24.04"]') }}
     strategy:
       fail-fast: false
       matrix:
@@ -695,13 +694,10 @@ jobs:
           if-no-files-found: error
 
   smoke_linux_arm64_artifact:
-    name: Smoke Linux ARM64 artifact (self-hosted ARM64 test only)
+    name: Smoke Linux ARM64 artifact
     needs: [metadata, build_linux_arm64]
     if: ${{ needs.build_linux_arm64.result == 'success' }}
-    # CM-class self-hosted ARM64 machines are validation hosts only. They
-    # download and run already-built artifacts, and must not compile release
-    # bundles or native runtimes.
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && '["self-hosted","Linux","ARM64"]' || '["ubuntu-24.04-arm"]') }}
     steps:
       - uses: actions/download-artifact@v7
         with:
@@ -807,9 +803,7 @@ jobs:
     name: Build Linux CUDA (${{ matrix.cuda_version }})
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
-    # CUDA release bundles are the release long pole and benefit most from the
-    # dedicated Linux x64 NVIDIA host.
-    runs-on: [self-hosted, Linux, X64, amd64, gpu-nvidia]
+    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && '["self-hosted","Linux","X64","amd64","gpu-nvidia"]' || '["ubuntu-24.04"]') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * CUDA-related CI and release jobs can now switch between self-hosted GPU runners and GitHub-hosted runners based on a repository setting.
  * Linux CUDA and ARM64 build/test jobs now use conditional runner selection, improving flexibility across environments.
  * Updated job labels and comments to better reflect the current runner behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->