### PR TITLE
feature: Refactor setup-first installer flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1741,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "shell-words",
+]
+
+[[package]]
 name = "diatomic-waker"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +1913,12 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3853,6 +3881,7 @@ version = "0.72.1"
 dependencies = [
  "anyhow",
  "chrono",
+ "dialoguer",
  "dirs",
  "hex",
  "hf-hub",
@@ -7278,6 +7307,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,18 +1101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,16 +1729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
-dependencies = [
- "console",
- "shell-words",
-]
-
-[[package]]
 name = "diatomic-waker"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,12 +1891,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3881,7 +3853,6 @@ version = "0.72.1"
 dependencies = [
  "anyhow",
  "chrono",
- "dialoguer",
  "dirs",
  "hex",
  "hf-hub",
@@ -7307,12 +7278,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ peer, or uses Skippy stage splits for models that are too large for one box.
 
 ## Quick start
 
-Install the latest release:
+Install the latest release executable:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash
@@ -22,6 +22,14 @@ On Windows, use PowerShell:
 ```powershell
 irm https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.ps1 | iex
 ```
+
+Finish setup:
+
+```bash
+mesh-llm setup
+```
+
+On Windows PowerShell, use `mesh-llm.exe setup`.
 
 Join the public mesh and start serving:
 
@@ -182,6 +190,7 @@ binary to `invalid`, but default startup still allows it.
 | [docs/plugins/flash-moe.md](docs/plugins/flash-moe.md) | Optional Flash-MoE SSD expert streaming backend setup |
 | [docs/skippy/FAMILY_STATUS.md](docs/skippy/FAMILY_STATUS.md) | Certified Skippy model-family status |
 | [docs/specs/layer-package-repos.md](docs/specs/layer-package-repos.md) | Manifest and artifact format spec |
+| [docs/specs/mesh-setup-installer.md](docs/specs/mesh-setup-installer.md) | Installer/bootstrap and setup command behavior spec |
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ mesh-llm setup
 
 On Windows PowerShell, use `mesh-llm.exe setup`.
 
+To remove an executable install later, preview the cleanup first:
+
+```bash
+mesh-llm uninstall --dry-run
+mesh-llm uninstall --yes
+```
+
+Uninstall preserves `~/.mesh-llm` configuration and identity data unless you
+explicitly pass `--purge-config`.
+
 Join the public mesh and start serving:
 
 ```bash

--- a/crates/mesh-llm-cli/src/parser.rs
+++ b/crates/mesh-llm-cli/src/parser.rs
@@ -730,6 +730,24 @@ pub enum Command {
         #[command(subcommand)]
         command: Option<DoctorCommand>,
     },
+    /// Bootstrap a new installation.
+    Setup {
+        /// Automatically answer yes to prompts.
+        #[arg(long)]
+        yes: bool,
+        /// Run without prompting for interactive input.
+        #[arg(long = "no-interactive")]
+        no_interactive: bool,
+        /// Install and enable the mesh-llm service.
+        #[arg(long, conflicts_with = "no_service")]
+        service: bool,
+        /// Skip installing and enabling the mesh-llm service.
+        #[arg(long = "no-service", conflicts_with = "service")]
+        no_service: bool,
+        /// Skip downloading or configuring the native runtime.
+        #[arg(long = "skip-runtime")]
+        skip_runtime: bool,
+    },
     /// Load a local model into a running mesh-llm instance.
     Load {
         /// Model name/path/url to load
@@ -1503,6 +1521,53 @@ mod tests {
 
         let rendered = err.to_string();
         assert!(rendered.contains("--owner-required"));
+    }
+
+    #[test]
+    fn setup_command_parses_without_plugin_fallback() {
+        let cli = Cli::parse_from([
+            "mesh-llm",
+            "setup",
+            "--yes",
+            "--no-interactive",
+            "--skip-runtime",
+        ]);
+
+        match cli.command.expect("setup command expected") {
+            Command::Setup {
+                yes,
+                no_interactive,
+                service,
+                no_service,
+                skip_runtime,
+            } => {
+                assert!(yes);
+                assert!(no_interactive);
+                assert!(!service);
+                assert!(!no_service);
+                assert!(skip_runtime);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn setup_command_rejects_conflicting_service_flags() {
+        let err = Cli::try_parse_from(["mesh-llm", "setup", "--service", "--no-service"])
+            .expect_err("setup should reject conflicting service flags");
+
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+        assert!(err.to_string().contains("--service"));
+        assert!(err.to_string().contains("--no-service"));
+    }
+
+    #[test]
+    fn setup_command_rejects_skip_doctor_flag() {
+        let err = Cli::try_parse_from(["mesh-llm", "setup", "--skip-doctor"])
+            .expect_err("setup should reject unknown skip-doctor flag");
+
+        assert_eq!(err.kind(), ErrorKind::UnknownArgument);
+        assert!(err.to_string().contains("--skip-doctor"));
     }
 
     #[test]

--- a/crates/mesh-llm-cli/src/parser.rs
+++ b/crates/mesh-llm-cli/src/parser.rs
@@ -16,6 +16,9 @@ pub use runtime_surface_help::runtime_surface_help;
 #[cfg(test)]
 mod setup_tests;
 
+#[cfg(test)]
+mod uninstall_tests;
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum BinaryFlavor {
     #[default]
@@ -750,6 +753,39 @@ pub enum Command {
         /// Skip downloading or configuring the native runtime.
         #[arg(long = "skip-runtime")]
         skip_runtime: bool,
+        /// Print detailed setup paths, commands, and follow-up guidance.
+        #[arg(long)]
+        verbose: bool,
+    },
+    /// Remove mesh-llm binaries, service files, and optional caches.
+    Uninstall {
+        /// Print what would be removed without changing the machine.
+        #[arg(long)]
+        dry_run: bool,
+        /// Do not prompt before removing files and services.
+        #[arg(long)]
+        yes: bool,
+        /// Preserve native runtime caches.
+        #[arg(long)]
+        keep_cache: bool,
+        /// Preserve setup-owned service helper files.
+        #[arg(long)]
+        keep_service_files: bool,
+        /// Also remove ~/.mesh-llm configuration and identity data.
+        #[arg(long, conflicts_with = "keep_config")]
+        purge_config: bool,
+        /// Explicitly preserve ~/.mesh-llm configuration and identity data.
+        #[arg(long, conflicts_with = "purge_config")]
+        keep_config: bool,
+        /// Override the installed binary path to remove.
+        #[arg(long)]
+        binary_path: Option<std::path::PathBuf>,
+        /// Print machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        /// Print detailed cleanup steps and removed paths.
+        #[arg(long)]
+        verbose: bool,
     },
     /// Load a local model into a running mesh-llm instance.
     Load {

--- a/crates/mesh-llm-cli/src/parser.rs
+++ b/crates/mesh-llm-cli/src/parser.rs
@@ -13,6 +13,9 @@ mod runtime_surface_help;
 
 pub use runtime_surface_help::runtime_surface_help;
 
+#[cfg(test)]
+mod setup_tests;
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum BinaryFlavor {
     #[default]
@@ -1521,53 +1524,6 @@ mod tests {
 
         let rendered = err.to_string();
         assert!(rendered.contains("--owner-required"));
-    }
-
-    #[test]
-    fn setup_command_parses_without_plugin_fallback() {
-        let cli = Cli::parse_from([
-            "mesh-llm",
-            "setup",
-            "--yes",
-            "--no-interactive",
-            "--skip-runtime",
-        ]);
-
-        match cli.command.expect("setup command expected") {
-            Command::Setup {
-                yes,
-                no_interactive,
-                service,
-                no_service,
-                skip_runtime,
-            } => {
-                assert!(yes);
-                assert!(no_interactive);
-                assert!(!service);
-                assert!(!no_service);
-                assert!(skip_runtime);
-            }
-            other => panic!("unexpected command: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn setup_command_rejects_conflicting_service_flags() {
-        let err = Cli::try_parse_from(["mesh-llm", "setup", "--service", "--no-service"])
-            .expect_err("setup should reject conflicting service flags");
-
-        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
-        assert!(err.to_string().contains("--service"));
-        assert!(err.to_string().contains("--no-service"));
-    }
-
-    #[test]
-    fn setup_command_rejects_skip_doctor_flag() {
-        let err = Cli::try_parse_from(["mesh-llm", "setup", "--skip-doctor"])
-            .expect_err("setup should reject unknown skip-doctor flag");
-
-        assert_eq!(err.kind(), ErrorKind::UnknownArgument);
-        assert!(err.to_string().contains("--skip-doctor"));
     }
 
     #[test]

--- a/crates/mesh-llm-cli/src/parser/setup_tests.rs
+++ b/crates/mesh-llm-cli/src/parser/setup_tests.rs
@@ -1,0 +1,49 @@
+use super::{Cli, Command};
+use clap::{Parser, error::ErrorKind};
+
+#[test]
+fn setup_command_parses_without_plugin_fallback() {
+    let cli = Cli::parse_from([
+        "mesh-llm",
+        "setup",
+        "--yes",
+        "--no-interactive",
+        "--skip-runtime",
+    ]);
+
+    match cli.command.expect("setup command expected") {
+        Command::Setup {
+            yes,
+            no_interactive,
+            service,
+            no_service,
+            skip_runtime,
+        } => {
+            assert!(yes);
+            assert!(no_interactive);
+            assert!(!service);
+            assert!(!no_service);
+            assert!(skip_runtime);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn setup_command_rejects_conflicting_service_flags() {
+    let err = Cli::try_parse_from(["mesh-llm", "setup", "--service", "--no-service"])
+        .expect_err("setup should reject conflicting service flags");
+
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    assert!(err.to_string().contains("--service"));
+    assert!(err.to_string().contains("--no-service"));
+}
+
+#[test]
+fn setup_command_rejects_skip_doctor_flag() {
+    let err = Cli::try_parse_from(["mesh-llm", "setup", "--skip-doctor"])
+        .expect_err("setup should reject unknown skip-doctor flag");
+
+    assert_eq!(err.kind(), ErrorKind::UnknownArgument);
+    assert!(err.to_string().contains("--skip-doctor"));
+}

--- a/crates/mesh-llm-cli/src/parser/setup_tests.rs
+++ b/crates/mesh-llm-cli/src/parser/setup_tests.rs
@@ -9,6 +9,7 @@ fn setup_command_parses_without_plugin_fallback() {
         "--yes",
         "--no-interactive",
         "--skip-runtime",
+        "--verbose",
     ]);
 
     match cli.command.expect("setup command expected") {
@@ -18,12 +19,14 @@ fn setup_command_parses_without_plugin_fallback() {
             service,
             no_service,
             skip_runtime,
+            verbose,
         } => {
             assert!(yes);
             assert!(no_interactive);
             assert!(!service);
             assert!(!no_service);
             assert!(skip_runtime);
+            assert!(verbose);
         }
         other => panic!("unexpected command: {other:?}"),
     }

--- a/crates/mesh-llm-cli/src/parser/uninstall_tests.rs
+++ b/crates/mesh-llm-cli/src/parser/uninstall_tests.rs
@@ -1,0 +1,77 @@
+use super::{Cli, Command};
+use clap::Parser;
+
+#[test]
+fn uninstall_defaults_to_confirming_real_changes() {
+    let cli = Cli::parse_from(["mesh-llm", "uninstall"]);
+
+    let Some(Command::Uninstall {
+        dry_run,
+        yes,
+        keep_cache,
+        keep_service_files,
+        purge_config,
+        keep_config,
+        binary_path,
+        json,
+        verbose,
+    }) = cli.command
+    else {
+        panic!("expected uninstall command");
+    };
+
+    assert!(!dry_run);
+    assert!(!yes);
+    assert!(!keep_cache);
+    assert!(!keep_service_files);
+    assert!(!purge_config);
+    assert!(!keep_config);
+    assert!(binary_path.is_none());
+    assert!(!json);
+    assert!(!verbose);
+}
+
+#[test]
+fn uninstall_accepts_automation_flags() {
+    let cli = Cli::parse_from([
+        "mesh-llm",
+        "uninstall",
+        "--dry-run",
+        "--yes",
+        "--keep-cache",
+        "--keep-service-files",
+        "--keep-config",
+        "--binary-path",
+        "/tmp/mesh-llm",
+        "--json",
+        "--verbose",
+    ]);
+
+    let Some(Command::Uninstall {
+        dry_run,
+        yes,
+        keep_cache,
+        keep_service_files,
+        purge_config,
+        keep_config,
+        binary_path,
+        json,
+        verbose,
+    }) = cli.command
+    else {
+        panic!("expected uninstall command");
+    };
+
+    assert!(dry_run);
+    assert!(yes);
+    assert!(keep_cache);
+    assert!(keep_service_files);
+    assert!(!purge_config);
+    assert!(keep_config);
+    assert_eq!(
+        binary_path.expect("binary path"),
+        std::path::Path::new("/tmp/mesh-llm")
+    );
+    assert!(json);
+    assert!(verbose);
+}

--- a/crates/mesh-llm-cli/src/parser/uninstall_tests.rs
+++ b/crates/mesh-llm-cli/src/parser/uninstall_tests.rs
@@ -75,3 +75,20 @@ fn uninstall_accepts_automation_flags() {
     assert!(json);
     assert!(verbose);
 }
+
+#[test]
+fn uninstall_accepts_purge_config() {
+    let cli = Cli::parse_from(["mesh-llm", "uninstall", "--purge-config"]);
+
+    let Some(Command::Uninstall {
+        purge_config,
+        keep_config,
+        ..
+    }) = cli.command
+    else {
+        panic!("expected uninstall command");
+    };
+
+    assert!(purge_config);
+    assert!(!keep_config);
+}

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+dialoguer = { version = "0.12", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-dialoguer = { version = "0.12", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }

--- a/crates/mesh-llm-commands/src/lib.rs
+++ b/crates/mesh-llm-commands/src/lib.rs
@@ -8,5 +8,6 @@ pub mod gpus;
 pub mod model_package;
 pub mod plugin;
 pub mod runtime_native;
+pub mod setup;
 pub mod skills;
 pub mod update;

--- a/crates/mesh-llm-commands/src/lib.rs
+++ b/crates/mesh-llm-commands/src/lib.rs
@@ -10,4 +10,5 @@ pub mod plugin;
 pub mod runtime_native;
 pub mod setup;
 pub mod skills;
+pub mod uninstall;
 pub mod update;

--- a/crates/mesh-llm-commands/src/lib.rs
+++ b/crates/mesh-llm-commands/src/lib.rs
@@ -10,5 +10,6 @@ pub mod plugin;
 pub mod runtime_native;
 pub mod setup;
 pub mod skills;
+mod terminal;
 pub mod uninstall;
 pub mod update;

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -1,11 +1,11 @@
 mod formatters;
+mod setup_helpers;
 
 use anyhow::Result;
 use mesh_llm_native_runtime::{NativeRuntimePruneMode, NativeRuntimeResolver, RuntimeSelection};
 use mesh_llm_runtime_install::{
-    CURRENT_MESH_VERSION, NativeRuntimeDownloadProgressCallback, NativeRuntimeInstallOptions,
-    NativeRuntimeManifestOptions, host_runtime_profile, install_native_runtime,
-    load_release_manifest, native_runtime_cache,
+    CURRENT_MESH_VERSION, NativeRuntimeDownloadProgressCallback, NativeRuntimeManifestOptions,
+    host_runtime_profile, install_native_runtime, load_release_manifest, native_runtime_cache,
 };
 use mesh_llm_tui::terminal_progress::{
     ratio_complete_u64, render_inline_gauge_with_reserved_width,
@@ -15,6 +15,13 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use formatters::{AvailableRuntimeRow, NativeRuntimeDoctorReport, runtime_native_formatter};
+pub use setup_helpers::{
+    SetupNativeRuntimeOptions, SetupNativeRuntimeOutcome, SetupNativeRuntimePruneResult,
+    SetupNativeRuntimeStatus, install_and_prune_native_runtime_for_setup,
+};
+use setup_helpers::{
+    native_runtime_install_options, prune_native_runtime_cache, resolve_runtime_selection,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct NativeRuntimeDoctorReadiness {
@@ -108,11 +115,7 @@ pub async fn run_native_runtime_install(
     configured: NativeRuntimeConfigSelection<'_>,
     json_output: bool,
 ) -> Result<()> {
-    let configured_selection = requested_runtime
-        .is_none()
-        .then_some(configured.selection)
-        .flatten();
-    let selection = RuntimeSelection::parse(requested_runtime.or(configured_selection))?;
+    let resolved_selection = resolve_runtime_selection(requested_runtime, configured)?;
     if !json_output && manifest_path.is_none() && bundle_dirs.is_empty() {
         eprintln!("🔎 Loading native runtime release manifest");
     }
@@ -121,24 +124,21 @@ pub async fn run_native_runtime_install(
     }
     print_configured_selector(
         NativeRuntimeConfigSelection {
-            selection: configured_selection,
+            selection: resolved_selection.configured_selection,
             ..configured
         },
         json_output,
     );
     let formatter = runtime_native_formatter(json_output);
-    let outcome = match install_native_runtime(NativeRuntimeInstallOptions {
-        mesh_version: configured.mesh_version_or_current().to_string(),
-        skippy_abi_version: configured.skippy_abi_version.map(ToString::to_string),
-        selection,
-        manifest_path: manifest_path.map(Path::to_path_buf),
-        bundle_dirs: bundle_dirs.to_vec(),
-        cache_dir: cache_dir.map(Path::to_path_buf),
-        progress: cli_download_progress(json_output),
-        ..Default::default()
-    })
-    .await
-    {
+    let install_options = native_runtime_install_options(
+        resolved_selection.selection,
+        manifest_path,
+        bundle_dirs,
+        cache_dir,
+        configured,
+        cli_download_progress(json_output),
+    );
+    let outcome = match install_native_runtime(install_options).await {
         Ok(outcome) => outcome,
         Err(error) => {
             formatter.render_install_error(&error)?;
@@ -299,8 +299,7 @@ pub fn run_native_runtime_prune(
     } else {
         NativeRuntimePruneMode::KeepActiveAndPrevious
     };
-    let cache = native_runtime_cache(cache_dir)?;
-    let plan = cache.prune(version, mode)?;
+    let plan = prune_native_runtime_cache(version, mode, cache_dir)?;
     runtime_native_formatter(json_output).render_prune(&plan)
 }
 

--- a/crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs
@@ -1,0 +1,335 @@
+use super::NativeRuntimeConfigSelection;
+use anyhow::Result;
+use mesh_llm_native_runtime::{CachePrunePlan, NativeRuntimePruneMode, RuntimeSelection};
+use mesh_llm_runtime_install::{
+    NativeRuntimeDownloadProgressCallback, NativeRuntimeInstallOptions,
+    NativeRuntimeInstallOutcome, install_native_runtime, native_runtime_cache,
+};
+use std::future::Future;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub struct SetupNativeRuntimeOptions<'a> {
+    pub skip_runtime: bool,
+    pub requested_runtime: Option<&'a str>,
+    pub manifest_path: Option<&'a Path>,
+    pub bundle_dirs: &'a [PathBuf],
+    pub cache_dir: Option<&'a Path>,
+    pub configured: NativeRuntimeConfigSelection<'a>,
+    pub progress: Option<NativeRuntimeDownloadProgressCallback>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SetupNativeRuntimeStatus {
+    Skipped,
+    Installed(Box<NativeRuntimeInstallOutcome>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SetupNativeRuntimePruneResult {
+    Skipped,
+    Pruned(CachePrunePlan),
+    Warning(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SetupNativeRuntimeOutcome {
+    pub status: SetupNativeRuntimeStatus,
+    pub prune: SetupNativeRuntimePruneResult,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct ResolvedNativeRuntimeSelection<'a> {
+    pub(super) selection: RuntimeSelection,
+    pub(super) configured_selection: Option<&'a str>,
+}
+
+pub async fn install_and_prune_native_runtime_for_setup(
+    options: SetupNativeRuntimeOptions<'_>,
+) -> Result<SetupNativeRuntimeOutcome> {
+    install_and_prune_native_runtime_for_setup_with(
+        options,
+        install_native_runtime,
+        prune_inactive_native_runtime_cache,
+    )
+    .await
+}
+
+pub(super) fn resolve_runtime_selection<'a>(
+    requested_runtime: Option<&'a str>,
+    configured: NativeRuntimeConfigSelection<'a>,
+) -> Result<ResolvedNativeRuntimeSelection<'a>> {
+    let configured_selection = requested_runtime
+        .is_none()
+        .then_some(configured.selection)
+        .flatten();
+    let selection = RuntimeSelection::parse(requested_runtime.or(configured_selection))?;
+    Ok(ResolvedNativeRuntimeSelection {
+        selection,
+        configured_selection,
+    })
+}
+
+pub(super) fn native_runtime_install_options(
+    selection: RuntimeSelection,
+    manifest_path: Option<&Path>,
+    bundle_dirs: &[PathBuf],
+    cache_dir: Option<&Path>,
+    configured: NativeRuntimeConfigSelection<'_>,
+    progress: Option<NativeRuntimeDownloadProgressCallback>,
+) -> NativeRuntimeInstallOptions {
+    NativeRuntimeInstallOptions {
+        mesh_version: configured.mesh_version_or_current().to_string(),
+        skippy_abi_version: configured.skippy_abi_version.map(ToString::to_string),
+        selection,
+        manifest_path: manifest_path.map(Path::to_path_buf),
+        bundle_dirs: bundle_dirs.to_vec(),
+        cache_dir: cache_dir.map(Path::to_path_buf),
+        progress,
+        ..Default::default()
+    }
+}
+
+pub(super) fn prune_native_runtime_cache(
+    mesh_version: &str,
+    mode: NativeRuntimePruneMode,
+    cache_dir: Option<&Path>,
+) -> Result<CachePrunePlan> {
+    let cache = native_runtime_cache(cache_dir)?;
+    cache.prune(mesh_version, mode)
+}
+
+fn prune_inactive_native_runtime_cache(
+    mesh_version: &str,
+    cache_dir: Option<&Path>,
+) -> Result<CachePrunePlan> {
+    prune_native_runtime_cache(
+        mesh_version,
+        NativeRuntimePruneMode::KeepActiveAndPrevious,
+        cache_dir,
+    )
+}
+
+async fn install_and_prune_native_runtime_for_setup_with<InstallFn, InstallFuture, PruneFn>(
+    options: SetupNativeRuntimeOptions<'_>,
+    install: InstallFn,
+    prune: PruneFn,
+) -> Result<SetupNativeRuntimeOutcome>
+where
+    InstallFn: Fn(NativeRuntimeInstallOptions) -> InstallFuture,
+    InstallFuture: Future<Output = Result<NativeRuntimeInstallOutcome>>,
+    PruneFn: Fn(&str, Option<&Path>) -> Result<CachePrunePlan>,
+{
+    if options.skip_runtime {
+        return Ok(SetupNativeRuntimeOutcome {
+            status: SetupNativeRuntimeStatus::Skipped,
+            prune: SetupNativeRuntimePruneResult::Skipped,
+        });
+    }
+
+    let resolved_selection =
+        resolve_runtime_selection(options.requested_runtime, options.configured)?;
+    let install_options = native_runtime_install_options(
+        resolved_selection.selection,
+        options.manifest_path,
+        options.bundle_dirs,
+        options.cache_dir,
+        options.configured,
+        options.progress,
+    );
+    let mesh_version = install_options.mesh_version.clone();
+    let cache_dir = install_options.cache_dir.clone();
+    let outcome = install(install_options).await?;
+    let prune = match prune(&mesh_version, cache_dir.as_deref()) {
+        Ok(plan) => SetupNativeRuntimePruneResult::Pruned(plan),
+        Err(error) => SetupNativeRuntimePruneResult::Warning(error.to_string()),
+    };
+
+    Ok(SetupNativeRuntimeOutcome {
+        status: SetupNativeRuntimeStatus::Installed(Box::new(outcome)),
+        prune,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mesh_llm_native_runtime::{
+        CachePrunePlan, InstalledNativeRuntime, NativeRuntimeArtifact, NativeRuntimeBackend,
+        NativeRuntimeBackendKind, NativeRuntimePlatform, NativeRuntimeResolution,
+        NativeRuntimeSource,
+    };
+    use mesh_llm_runtime_install::{CURRENT_MESH_VERSION, NativeRuntimeInstallStatus};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    #[tokio::test]
+    async fn setup_runtime_helper_honors_configured_selection() {
+        let install_calls = Arc::new(Mutex::new(Vec::new()));
+        let install_calls_for_executor = Arc::clone(&install_calls);
+
+        let outcome = install_and_prune_native_runtime_for_setup_with(
+            SetupNativeRuntimeOptions {
+                skip_runtime: false,
+                requested_runtime: None,
+                manifest_path: None,
+                bundle_dirs: &[],
+                cache_dir: None,
+                configured: NativeRuntimeConfigSelection {
+                    mesh_version: Some("0.68.0"),
+                    skippy_abi_version: Some("0.1.25"),
+                    selection: Some("cpu"),
+                },
+                progress: None,
+            },
+            move |options| {
+                install_calls_for_executor
+                    .lock()
+                    .expect("lock install calls")
+                    .push(options.clone());
+                async move { Ok(fake_install_outcome("0.68.0")) }
+            },
+            |_mesh_version, _cache_dir| {
+                Ok(CachePrunePlan {
+                    remove_dirs: Vec::new(),
+                })
+            },
+        )
+        .await
+        .expect("setup runtime helper should install");
+
+        let calls = install_calls.lock().expect("lock install calls");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].mesh_version, "0.68.0");
+        assert_eq!(calls[0].skippy_abi_version.as_deref(), Some("0.1.25"));
+        assert_eq!(
+            calls[0].selection,
+            RuntimeSelection::Backend {
+                kind: NativeRuntimeBackendKind::Cpu,
+                cuda_toolkit_major: None,
+            }
+        );
+        assert!(matches!(
+            outcome.status,
+            SetupNativeRuntimeStatus::Installed(_)
+        ));
+        assert_eq!(
+            outcome.prune,
+            SetupNativeRuntimePruneResult::Pruned(CachePrunePlan {
+                remove_dirs: Vec::new(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn setup_runtime_helper_skips_install_and_prune() {
+        let install_called = AtomicBool::new(false);
+        let prune_called = AtomicBool::new(false);
+
+        let outcome = install_and_prune_native_runtime_for_setup_with(
+            SetupNativeRuntimeOptions {
+                skip_runtime: true,
+                requested_runtime: None,
+                manifest_path: None,
+                bundle_dirs: &[],
+                cache_dir: None,
+                configured: NativeRuntimeConfigSelection::default(),
+                progress: None,
+            },
+            |_options| {
+                install_called.store(true, Ordering::SeqCst);
+                async move { Ok(fake_install_outcome(CURRENT_MESH_VERSION)) }
+            },
+            |_mesh_version, _cache_dir| {
+                prune_called.store(true, Ordering::SeqCst);
+                Ok(CachePrunePlan {
+                    remove_dirs: Vec::new(),
+                })
+            },
+        )
+        .await
+        .expect("skip runtime should succeed");
+
+        assert_eq!(outcome.status, SetupNativeRuntimeStatus::Skipped);
+        assert_eq!(outcome.prune, SetupNativeRuntimePruneResult::Skipped);
+        assert!(!install_called.load(Ordering::SeqCst));
+        assert!(!prune_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn setup_runtime_helper_keeps_install_success_when_prune_warns() {
+        let outcome = install_and_prune_native_runtime_for_setup_with(
+            SetupNativeRuntimeOptions {
+                skip_runtime: false,
+                requested_runtime: None,
+                manifest_path: None,
+                bundle_dirs: &[],
+                cache_dir: None,
+                configured: NativeRuntimeConfigSelection {
+                    mesh_version: Some("0.68.0"),
+                    skippy_abi_version: None,
+                    selection: Some("recommended"),
+                },
+                progress: None,
+            },
+            |_options| async move { Ok(fake_install_outcome("0.68.0")) },
+            |_mesh_version, _cache_dir| anyhow::bail!("prune failed after install"),
+        )
+        .await
+        .expect("prune warnings should not fail setup install");
+
+        match outcome.status {
+            SetupNativeRuntimeStatus::Installed(ref installed) => {
+                assert_eq!(installed.status, NativeRuntimeInstallStatus::Installed);
+                assert_eq!(installed.runtime.mesh_version, "0.68.0");
+            }
+            SetupNativeRuntimeStatus::Skipped => panic!("install should have run"),
+        }
+
+        assert_eq!(
+            outcome.prune,
+            SetupNativeRuntimePruneResult::Warning("prune failed after install".to_string())
+        );
+    }
+
+    fn fake_install_outcome(mesh_version: &str) -> NativeRuntimeInstallOutcome {
+        let artifact = NativeRuntimeArtifact {
+            id: "meshllm-runtime-linux-x86_64-cpu".to_string(),
+            mesh_version: Some(mesh_version.to_string()),
+            skippy_abi: "0.1.25".to_string(),
+            platform: NativeRuntimePlatform {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                target: None,
+            },
+            backend: NativeRuntimeBackend::cpu(),
+            rank: 0,
+            libraries: vec!["libmeshllm_runtime.so".to_string()],
+            url: None,
+            sha256: None,
+            signature: None,
+        };
+
+        NativeRuntimeInstallOutcome {
+            status: NativeRuntimeInstallStatus::Installed,
+            runtime: InstalledNativeRuntime {
+                mesh_version: mesh_version.to_string(),
+                native_runtime_id: artifact.id.clone(),
+                flavor: "cpu".to_string(),
+                path: PathBuf::from("/tmp/meshllm-runtime-linux-x86_64-cpu"),
+                manifest: mesh_llm_native_runtime::NativeRuntimeManifest {
+                    runtime: artifact.clone(),
+                },
+            },
+            resolution: NativeRuntimeResolution {
+                selected: artifact,
+                source: NativeRuntimeSource::Installed {
+                    path: PathBuf::from("/tmp/meshllm-runtime-linux-x86_64-cpu"),
+                },
+                evaluated: Vec::new(),
+            },
+        }
+    }
+}

--- a/crates/mesh-llm-commands/src/setup/actions.rs
+++ b/crates/mesh-llm-commands/src/setup/actions.rs
@@ -1,0 +1,20 @@
+use super::{SetupGitHubStarPlan, SetupPrompter, SetupStep};
+use std::future::Future;
+
+pub trait SetupActions {
+    type Error;
+    type GitHubStarFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    where
+        Self: 'a;
+    type StepFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    where
+        Self: 'a;
+
+    fn run_step(&mut self, step: SetupStep) -> Self::StepFuture<'_>;
+
+    fn handle_github_star<'a>(
+        &'a mut self,
+        plan: SetupGitHubStarPlan,
+        prompter: &'a mut dyn SetupPrompter,
+    ) -> Self::GitHubStarFuture<'a>;
+}

--- a/crates/mesh-llm-commands/src/setup/cli_actions_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/cli_actions_tests.rs
@@ -1,0 +1,92 @@
+use super::command::{CliSetupActions, SetupServiceOutcome};
+use super::github::SetupGitHubOutcome;
+use super::github_runner::{GhCommand, GhCommandError};
+use super::test_support::{
+    FakePrompter, FakeServiceRunner, SharedGhRunner, service_context_fixture, success_output,
+};
+use super::{SetupActions, SetupEnvironment, SetupOptions, SetupPlatform, SetupStep, run_setup};
+use crate::runtime_native::{
+    NativeRuntimeConfigSelection, SetupNativeRuntimeOutcome, SetupNativeRuntimePruneResult,
+    SetupNativeRuntimeStatus,
+};
+
+#[tokio::test]
+async fn cli_setup_actions_treat_runtime_prune_warning_as_non_fatal() {
+    let (_temp, context) = service_context_fixture();
+    let mut actions = CliSetupActions::with_service_support(
+        SetupEnvironment {
+            platform: SetupPlatform::Linux,
+            interactive: false,
+        },
+        NativeRuntimeConfigSelection::default(),
+        context,
+        Box::new(FakeServiceRunner),
+        Box::new(SharedGhRunner::new([]).0),
+    );
+    actions.runtime_outcome = Some(SetupNativeRuntimeOutcome {
+        status: SetupNativeRuntimeStatus::Skipped,
+        prune: SetupNativeRuntimePruneResult::Warning("prune failed".to_string()),
+    });
+
+    actions
+        .run_step(SetupStep::PruneInactiveRuntimes)
+        .await
+        .expect("prune warnings should stay non-fatal");
+
+    assert_eq!(actions.service_outcome, SetupServiceOutcome::NotRequested);
+}
+
+#[tokio::test]
+async fn run_setup_with_cli_actions_records_nonfatal_github_failure() {
+    let (_temp, context) = service_context_fixture();
+    let (runner, state) = SharedGhRunner::new([
+        success_output("gh version 2.85.0"),
+        success_output("authenticated"),
+        success_output("false"),
+        Err(GhCommandError::TimedOut("gh api")),
+    ]);
+    let mut actions = CliSetupActions::with_service_support(
+        SetupEnvironment {
+            platform: SetupPlatform::Linux,
+            interactive: true,
+        },
+        NativeRuntimeConfigSelection::default(),
+        context,
+        Box::new(FakeServiceRunner),
+        Box::new(runner),
+    );
+    let mut prompter = FakePrompter::with_replies([None]);
+    let options = SetupOptions {
+        skip_runtime: true,
+        no_service: true,
+        ..SetupOptions::default()
+    };
+
+    let plan = run_setup(
+        options,
+        SetupEnvironment {
+            platform: SetupPlatform::Linux,
+            interactive: true,
+        },
+        &mut prompter,
+        &mut actions,
+    )
+    .await
+    .expect("github star failures should remain non-fatal");
+
+    assert!(plan.core_steps.is_empty());
+    assert_eq!(prompter.prompts.len(), 1);
+    assert_eq!(
+        actions.github_outcome,
+        SetupGitHubOutcome::StarRequestFailed("timed out running `gh api`".to_string())
+    );
+    assert_eq!(
+        state.borrow().commands,
+        vec![
+            GhCommand::CheckAvailability,
+            GhCommand::CheckAuthentication,
+            GhCommand::CheckViewerHasStarred,
+            GhCommand::StarRepository,
+        ]
+    );
+}

--- a/crates/mesh-llm-commands/src/setup/command.rs
+++ b/crates/mesh-llm-commands/src/setup/command.rs
@@ -51,9 +51,9 @@ where
 
 pub async fn run_setup_command(args: SetupCommandArgs<'_>) -> Result<()> {
     let mut prompter = CliSetupPrompter;
-    let mut actions = CliSetupActions::new(args.environment, args.configured);
+    let mut actions = CliSetupActions::new(args.environment, args.configured, args.options.verbose);
     let plan = run_setup(args.options, args.environment, &mut prompter, &mut actions).await?;
-    print_setup_summary(&plan, &actions);
+    print_setup_summary(&plan, &actions, args.options.verbose);
     Ok(())
 }
 
@@ -74,12 +74,14 @@ pub(crate) struct CliSetupActions<'a> {
     github_runner: Box<dyn GhCommandRunner>,
     pub(crate) service_outcome: SetupServiceOutcome,
     pub(crate) github_outcome: SetupGitHubOutcome,
+    verbose: bool,
 }
 
 impl<'a> CliSetupActions<'a> {
     pub(crate) fn new(
         environment: SetupEnvironment,
         configured: NativeRuntimeConfigSelection<'a>,
+        verbose: bool,
     ) -> Self {
         Self::with_support(
             environment,
@@ -87,6 +89,7 @@ impl<'a> CliSetupActions<'a> {
             None,
             Box::new(CliServiceCommandRunner),
             Box::new(ProcessGhCommandRunner::default()),
+            verbose,
         )
     }
 
@@ -96,6 +99,7 @@ impl<'a> CliSetupActions<'a> {
         service_context: Option<ServiceInstallContext>,
         service_runner: Box<dyn ServiceCommandRunner>,
         github_runner: Box<dyn GhCommandRunner>,
+        verbose: bool,
     ) -> Self {
         Self {
             environment,
@@ -106,6 +110,7 @@ impl<'a> CliSetupActions<'a> {
             github_runner,
             service_outcome: SetupServiceOutcome::NotRequested,
             github_outcome: SetupGitHubOutcome::NotEvaluated,
+            verbose,
         }
     }
 
@@ -123,6 +128,7 @@ impl<'a> CliSetupActions<'a> {
             Some(service_context),
             service_runner,
             github_runner,
+            false,
         )
     }
 
@@ -137,7 +143,9 @@ impl<'a> CliSetupActions<'a> {
             progress: None,
         })
         .await?;
-        print_runtime_install_result(&outcome);
+        if self.verbose {
+            print_runtime_install_result(&outcome);
+        }
         self.runtime_outcome = Some(outcome);
         Ok(())
     }
@@ -150,24 +158,24 @@ impl<'a> CliSetupActions<'a> {
         match &outcome.prune {
             SetupNativeRuntimePruneResult::Skipped => {}
             SetupNativeRuntimePruneResult::Pruned(plan) => {
-                if plan.remove_dirs.is_empty() {
-                    eprintln!("🧹 Native runtime cache is already clean");
-                } else {
-                    eprintln!(
-                        "🧹 Pruned {} inactive native runtime cache entr{}",
-                        plan.remove_dirs.len(),
-                        if plan.remove_dirs.len() == 1 {
-                            "y"
-                        } else {
-                            "ies"
-                        }
-                    );
+                if self.verbose {
+                    if plan.remove_dirs.is_empty() {
+                        eprintln!("Native runtime cache is already clean");
+                    } else {
+                        eprintln!(
+                            "Pruned {} inactive native runtime cache entr{}",
+                            plan.remove_dirs.len(),
+                            if plan.remove_dirs.len() == 1 {
+                                "y"
+                            } else {
+                                "ies"
+                            }
+                        );
+                    }
                 }
             }
             SetupNativeRuntimePruneResult::Warning(warning) => {
-                eprintln!(
-                    "⚠️  Native runtime installed, but inactive runtime cache pruning failed: {warning}"
-                );
+                eprintln!("warning: native runtime installed, but cache pruning failed: {warning}");
             }
         }
         Ok(())
@@ -179,15 +187,13 @@ impl<'a> CliSetupActions<'a> {
             None => ServiceInstallContext::detect(self.environment.platform, true)?,
         };
         let report = install_service(&context, self.service_runner.as_mut())?;
-        print_service_install_result(&report);
+        print_service_install_result(&report, self.verbose);
         self.service_outcome = SetupServiceOutcome::Installed(report);
         Ok(())
     }
 
     fn print_service_guidance(&self) {
-        eprintln!(
-            "ℹ️  Setup skipped background service installation. Re-run `mesh-llm setup --service` to opt in later."
-        );
+        eprintln!("Service not installed. Run `mesh-llm setup --service` to enable it later.");
     }
 }
 

--- a/crates/mesh-llm-commands/src/setup/command.rs
+++ b/crates/mesh-llm-commands/src/setup/command.rs
@@ -1,0 +1,238 @@
+use super::prompt::confirm_yes_no;
+use super::service_paths::ServiceInstallContext;
+use super::service_runner::{CliServiceCommandRunner, ServiceCommandRunner};
+use super::summary::{
+    print_runtime_install_result, print_service_install_result, print_setup_summary,
+};
+use super::{
+    SetupActions, SetupConfirmPrompt, SetupEnvironment, SetupGitHubStarPlan, SetupOptions,
+    SetupPlan, SetupPrompter, SetupStep,
+    github::{SetupGitHubOutcome, execute_github_star_plan},
+    github_runner::{GhCommandRunner, ProcessGhCommandRunner},
+    plan_setup,
+    service::{ServiceInstallReport, install_service},
+};
+use crate::runtime_native::{
+    NativeRuntimeConfigSelection, SetupNativeRuntimeOptions, SetupNativeRuntimeOutcome,
+    SetupNativeRuntimePruneResult, install_and_prune_native_runtime_for_setup,
+};
+use anyhow::{Result, anyhow};
+use std::future::Future;
+use std::pin::Pin;
+
+#[derive(Clone, Copy, Debug)]
+pub struct SetupCommandArgs<'a> {
+    pub options: SetupOptions,
+    pub environment: SetupEnvironment,
+    pub configured: NativeRuntimeConfigSelection<'a>,
+}
+
+pub async fn run_setup<P, A>(
+    options: SetupOptions,
+    environment: SetupEnvironment,
+    prompter: &mut P,
+    actions: &mut A,
+) -> Result<SetupPlan>
+where
+    P: SetupPrompter,
+    A: SetupActions,
+    A::Error: Into<anyhow::Error>,
+{
+    let plan = plan_setup(options, environment, prompter).map_err(anyhow::Error::new)?;
+    for step in plan.core_steps.iter().copied() {
+        actions.run_step(step).await.map_err(Into::into)?;
+    }
+    actions
+        .handle_github_star(plan.github_star, prompter)
+        .await
+        .map_err(Into::into)?;
+    Ok(plan)
+}
+
+pub async fn run_setup_command(args: SetupCommandArgs<'_>) -> Result<()> {
+    let mut prompter = CliSetupPrompter;
+    let mut actions = CliSetupActions::new(args.environment, args.configured);
+    let plan = run_setup(args.options, args.environment, &mut prompter, &mut actions).await?;
+    print_setup_summary(&plan, &actions);
+    Ok(())
+}
+
+struct CliSetupPrompter;
+
+impl SetupPrompter for CliSetupPrompter {
+    fn confirm(&mut self, prompt: SetupConfirmPrompt) -> Option<bool> {
+        confirm_yes_no(prompt.message)
+    }
+}
+
+pub(crate) struct CliSetupActions<'a> {
+    environment: SetupEnvironment,
+    configured: NativeRuntimeConfigSelection<'a>,
+    pub(crate) runtime_outcome: Option<SetupNativeRuntimeOutcome>,
+    service_context: Option<ServiceInstallContext>,
+    service_runner: Box<dyn ServiceCommandRunner>,
+    github_runner: Box<dyn GhCommandRunner>,
+    pub(crate) service_outcome: SetupServiceOutcome,
+    pub(crate) github_outcome: SetupGitHubOutcome,
+}
+
+impl<'a> CliSetupActions<'a> {
+    pub(crate) fn new(
+        environment: SetupEnvironment,
+        configured: NativeRuntimeConfigSelection<'a>,
+    ) -> Self {
+        Self::with_support(
+            environment,
+            configured,
+            None,
+            Box::new(CliServiceCommandRunner),
+            Box::new(ProcessGhCommandRunner::default()),
+        )
+    }
+
+    fn with_support(
+        environment: SetupEnvironment,
+        configured: NativeRuntimeConfigSelection<'a>,
+        service_context: Option<ServiceInstallContext>,
+        service_runner: Box<dyn ServiceCommandRunner>,
+        github_runner: Box<dyn GhCommandRunner>,
+    ) -> Self {
+        Self {
+            environment,
+            configured,
+            runtime_outcome: None,
+            service_context,
+            service_runner,
+            github_runner,
+            service_outcome: SetupServiceOutcome::NotRequested,
+            github_outcome: SetupGitHubOutcome::NotEvaluated,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_service_support(
+        environment: SetupEnvironment,
+        configured: NativeRuntimeConfigSelection<'a>,
+        service_context: ServiceInstallContext,
+        service_runner: Box<dyn ServiceCommandRunner>,
+        github_runner: Box<dyn GhCommandRunner>,
+    ) -> Self {
+        Self::with_support(
+            environment,
+            configured,
+            Some(service_context),
+            service_runner,
+            github_runner,
+        )
+    }
+
+    async fn install_runtime(&mut self) -> Result<()> {
+        let outcome = install_and_prune_native_runtime_for_setup(SetupNativeRuntimeOptions {
+            skip_runtime: false,
+            requested_runtime: None,
+            manifest_path: None,
+            bundle_dirs: &[],
+            cache_dir: None,
+            configured: self.configured,
+            progress: None,
+        })
+        .await?;
+        print_runtime_install_result(&outcome);
+        self.runtime_outcome = Some(outcome);
+        Ok(())
+    }
+
+    fn report_runtime_prune(&self) -> Result<()> {
+        let outcome = self
+            .runtime_outcome
+            .as_ref()
+            .ok_or_else(|| anyhow!("setup runtime prune step ran before runtime install"))?;
+        match &outcome.prune {
+            SetupNativeRuntimePruneResult::Skipped => {}
+            SetupNativeRuntimePruneResult::Pruned(plan) => {
+                if plan.remove_dirs.is_empty() {
+                    eprintln!("🧹 Native runtime cache is already clean");
+                } else {
+                    eprintln!(
+                        "🧹 Pruned {} inactive native runtime cache entr{}",
+                        plan.remove_dirs.len(),
+                        if plan.remove_dirs.len() == 1 {
+                            "y"
+                        } else {
+                            "ies"
+                        }
+                    );
+                }
+            }
+            SetupNativeRuntimePruneResult::Warning(warning) => {
+                eprintln!(
+                    "⚠️  Native runtime installed, but inactive runtime cache pruning failed: {warning}"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn install_service(&mut self) -> Result<()> {
+        let context = match self.service_context.clone() {
+            Some(context) => context,
+            None => ServiceInstallContext::detect(self.environment.platform, true)?,
+        };
+        let report = install_service(&context, self.service_runner.as_mut())?;
+        print_service_install_result(&report);
+        self.service_outcome = SetupServiceOutcome::Installed(report);
+        Ok(())
+    }
+
+    fn print_service_guidance(&self) {
+        eprintln!(
+            "ℹ️  Setup skipped background service installation. Re-run `mesh-llm setup --service` to opt in later."
+        );
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SetupServiceOutcome {
+    NotRequested,
+    Installed(ServiceInstallReport),
+    PrintedGuidance,
+}
+
+impl SetupActions for CliSetupActions<'_> {
+    type Error = anyhow::Error;
+    type GitHubStarFuture<'a>
+        = Pin<Box<dyn Future<Output = Result<(), Self::Error>> + 'a>>
+    where
+        Self: 'a;
+    type StepFuture<'a>
+        = Pin<Box<dyn Future<Output = Result<(), Self::Error>> + 'a>>
+    where
+        Self: 'a;
+
+    fn run_step(&mut self, step: SetupStep) -> Self::StepFuture<'_> {
+        Box::pin(async move {
+            match step {
+                SetupStep::InstallRuntime => self.install_runtime().await,
+                SetupStep::PruneInactiveRuntimes => self.report_runtime_prune(),
+                SetupStep::InstallService => self.install_service(),
+                SetupStep::PrintServiceGuidance => {
+                    self.service_outcome = SetupServiceOutcome::PrintedGuidance;
+                    self.print_service_guidance();
+                    Ok(())
+                }
+            }
+        })
+    }
+
+    fn handle_github_star<'a>(
+        &'a mut self,
+        plan: SetupGitHubStarPlan,
+        prompter: &'a mut dyn super::SetupPrompter,
+    ) -> Self::GitHubStarFuture<'a> {
+        Box::pin(async move {
+            self.github_outcome =
+                execute_github_star_plan(plan, &mut *self.github_runner, prompter);
+            Ok(())
+        })
+    }
+}

--- a/crates/mesh-llm-commands/src/setup/command_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/command_tests.rs
@@ -1,0 +1,235 @@
+use super::service_paths::ServiceInstallContext;
+use super::service_runner::{ServiceCommand, ServiceCommandRunner};
+use super::{
+    SetupActions, SetupConfirmPrompt, SetupEnvironment, SetupGitHubStarPlan,
+    SetupGitHubStarSkipReason, SetupOptions, SetupPlatform, SetupPrompter, SetupServicePlan,
+    SetupStep, run_setup,
+};
+use crate::setup::command::CliSetupActions;
+use crate::setup::github::{SetupGitHubOutcome, github_summary};
+use crate::setup::github_runner::{GhCommand, GhCommandError, GhCommandOutput, GhCommandRunner};
+use crate::setup::summary::service_summary;
+use std::collections::VecDeque;
+use std::fs;
+use std::future::{Ready, ready};
+
+#[derive(Default)]
+struct FakePrompter {
+    replies: VecDeque<Option<bool>>,
+}
+
+impl FakePrompter {
+    fn with_replies(replies: impl IntoIterator<Item = Option<bool>>) -> Self {
+        Self {
+            replies: replies.into_iter().collect(),
+        }
+    }
+}
+
+impl SetupPrompter for FakePrompter {
+    fn confirm(&mut self, _prompt: SetupConfirmPrompt) -> Option<bool> {
+        self.replies.pop_front().unwrap_or(None)
+    }
+}
+
+#[derive(Default)]
+struct FakeActions {
+    steps: Vec<SetupStep>,
+    github: Vec<SetupGitHubStarPlan>,
+}
+
+impl SetupActions for FakeActions {
+    type Error = anyhow::Error;
+    type GitHubStarFuture<'a>
+        = Ready<Result<(), Self::Error>>
+    where
+        Self: 'a;
+    type StepFuture<'a>
+        = Ready<Result<(), Self::Error>>
+    where
+        Self: 'a;
+
+    fn run_step(&mut self, step: SetupStep) -> Self::StepFuture<'_> {
+        self.steps.push(step);
+        ready(Ok(()))
+    }
+
+    fn handle_github_star<'a>(
+        &'a mut self,
+        plan: SetupGitHubStarPlan,
+        _prompter: &'a mut dyn super::SetupPrompter,
+    ) -> Self::GitHubStarFuture<'a> {
+        self.github.push(plan);
+        ready(Ok(()))
+    }
+}
+
+#[derive(Default)]
+struct FakeServiceRunner {
+    commands: Vec<ServiceCommand>,
+}
+
+impl ServiceCommandRunner for FakeServiceRunner {
+    fn run(&mut self, command: &ServiceCommand) -> anyhow::Result<()> {
+        self.commands.push(command.clone());
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct NoopGhRunner;
+
+impl GhCommandRunner for NoopGhRunner {
+    fn run(&mut self, _command: GhCommand) -> Result<GhCommandOutput, GhCommandError> {
+        Err(GhCommandError::WaitFailed(
+            "github runner should not be used in this test".to_string(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn run_setup_executes_planned_steps_and_github_star_action() {
+    let options = SetupOptions::default();
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::with_replies([Some(false)]);
+    let mut actions = FakeActions::default();
+
+    let plan = run_setup(options, environment, &mut prompter, &mut actions)
+        .await
+        .expect("setup should execute");
+
+    assert_eq!(plan.service, SetupServicePlan::Skip);
+    assert_eq!(
+        actions.steps,
+        vec![SetupStep::InstallRuntime, SetupStep::PruneInactiveRuntimes]
+    );
+    assert_eq!(actions.github, vec![SetupGitHubStarPlan::PromptIfEligible]);
+}
+
+#[tokio::test]
+async fn run_setup_stops_before_actions_on_plan_error() {
+    let options = SetupOptions {
+        service: true,
+        no_service: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+    let mut actions = FakeActions::default();
+
+    let error = run_setup(options, environment, &mut prompter, &mut actions)
+        .await
+        .expect_err("conflicting flags should fail planning");
+
+    assert!(
+        error
+            .to_string()
+            .contains("setup received both --service and --no-service"),
+        "unexpected error: {error:#}"
+    );
+    assert!(actions.steps.is_empty());
+    assert!(actions.github.is_empty());
+}
+
+#[tokio::test]
+async fn run_setup_suppresses_github_star_for_yes_mode() {
+    let options = SetupOptions {
+        yes: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::MacOs,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+    let mut actions = FakeActions::default();
+
+    let _plan = run_setup(options, environment, &mut prompter, &mut actions)
+        .await
+        .expect("setup should execute");
+
+    assert_eq!(
+        actions.github,
+        vec![SetupGitHubStarPlan::Skip(
+            SetupGitHubStarSkipReason::AutomaticYes
+        )]
+    );
+}
+
+#[test]
+fn github_summary_reports_authenticated_star_success() {
+    let plan = super::SetupPlan::new(
+        super::SetupRuntimePlan::Skip,
+        super::SetupServicePlan::Skip,
+        SetupGitHubStarPlan::PromptIfEligible,
+    );
+
+    assert_eq!(
+        github_summary(&plan, &SetupGitHubOutcome::Starred),
+        "starred Mesh-LLM/mesh-llm with the authenticated GitHub CLI account"
+    );
+}
+
+#[tokio::test]
+async fn service_summary_reports_real_service_installation() {
+    let plan = super::SetupPlan::new(
+        super::SetupRuntimePlan::Skip,
+        super::SetupServicePlan::Install,
+        SetupGitHubStarPlan::Skip(SetupGitHubStarSkipReason::AutomaticYes),
+    );
+    let temp = tempfile::tempdir().expect("tempdir should exist");
+    let binary_path = temp.path().join("bin/mesh-llm");
+    fs::create_dir_all(binary_path.parent().expect("binary parent should exist"))
+        .expect("binary dir should exist");
+    fs::write(&binary_path, "binary").expect("binary should write");
+    let context = ServiceInstallContext {
+        platform: SetupPlatform::MacOs,
+        home_dir: temp.path().join("home"),
+        config_root: temp.path().join("config"),
+        binary_path,
+        user_id: "501".to_string(),
+        start_service: false,
+    };
+    let mut actions = CliSetupActions::with_service_support(
+        SetupEnvironment {
+            platform: SetupPlatform::MacOs,
+            interactive: false,
+        },
+        crate::runtime_native::NativeRuntimeConfigSelection::default(),
+        context,
+        Box::new(FakeServiceRunner::default()),
+        Box::new(NoopGhRunner),
+    );
+    actions
+        .run_step(SetupStep::InstallService)
+        .await
+        .expect("service install should execute");
+
+    assert_eq!(
+        service_summary(&plan, &actions),
+        "installed; automatic start needs manual follow-up"
+    );
+}
+
+#[test]
+fn github_summary_reports_nonfatal_star_request_failure() {
+    let plan = super::SetupPlan::new(
+        super::SetupRuntimePlan::Skip,
+        super::SetupServicePlan::Skip,
+        SetupGitHubStarPlan::PromptIfEligible,
+    );
+
+    assert_eq!(
+        github_summary(
+            &plan,
+            &SetupGitHubOutcome::StarRequestFailed(GhCommandError::TimedOut("gh api").to_string())
+        ),
+        "not starred; GitHub star request failed: timed out running `gh api`"
+    );
+}

--- a/crates/mesh-llm-commands/src/setup/environment.rs
+++ b/crates/mesh-llm-commands/src/setup/environment.rs
@@ -1,0 +1,41 @@
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SetupOptions {
+    pub yes: bool,
+    pub no_interactive: bool,
+    pub service: bool,
+    pub no_service: bool,
+    pub skip_runtime: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SetupEnvironment {
+    pub platform: SetupPlatform,
+    pub interactive: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupPlatform {
+    Linux,
+    MacOs,
+    Windows,
+}
+
+impl SetupEnvironment {
+    pub const fn prompts_visible(self, options: SetupOptions) -> bool {
+        self.interactive && !options.no_interactive && !options.yes
+    }
+}
+
+impl SetupPlatform {
+    pub const fn supports_service(self) -> bool {
+        matches!(self, Self::Linux | Self::MacOs)
+    }
+
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::Linux => "linux",
+            Self::MacOs => "macos",
+            Self::Windows => "windows",
+        }
+    }
+}

--- a/crates/mesh-llm-commands/src/setup/environment.rs
+++ b/crates/mesh-llm-commands/src/setup/environment.rs
@@ -5,6 +5,7 @@ pub struct SetupOptions {
     pub service: bool,
     pub no_service: bool,
     pub skip_runtime: bool,
+    pub verbose: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/mesh-llm-commands/src/setup/github.rs
+++ b/crates/mesh-llm-commands/src/setup/github.rs
@@ -4,8 +4,7 @@ use super::{
     SetupPromptDefault, SetupPromptKind, SetupPrompter,
 };
 
-const GITHUB_STAR_PROMPT: &str =
-    "Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account?";
+const GITHUB_STAR_PROMPT: &str = "Star Mesh-LLM/mesh-llm on GitHub?";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum SetupGitHubOutcome {

--- a/crates/mesh-llm-commands/src/setup/github.rs
+++ b/crates/mesh-llm-commands/src/setup/github.rs
@@ -5,7 +5,7 @@ use super::{
 };
 
 const GITHUB_STAR_PROMPT: &str =
-    "Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account? [Y/n]";
+    "Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account?";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum SetupGitHubOutcome {

--- a/crates/mesh-llm-commands/src/setup/github.rs
+++ b/crates/mesh-llm-commands/src/setup/github.rs
@@ -1,0 +1,158 @@
+use super::github_runner::{GhCommand, GhCommandError, GhCommandOutput, GhCommandRunner};
+use super::{
+    SetupConfirmPrompt, SetupGitHubStarPlan, SetupGitHubStarSkipReason, SetupPlan,
+    SetupPromptDefault, SetupPromptKind, SetupPrompter,
+};
+
+const GITHUB_STAR_PROMPT: &str =
+    "Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account? [Y/n]";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SetupGitHubOutcome {
+    NotEvaluated,
+    AutomaticYes,
+    HiddenPrompt,
+    CliUnavailable,
+    NotAuthenticated,
+    AlreadyStarred,
+    DeclinedAtPrompt,
+    Starred,
+    EligibilityCheckFailed(String),
+    StarRequestFailed(String),
+}
+
+pub(crate) fn execute_github_star_plan<R: GhCommandRunner + ?Sized>(
+    plan: SetupGitHubStarPlan,
+    runner: &mut R,
+    prompter: &mut dyn SetupPrompter,
+) -> SetupGitHubOutcome {
+    match plan {
+        SetupGitHubStarPlan::Skip(skip_reason) => match skip_reason {
+            SetupGitHubStarSkipReason::AutomaticYes => SetupGitHubOutcome::AutomaticYes,
+            SetupGitHubStarSkipReason::HiddenPrompt => SetupGitHubOutcome::HiddenPrompt,
+        },
+        SetupGitHubStarPlan::PromptIfEligible => {
+            run_github_star_prompt_if_eligible(runner, prompter)
+        }
+    }
+}
+
+pub(crate) fn github_summary(plan: &SetupPlan, outcome: &SetupGitHubOutcome) -> String {
+    match plan.github_star {
+        SetupGitHubStarPlan::PromptIfEligible => match outcome {
+            SetupGitHubOutcome::NotEvaluated => "not recorded".to_string(),
+            SetupGitHubOutcome::CliUnavailable => "skipped; GitHub CLI is not on PATH".to_string(),
+            SetupGitHubOutcome::NotAuthenticated => {
+                "skipped; GitHub CLI is not authenticated for github.com".to_string()
+            }
+            SetupGitHubOutcome::AlreadyStarred => {
+                "already starred via the authenticated GitHub CLI account".to_string()
+            }
+            SetupGitHubOutcome::DeclinedAtPrompt => {
+                "skipped at the visible GitHub star prompt".to_string()
+            }
+            SetupGitHubOutcome::Starred => {
+                "starred Mesh-LLM/mesh-llm with the authenticated GitHub CLI account".to_string()
+            }
+            SetupGitHubOutcome::EligibilityCheckFailed(error) => {
+                format!("skipped; GitHub eligibility check failed: {error}")
+            }
+            SetupGitHubOutcome::StarRequestFailed(error) => {
+                format!("not starred; GitHub star request failed: {error}")
+            }
+            SetupGitHubOutcome::AutomaticYes | SetupGitHubOutcome::HiddenPrompt => {
+                "not recorded".to_string()
+            }
+        },
+        SetupGitHubStarPlan::Skip(_) => match outcome {
+            SetupGitHubOutcome::AutomaticYes => {
+                "skipped because --yes suppresses prompts".to_string()
+            }
+            SetupGitHubOutcome::HiddenPrompt => "skipped because prompts were hidden".to_string(),
+            SetupGitHubOutcome::NotEvaluated
+            | SetupGitHubOutcome::CliUnavailable
+            | SetupGitHubOutcome::NotAuthenticated
+            | SetupGitHubOutcome::AlreadyStarred
+            | SetupGitHubOutcome::DeclinedAtPrompt
+            | SetupGitHubOutcome::Starred
+            | SetupGitHubOutcome::EligibilityCheckFailed(_)
+            | SetupGitHubOutcome::StarRequestFailed(_) => "not requested".to_string(),
+        },
+    }
+}
+
+fn run_github_star_prompt_if_eligible<R: GhCommandRunner + ?Sized>(
+    runner: &mut R,
+    prompter: &mut dyn SetupPrompter,
+) -> SetupGitHubOutcome {
+    match runner.run(GhCommand::CheckAvailability) {
+        Ok(output) if output.success => {}
+        Ok(output) => {
+            return SetupGitHubOutcome::EligibilityCheckFailed(command_failure(
+                GhCommand::CheckAvailability,
+                &output,
+            ));
+        }
+        Err(GhCommandError::NotOnPath) => return SetupGitHubOutcome::CliUnavailable,
+        Err(error) => return SetupGitHubOutcome::EligibilityCheckFailed(error.to_string()),
+    }
+
+    match runner.run(GhCommand::CheckAuthentication) {
+        Ok(output) if output.success => {}
+        Ok(_) => return SetupGitHubOutcome::NotAuthenticated,
+        Err(error) => return SetupGitHubOutcome::EligibilityCheckFailed(error.to_string()),
+    }
+
+    let viewer_has_starred = match runner.run(GhCommand::CheckViewerHasStarred) {
+        Ok(output) if output.success => match output.stdout.trim() {
+            "true" => true,
+            "false" => false,
+            other => {
+                return SetupGitHubOutcome::EligibilityCheckFailed(format!(
+                    "unexpected output from `{}`: {other}",
+                    GhCommand::CheckViewerHasStarred.display_name()
+                ));
+            }
+        },
+        Ok(output) => {
+            return SetupGitHubOutcome::EligibilityCheckFailed(command_failure(
+                GhCommand::CheckViewerHasStarred,
+                &output,
+            ));
+        }
+        Err(error) => return SetupGitHubOutcome::EligibilityCheckFailed(error.to_string()),
+    };
+    if viewer_has_starred {
+        return SetupGitHubOutcome::AlreadyStarred;
+    }
+
+    let prompt = SetupConfirmPrompt {
+        kind: SetupPromptKind::GitHubStar,
+        message: GITHUB_STAR_PROMPT,
+        default: SetupPromptDefault::Yes,
+    };
+    let accepted = prompt.default.resolve(prompter.confirm(prompt));
+    if !accepted {
+        return SetupGitHubOutcome::DeclinedAtPrompt;
+    }
+
+    match runner.run(GhCommand::StarRepository) {
+        Ok(output) if output.success => SetupGitHubOutcome::Starred,
+        Ok(output) => SetupGitHubOutcome::StarRequestFailed(command_failure(
+            GhCommand::StarRepository,
+            &output,
+        )),
+        Err(error) => SetupGitHubOutcome::StarRequestFailed(error.to_string()),
+    }
+}
+
+fn command_failure(command: GhCommand, output: &GhCommandOutput) -> String {
+    let detail = first_non_empty_line(&output.stderr)
+        .or_else(|| first_non_empty_line(&output.stdout))
+        .unwrap_or("no output");
+    format!("`{}` reported: {detail}", command.display_name())
+}
+
+fn first_non_empty_line(value: &str) -> Option<&str> {
+    value.lines().map(str::trim).find(|line| !line.is_empty())
+}

--- a/crates/mesh-llm-commands/src/setup/github_runner.rs
+++ b/crates/mesh-llm-commands/src/setup/github_runner.rs
@@ -1,0 +1,140 @@
+use std::fmt::{self, Display, Formatter};
+use std::io;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const GITHUB_REPOSITORY: &str = "Mesh-LLM/mesh-llm";
+const GH_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const GH_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GhCommand {
+    CheckAvailability,
+    CheckAuthentication,
+    CheckViewerHasStarred,
+    StarRepository,
+}
+
+impl GhCommand {
+    const fn args(self) -> &'static [&'static str] {
+        match self {
+            Self::CheckAvailability => &["--version"],
+            Self::CheckAuthentication => {
+                &["auth", "status", "--active", "--hostname", "github.com"]
+            }
+            Self::CheckViewerHasStarred => &[
+                "repo",
+                "view",
+                GITHUB_REPOSITORY,
+                "--json",
+                "viewerHasStarred",
+                "--jq",
+                ".viewerHasStarred",
+            ],
+            Self::StarRepository => &[
+                "api",
+                "--method",
+                "PUT",
+                "/user/starred/Mesh-LLM/mesh-llm",
+                "--silent",
+            ],
+        }
+    }
+
+    pub(crate) const fn display_name(self) -> &'static str {
+        match self {
+            Self::CheckAvailability => "gh --version",
+            Self::CheckAuthentication => "gh auth status --active --hostname github.com",
+            Self::CheckViewerHasStarred => {
+                "gh repo view Mesh-LLM/mesh-llm --json viewerHasStarred --jq .viewerHasStarred"
+            }
+            Self::StarRepository => "gh api --method PUT /user/starred/Mesh-LLM/mesh-llm --silent",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct GhCommandOutput {
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum GhCommandError {
+    NotOnPath,
+    SpawnFailed(String),
+    WaitFailed(String),
+    TimedOut(&'static str),
+    KillFailed(String),
+}
+
+impl Display for GhCommandError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotOnPath => f.write_str("GitHub CLI is not on PATH"),
+            Self::SpawnFailed(error) => write!(f, "failed to start gh: {error}"),
+            Self::WaitFailed(error) => write!(f, "failed while waiting for gh: {error}"),
+            Self::TimedOut(command) => write!(f, "timed out running `{command}`"),
+            Self::KillFailed(error) => write!(f, "failed to stop timed out gh command: {error}"),
+        }
+    }
+}
+
+pub(crate) trait GhCommandRunner {
+    fn run(&mut self, command: GhCommand) -> Result<GhCommandOutput, GhCommandError>;
+}
+
+pub(crate) struct ProcessGhCommandRunner {
+    timeout: Duration,
+}
+
+impl Default for ProcessGhCommandRunner {
+    fn default() -> Self {
+        Self {
+            timeout: GH_COMMAND_TIMEOUT,
+        }
+    }
+}
+
+impl GhCommandRunner for ProcessGhCommandRunner {
+    fn run(&mut self, command: GhCommand) -> Result<GhCommandOutput, GhCommandError> {
+        let mut child = Command::new("gh")
+            .args(command.args())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| match error.kind() {
+                io::ErrorKind::NotFound => GhCommandError::NotOnPath,
+                _ => GhCommandError::SpawnFailed(error.to_string()),
+            })?;
+
+        let started_at = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    let output = child
+                        .wait_with_output()
+                        .map_err(|error| GhCommandError::WaitFailed(error.to_string()))?;
+                    return Ok(GhCommandOutput {
+                        success: output.status.success(),
+                        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                    });
+                }
+                Ok(None) => {
+                    if started_at.elapsed() >= self.timeout {
+                        child
+                            .kill()
+                            .map_err(|error| GhCommandError::KillFailed(error.to_string()))?;
+                        let _ = child.wait();
+                        return Err(GhCommandError::TimedOut(command.display_name()));
+                    }
+                    thread::sleep(GH_POLL_INTERVAL);
+                }
+                Err(error) => return Err(GhCommandError::WaitFailed(error.to_string())),
+            }
+        }
+    }
+}

--- a/crates/mesh-llm-commands/src/setup/github_runner.rs
+++ b/crates/mesh-llm-commands/src/setup/github_runner.rs
@@ -125,11 +125,28 @@ impl GhCommandRunner for ProcessGhCommandRunner {
                 }
                 Ok(None) => {
                     if started_at.elapsed() >= self.timeout {
-                        child
-                            .kill()
-                            .map_err(|error| GhCommandError::KillFailed(error.to_string()))?;
-                        let _ = child.wait();
-                        return Err(GhCommandError::TimedOut(command.display_name()));
+                        match child.try_wait() {
+                            Ok(Some(_)) => {
+                                let output = child.wait_with_output().map_err(|error| {
+                                    GhCommandError::WaitFailed(error.to_string())
+                                })?;
+                                return Ok(GhCommandOutput {
+                                    success: output.status.success(),
+                                    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                                    stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                                });
+                            }
+                            Ok(None) => {
+                                child.kill().map_err(|error| {
+                                    GhCommandError::KillFailed(error.to_string())
+                                })?;
+                                let _ = child.wait();
+                                return Err(GhCommandError::TimedOut(command.display_name()));
+                            }
+                            Err(error) => {
+                                return Err(GhCommandError::WaitFailed(error.to_string()));
+                            }
+                        }
                     }
                     thread::sleep(GH_POLL_INTERVAL);
                 }

--- a/crates/mesh-llm-commands/src/setup/github_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/github_tests.rs
@@ -193,7 +193,7 @@ fn eligible_default_yes_stars_with_api_fallback_and_exact_prompt() {
     assert_eq!(prompter.prompts[0].default, SetupPromptDefault::Yes);
     assert_eq!(
         prompter.prompts[0].message,
-        "Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account?"
+        "Star Mesh-LLM/mesh-llm on GitHub?"
     );
     assert_eq!(
         runner.commands,

--- a/crates/mesh-llm-commands/src/setup/github_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/github_tests.rs
@@ -1,0 +1,260 @@
+use super::github::{SetupGitHubOutcome, execute_github_star_plan, github_summary};
+use super::github_runner::{GhCommand, GhCommandError, GhCommandOutput, GhCommandRunner};
+use super::{
+    SetupConfirmPrompt, SetupGitHubStarPlan, SetupGitHubStarSkipReason, SetupPlan,
+    SetupPromptDefault, SetupPromptKind, SetupPrompter,
+};
+use std::collections::VecDeque;
+
+#[derive(Default)]
+struct FakePrompter {
+    prompts: Vec<SetupConfirmPrompt>,
+    replies: VecDeque<Option<bool>>,
+}
+
+impl FakePrompter {
+    fn with_replies(replies: impl IntoIterator<Item = Option<bool>>) -> Self {
+        Self {
+            prompts: Vec::new(),
+            replies: replies.into_iter().collect(),
+        }
+    }
+}
+
+impl SetupPrompter for FakePrompter {
+    fn confirm(&mut self, prompt: SetupConfirmPrompt) -> Option<bool> {
+        self.prompts.push(prompt);
+        self.replies.pop_front().unwrap_or(None)
+    }
+}
+
+#[derive(Default)]
+struct FakeGhCommandRunner {
+    commands: Vec<GhCommand>,
+    responses: VecDeque<Result<GhCommandOutput, GhCommandError>>,
+}
+
+impl FakeGhCommandRunner {
+    fn with_responses(
+        responses: impl IntoIterator<Item = Result<GhCommandOutput, GhCommandError>>,
+    ) -> Self {
+        Self {
+            commands: Vec::new(),
+            responses: responses.into_iter().collect(),
+        }
+    }
+}
+
+impl GhCommandRunner for FakeGhCommandRunner {
+    fn run(&mut self, command: GhCommand) -> Result<GhCommandOutput, GhCommandError> {
+        self.commands.push(command);
+        self.responses
+            .pop_front()
+            .unwrap_or_else(|| Err(GhCommandError::WaitFailed("missing fake response".into())))
+    }
+}
+
+fn prompt_plan() -> SetupGitHubStarPlan {
+    SetupGitHubStarPlan::PromptIfEligible
+}
+
+fn skip_plan(reason: SetupGitHubStarSkipReason) -> SetupGitHubStarPlan {
+    SetupGitHubStarPlan::Skip(reason)
+}
+
+#[test]
+fn hidden_prompt_skip_never_runs_gh_or_prompts() {
+    let mut runner = FakeGhCommandRunner::default();
+    let mut prompter = FakePrompter::default();
+
+    let outcome = execute_github_star_plan(
+        skip_plan(SetupGitHubStarSkipReason::HiddenPrompt),
+        &mut runner,
+        &mut prompter,
+    );
+
+    assert_eq!(outcome, SetupGitHubOutcome::HiddenPrompt);
+    assert!(runner.commands.is_empty());
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn automatic_yes_skip_never_runs_gh_or_prompts() {
+    let mut runner = FakeGhCommandRunner::default();
+    let mut prompter = FakePrompter::default();
+
+    let outcome = execute_github_star_plan(
+        skip_plan(SetupGitHubStarSkipReason::AutomaticYes),
+        &mut runner,
+        &mut prompter,
+    );
+
+    assert_eq!(outcome, SetupGitHubOutcome::AutomaticYes);
+    assert!(runner.commands.is_empty());
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn unavailable_gh_skips_without_prompt() {
+    let mut runner = FakeGhCommandRunner::with_responses([Err(GhCommandError::NotOnPath)]);
+    let mut prompter = FakePrompter::default();
+
+    let outcome = execute_github_star_plan(prompt_plan(), &mut runner, &mut prompter);
+
+    assert_eq!(outcome, SetupGitHubOutcome::CliUnavailable);
+    assert_eq!(runner.commands, vec![GhCommand::CheckAvailability]);
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn unauthenticated_gh_skips_without_prompt() {
+    let mut runner = FakeGhCommandRunner::with_responses([
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "gh version 2.85.0".to_string(),
+            stderr: String::new(),
+        }),
+        Ok(GhCommandOutput {
+            success: false,
+            stdout: String::new(),
+            stderr: "not logged in".to_string(),
+        }),
+    ]);
+    let mut prompter = FakePrompter::default();
+
+    let outcome = execute_github_star_plan(prompt_plan(), &mut runner, &mut prompter);
+
+    assert_eq!(outcome, SetupGitHubOutcome::NotAuthenticated);
+    assert_eq!(
+        runner.commands,
+        vec![GhCommand::CheckAvailability, GhCommand::CheckAuthentication]
+    );
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn already_starred_skips_without_prompt() {
+    let mut runner = FakeGhCommandRunner::with_responses([
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "gh version 2.85.0".to_string(),
+            stderr: String::new(),
+        }),
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "authenticated".to_string(),
+            stderr: String::new(),
+        }),
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "true".to_string(),
+            stderr: String::new(),
+        }),
+    ]);
+    let mut prompter = FakePrompter::default();
+
+    let outcome = execute_github_star_plan(prompt_plan(), &mut runner, &mut prompter);
+
+    assert_eq!(outcome, SetupGitHubOutcome::AlreadyStarred);
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn eligible_default_yes_stars_with_api_fallback_and_exact_prompt() {
+    let mut runner = FakeGhCommandRunner::with_responses([
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "gh version 2.85.0".to_string(),
+            stderr: String::new(),
+        }),
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "authenticated".to_string(),
+            stderr: String::new(),
+        }),
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "false".to_string(),
+            stderr: String::new(),
+        }),
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: String::new(),
+            stderr: String::new(),
+        }),
+    ]);
+    let mut prompter = FakePrompter::with_replies([None]);
+
+    let outcome = execute_github_star_plan(prompt_plan(), &mut runner, &mut prompter);
+
+    assert_eq!(outcome, SetupGitHubOutcome::Starred);
+    assert_eq!(prompter.prompts.len(), 1);
+    assert_eq!(prompter.prompts[0].kind, SetupPromptKind::GitHubStar);
+    assert_eq!(prompter.prompts[0].default, SetupPromptDefault::Yes);
+    assert_eq!(
+        prompter.prompts[0].message,
+        "Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account? [Y/n]"
+    );
+    assert_eq!(
+        runner.commands,
+        vec![
+            GhCommand::CheckAvailability,
+            GhCommand::CheckAuthentication,
+            GhCommand::CheckViewerHasStarred,
+            GhCommand::StarRepository,
+        ]
+    );
+}
+
+#[test]
+fn eligible_explicit_no_skips_star_command() {
+    let mut runner = FakeGhCommandRunner::with_responses([
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "gh version 2.85.0".to_string(),
+            stderr: String::new(),
+        }),
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "authenticated".to_string(),
+            stderr: String::new(),
+        }),
+        Ok(GhCommandOutput {
+            success: true,
+            stdout: "false".to_string(),
+            stderr: String::new(),
+        }),
+    ]);
+    let mut prompter = FakePrompter::with_replies([Some(false)]);
+
+    let outcome = execute_github_star_plan(prompt_plan(), &mut runner, &mut prompter);
+
+    assert_eq!(outcome, SetupGitHubOutcome::DeclinedAtPrompt);
+    assert_eq!(
+        runner.commands,
+        vec![
+            GhCommand::CheckAvailability,
+            GhCommand::CheckAuthentication,
+            GhCommand::CheckViewerHasStarred,
+        ]
+    );
+}
+
+#[test]
+fn summary_reports_nonfatal_eligibility_failures_honestly() {
+    let plan = SetupPlan::new(
+        super::SetupRuntimePlan::Skip,
+        super::SetupServicePlan::Skip,
+        prompt_plan(),
+    );
+
+    let summary = github_summary(
+        &plan,
+        &SetupGitHubOutcome::EligibilityCheckFailed("timed out running `gh --version`".into()),
+    );
+
+    assert_eq!(
+        summary,
+        "skipped; GitHub eligibility check failed: timed out running `gh --version`"
+    );
+}

--- a/crates/mesh-llm-commands/src/setup/github_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/github_tests.rs
@@ -193,7 +193,7 @@ fn eligible_default_yes_stars_with_api_fallback_and_exact_prompt() {
     assert_eq!(prompter.prompts[0].default, SetupPromptDefault::Yes);
     assert_eq!(
         prompter.prompts[0].message,
-        "Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account? [Y/n]"
+        "Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account?"
     );
     assert_eq!(
         runner.commands,

--- a/crates/mesh-llm-commands/src/setup/mod.rs
+++ b/crates/mesh-llm-commands/src/setup/mod.rs
@@ -1,0 +1,45 @@
+mod actions;
+mod command;
+mod environment;
+mod github;
+mod github_runner;
+mod plan;
+mod planner;
+mod prompt;
+mod service;
+pub(crate) mod service_files;
+pub(crate) mod service_paths;
+pub(crate) mod service_runner;
+mod service_templates;
+pub(crate) mod summary;
+
+pub use actions::SetupActions;
+pub use command::{SetupCommandArgs, run_setup, run_setup_command};
+pub use environment::{SetupEnvironment, SetupOptions, SetupPlatform};
+pub use plan::{
+    SetupGitHubStarPlan, SetupGitHubStarSkipReason, SetupPlan, SetupRuntimePlan, SetupServicePlan,
+    SetupStep,
+};
+pub use planner::{SetupPlanError, plan_setup};
+pub use prompt::{SetupConfirmPrompt, SetupPromptDefault, SetupPromptKind, SetupPrompter};
+
+#[cfg(test)]
+mod cli_actions_tests;
+
+#[cfg(test)]
+mod command_tests;
+
+#[cfg(test)]
+mod github_tests;
+
+#[cfg(test)]
+mod orchestration_tests;
+
+#[cfg(test)]
+mod service_tests;
+
+#[cfg(test)]
+mod test_support;
+
+#[cfg(test)]
+mod tests;

--- a/crates/mesh-llm-commands/src/setup/orchestration_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/orchestration_tests.rs
@@ -1,0 +1,84 @@
+use super::test_support::{FakePrompter, RecordingActions};
+use super::{SetupEnvironment, SetupOptions, SetupPlatform, SetupStep, run_setup};
+
+#[tokio::test]
+async fn run_setup_no_interactive_uses_guidance_step_and_hidden_star_without_prompts() {
+    let options = SetupOptions {
+        no_interactive: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: false,
+    };
+    let mut prompter = FakePrompter::default();
+    let mut actions = RecordingActions::default();
+
+    let plan = run_setup(options, environment, &mut prompter, &mut actions)
+        .await
+        .expect("setup should execute without prompts");
+
+    assert_eq!(
+        plan.core_steps,
+        vec![
+            SetupStep::InstallRuntime,
+            SetupStep::PruneInactiveRuntimes,
+            SetupStep::PrintServiceGuidance,
+        ]
+    );
+    assert_eq!(actions.steps, plan.core_steps);
+    assert_eq!(actions.github, vec![plan.github_star]);
+    assert!(prompter.prompts.is_empty());
+}
+
+#[tokio::test]
+async fn run_setup_skip_runtime_and_no_service_runs_no_hidden_core_side_effects() {
+    let options = SetupOptions {
+        skip_runtime: true,
+        no_service: true,
+        yes: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+    let mut actions = RecordingActions::default();
+
+    let plan = run_setup(options, environment, &mut prompter, &mut actions)
+        .await
+        .expect("setup should execute without hidden work");
+
+    assert!(plan.core_steps.is_empty());
+    assert!(actions.steps.is_empty());
+    assert_eq!(actions.github, vec![plan.github_star]);
+    assert!(prompter.prompts.is_empty());
+}
+
+#[tokio::test]
+async fn run_setup_service_failure_is_core_fatal_and_skips_github() {
+    let options = SetupOptions {
+        skip_runtime: true,
+        service: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+    let mut actions = RecordingActions::failing_on(SetupStep::InstallService);
+
+    let error = run_setup(options, environment, &mut prompter, &mut actions)
+        .await
+        .expect_err("service installation failure should stop setup");
+
+    assert!(
+        error
+            .to_string()
+            .contains("simulated step failure for InstallService")
+    );
+    assert_eq!(actions.steps, vec![SetupStep::InstallService]);
+    assert!(actions.github.is_empty());
+}

--- a/crates/mesh-llm-commands/src/setup/plan.rs
+++ b/crates/mesh-llm-commands/src/setup/plan.rs
@@ -1,0 +1,70 @@
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SetupPlan {
+    pub runtime: SetupRuntimePlan,
+    pub service: SetupServicePlan,
+    pub github_star: SetupGitHubStarPlan,
+    pub core_steps: Vec<SetupStep>,
+}
+
+impl SetupPlan {
+    pub fn new(
+        runtime: SetupRuntimePlan,
+        service: SetupServicePlan,
+        github_star: SetupGitHubStarPlan,
+    ) -> Self {
+        let core_steps = build_core_steps(runtime, service);
+        Self {
+            runtime,
+            service,
+            github_star,
+            core_steps,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupRuntimePlan {
+    InstallAndPrune,
+    Skip,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupServicePlan {
+    Install,
+    Skip,
+    PrintGuidance,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupGitHubStarPlan {
+    PromptIfEligible,
+    Skip(SetupGitHubStarSkipReason),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupGitHubStarSkipReason {
+    AutomaticYes,
+    HiddenPrompt,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupStep {
+    InstallRuntime,
+    PruneInactiveRuntimes,
+    InstallService,
+    PrintServiceGuidance,
+}
+
+fn build_core_steps(runtime: SetupRuntimePlan, service: SetupServicePlan) -> Vec<SetupStep> {
+    let mut steps = Vec::new();
+    if matches!(runtime, SetupRuntimePlan::InstallAndPrune) {
+        steps.push(SetupStep::InstallRuntime);
+        steps.push(SetupStep::PruneInactiveRuntimes);
+    }
+    match service {
+        SetupServicePlan::Install => steps.push(SetupStep::InstallService),
+        SetupServicePlan::PrintGuidance => steps.push(SetupStep::PrintServiceGuidance),
+        SetupServicePlan::Skip => {}
+    }
+    steps
+}

--- a/crates/mesh-llm-commands/src/setup/planner.rs
+++ b/crates/mesh-llm-commands/src/setup/planner.rs
@@ -77,7 +77,7 @@ fn plan_service<P: SetupPrompter>(
 
     let prompt = SetupConfirmPrompt {
         kind: SetupPromptKind::InstallService,
-        message: "Install and enable the mesh-llm background service?",
+        message: "Install the background service?",
         default: SetupPromptDefault::Yes,
     };
     let accepted = prompt.default.resolve(prompter.confirm(prompt));

--- a/crates/mesh-llm-commands/src/setup/planner.rs
+++ b/crates/mesh-llm-commands/src/setup/planner.rs
@@ -1,0 +1,101 @@
+use super::{
+    SetupConfirmPrompt, SetupEnvironment, SetupGitHubStarPlan, SetupGitHubStarSkipReason,
+    SetupOptions, SetupPlan, SetupPlatform, SetupPromptDefault, SetupPromptKind, SetupPrompter,
+    SetupRuntimePlan, SetupServicePlan,
+};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SetupPlanError {
+    ConflictingServiceFlags,
+    UnsupportedService { platform: SetupPlatform },
+}
+
+impl Display for SetupPlanError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConflictingServiceFlags => {
+                f.write_str("setup received both --service and --no-service")
+            }
+            Self::UnsupportedService { platform } => write!(
+                f,
+                "setup cannot install the background service on {}",
+                platform.display_name()
+            ),
+        }
+    }
+}
+
+impl Error for SetupPlanError {}
+
+pub fn plan_setup<P: SetupPrompter>(
+    options: SetupOptions,
+    environment: SetupEnvironment,
+    prompter: &mut P,
+) -> Result<SetupPlan, SetupPlanError> {
+    if options.service && options.no_service {
+        return Err(SetupPlanError::ConflictingServiceFlags);
+    }
+
+    if options.service && matches!(environment.platform, SetupPlatform::Windows) {
+        return Err(SetupPlanError::UnsupportedService {
+            platform: environment.platform,
+        });
+    }
+
+    let runtime = if options.skip_runtime {
+        SetupRuntimePlan::Skip
+    } else {
+        SetupRuntimePlan::InstallAndPrune
+    };
+    let service = plan_service(options, environment, prompter);
+    let github_star = plan_github_star(options, environment);
+    Ok(SetupPlan::new(runtime, service, github_star))
+}
+
+fn plan_service<P: SetupPrompter>(
+    options: SetupOptions,
+    environment: SetupEnvironment,
+    prompter: &mut P,
+) -> SetupServicePlan {
+    if !environment.platform.supports_service() {
+        return SetupServicePlan::Skip;
+    }
+
+    if options.no_service {
+        return SetupServicePlan::Skip;
+    }
+
+    if options.service || options.yes {
+        return SetupServicePlan::Install;
+    }
+
+    if !environment.prompts_visible(options) {
+        return SetupServicePlan::PrintGuidance;
+    }
+
+    let prompt = SetupConfirmPrompt {
+        kind: SetupPromptKind::InstallService,
+        message: "Install and enable the mesh-llm background service?",
+        default: SetupPromptDefault::Yes,
+    };
+    let accepted = prompt.default.resolve(prompter.confirm(prompt));
+    if accepted {
+        SetupServicePlan::Install
+    } else {
+        SetupServicePlan::Skip
+    }
+}
+
+fn plan_github_star(options: SetupOptions, environment: SetupEnvironment) -> SetupGitHubStarPlan {
+    if options.yes {
+        return SetupGitHubStarPlan::Skip(SetupGitHubStarSkipReason::AutomaticYes);
+    }
+
+    if environment.prompts_visible(options) {
+        SetupGitHubStarPlan::PromptIfEligible
+    } else {
+        SetupGitHubStarPlan::Skip(SetupGitHubStarSkipReason::HiddenPrompt)
+    }
+}

--- a/crates/mesh-llm-commands/src/setup/prompt.rs
+++ b/crates/mesh-llm-commands/src/setup/prompt.rs
@@ -1,4 +1,4 @@
-use std::io::{self, IsTerminal, Write};
+use crate::terminal::{self, ConfirmDefault};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SetupPromptKind {
@@ -32,32 +32,9 @@ pub trait SetupPrompter {
 }
 
 pub(crate) fn confirm_yes_no(message: &str) -> Option<bool> {
-    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
-        return None;
-    }
-
-    loop {
-        eprint!("{} {} [Y/n] ", prompt_marker(), message);
-        let _ = io::stderr().flush();
-
-        let mut reply = String::new();
-        if io::stdin().read_line(&mut reply).is_err() {
-            return Some(false);
-        }
-
-        match reply.trim().to_ascii_lowercase().as_str() {
-            "" | "y" | "yes" => return Some(true),
-            "n" | "no" => return Some(false),
-            _ => eprintln!("Please answer y or n."),
-        }
-    }
-}
-
-fn prompt_marker() -> String {
-    if io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
-        "\x1b[36m?\x1b[0m".to_string()
-    } else {
-        "?".to_string()
+    match terminal::confirm_yes_no(message, ConfirmDefault::Yes) {
+        Ok(reply) => reply,
+        Err(_) => Some(false),
     }
 }
 

--- a/crates/mesh-llm-commands/src/setup/prompt.rs
+++ b/crates/mesh-llm-commands/src/setup/prompt.rs
@@ -1,0 +1,47 @@
+use dialoguer::Confirm;
+use std::io::{self, IsTerminal};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupPromptKind {
+    InstallService,
+    GitHubStar,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupPromptDefault {
+    Yes,
+}
+
+impl SetupPromptDefault {
+    pub const fn resolve(self, reply: Option<bool>) -> bool {
+        match (self, reply) {
+            (_, Some(value)) => value,
+            (Self::Yes, None) => true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SetupConfirmPrompt {
+    pub kind: SetupPromptKind,
+    pub message: &'static str,
+    pub default: SetupPromptDefault,
+}
+
+pub trait SetupPrompter {
+    fn confirm(&mut self, prompt: SetupConfirmPrompt) -> Option<bool>;
+}
+
+pub(crate) fn confirm_yes_no(message: &str) -> Option<bool> {
+    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        return None;
+    }
+
+    Confirm::new()
+        .with_prompt(message)
+        .default(true)
+        .wait_for_newline(true)
+        .interact_opt()
+        .ok()
+        .flatten()
+}

--- a/crates/mesh-llm-commands/src/setup/prompt.rs
+++ b/crates/mesh-llm-commands/src/setup/prompt.rs
@@ -44,4 +44,20 @@ pub(crate) fn confirm_yes_no(message: &str) -> Option<bool> {
         .interact_opt()
         .ok()
         .flatten()
+        .or(Some(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SetupPromptDefault;
+
+    #[test]
+    fn default_yes_still_applies_to_hidden_prompts() {
+        assert!(SetupPromptDefault::Yes.resolve(None));
+    }
+
+    #[test]
+    fn explicit_false_overrides_default_yes() {
+        assert!(!SetupPromptDefault::Yes.resolve(Some(false)));
+    }
 }

--- a/crates/mesh-llm-commands/src/setup/prompt.rs
+++ b/crates/mesh-llm-commands/src/setup/prompt.rs
@@ -1,5 +1,4 @@
-use dialoguer::Confirm;
-use std::io::{self, IsTerminal};
+use std::io::{self, IsTerminal, Write};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SetupPromptKind {
@@ -37,14 +36,29 @@ pub(crate) fn confirm_yes_no(message: &str) -> Option<bool> {
         return None;
     }
 
-    Confirm::new()
-        .with_prompt(message)
-        .default(true)
-        .wait_for_newline(true)
-        .interact_opt()
-        .ok()
-        .flatten()
-        .or(Some(false))
+    loop {
+        eprint!("{} {} [Y/n] ", prompt_marker(), message);
+        let _ = io::stderr().flush();
+
+        let mut reply = String::new();
+        if io::stdin().read_line(&mut reply).is_err() {
+            return Some(false);
+        }
+
+        match reply.trim().to_ascii_lowercase().as_str() {
+            "" | "y" | "yes" => return Some(true),
+            "n" | "no" => return Some(false),
+            _ => eprintln!("Please answer y or n."),
+        }
+    }
+}
+
+fn prompt_marker() -> String {
+    if io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+        "\x1b[36m?\x1b[0m".to_string()
+    } else {
+        "?".to_string()
+    }
 }
 
 #[cfg(test)]

--- a/crates/mesh-llm-commands/src/setup/service.rs
+++ b/crates/mesh-llm-commands/src/setup/service.rs
@@ -1,0 +1,239 @@
+use super::SetupPlatform;
+use super::service_files::{ensure_service_env_file, shell_quote, write_service_runner};
+use super::service_paths::{ServiceInstallContext, ServicePaths};
+use super::service_runner::{ServiceCommand, ServiceCommandRunner};
+use super::service_templates::{
+    SERVICE_LABEL, SERVICE_NAME, render_launchd_plist, render_systemd_unit,
+};
+use anyhow::{Context, Result, bail};
+use std::fs;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ServiceInstallReport {
+    pub(crate) summary: String,
+    pub(crate) messages: Vec<String>,
+    pub(crate) service_file: std::path::PathBuf,
+    pub(crate) env_file: std::path::PathBuf,
+    pub(crate) runner_file: Option<std::path::PathBuf>,
+}
+
+pub(crate) fn install_service(
+    context: &ServiceInstallContext,
+    runner: &mut dyn ServiceCommandRunner,
+) -> Result<ServiceInstallReport> {
+    match context.platform {
+        SetupPlatform::Linux => install_systemd_service(context, runner),
+        SetupPlatform::MacOs => install_launchd_service(context, runner),
+        SetupPlatform::Windows => bail!("setup cannot install the background service on windows"),
+    }
+}
+
+fn install_systemd_service(
+    context: &ServiceInstallContext,
+    runner: &mut dyn ServiceCommandRunner,
+) -> Result<ServiceInstallReport> {
+    let paths = ServicePaths::from_context(context);
+    fs::create_dir_all(&paths.service_config_dir)?;
+    fs::create_dir_all(&paths.systemd_unit_dir)?;
+    ensure_service_env_file(&paths.service_env_file)?;
+    fs::write(
+        &paths.systemd_unit_path,
+        render_systemd_unit(
+            &context.binary_path,
+            &paths.service_env_file,
+            &paths.mesh_config_file,
+        ),
+    )?;
+
+    runner
+        .run(&ServiceCommand::new(
+            "systemctl",
+            ["--user", "daemon-reload"],
+        ))
+        .context("reload systemd user service manager")?;
+
+    let service_name = format!("{SERVICE_NAME}.service");
+    let manual_start_hint = format!("Start it with: systemctl --user enable --now {service_name}");
+    let started = if context.start_service {
+        runner
+            .run(&ServiceCommand::new(
+                "systemctl",
+                ["--user", "enable", service_name.as_str()],
+            ))
+            .with_context(|| format!("enable systemd user service {service_name}"))?;
+        runner
+            .run(&ServiceCommand::new(
+                "systemctl",
+                ["--user", "restart", service_name.as_str()],
+            ))
+            .or_else(|restart_error| {
+                runner
+                    .run(&ServiceCommand::new(
+                        "systemctl",
+                        ["--user", "start", service_name.as_str()],
+                    ))
+                    .with_context(|| {
+                        format!(
+                            "restart systemd user service {service_name} failed ({restart_error}); start fallback"
+                        )
+                    })
+            })
+            .with_context(|| format!("start systemd user service {service_name}"))?;
+        true
+    } else {
+        false
+    };
+
+    let exec_line = format!("ExecStart={} serve", shell_quote(&context.binary_path));
+    let mut messages = Vec::new();
+    if started {
+        messages.push(format!(
+            "Installed and started systemd user service: {service_name}"
+        ));
+    } else {
+        messages.push(format!("Installed {}", paths.systemd_unit_path.display()));
+        messages.push(manual_start_hint.clone());
+    }
+    messages.push(format!("Command: {exec_line}"));
+    messages.push(format!(
+        "Optional env: {}",
+        paths.service_env_file.display()
+    ));
+    messages.push(format!(
+        "Edit startup models: {}",
+        paths.mesh_config_file.display()
+    ));
+    messages.push(format!("Logs: journalctl --user -u {service_name} -f"));
+    messages.push("Boot without login (optional): sudo loginctl enable-linger $USER".to_string());
+
+    Ok(ServiceInstallReport {
+        summary: if started {
+            "installed and started".to_string()
+        } else {
+            "installed; automatic start needs manual follow-up".to_string()
+        },
+        messages,
+        service_file: paths.systemd_unit_path,
+        env_file: paths.service_env_file,
+        runner_file: None,
+    })
+}
+
+fn install_launchd_service(
+    context: &ServiceInstallContext,
+    runner: &mut dyn ServiceCommandRunner,
+) -> Result<ServiceInstallReport> {
+    let paths = ServicePaths::from_context(context);
+    fs::create_dir_all(&paths.service_config_dir)?;
+    fs::create_dir_all(&paths.launchd_agent_dir)?;
+    fs::create_dir_all(&paths.launchd_log_dir)?;
+    ensure_service_env_file(&paths.service_env_file)?;
+    write_service_runner(
+        &paths.service_runner,
+        &context.binary_path,
+        &paths.service_env_file,
+    )?;
+
+    let plist_existed = paths.launchd_plist_path.exists();
+    fs::write(
+        &paths.launchd_plist_path,
+        render_launchd_plist(
+            &paths.service_runner,
+            &context.home_dir,
+            &paths.launchd_stdout_log,
+            &paths.launchd_stderr_log,
+        ),
+    )?;
+
+    let launch_domain = format!("gui/{}", context.user_id);
+    let manual_start_hint = format!(
+        "Start it with: launchctl bootstrap {launch_domain} {}",
+        paths.launchd_plist_path.display()
+    );
+    let mut warnings = Vec::new();
+    let started = if context.start_service {
+        if plist_existed
+            && let Err(error) = runner.run(&ServiceCommand::new(
+                "launchctl",
+                [
+                    "bootout",
+                    launch_domain.as_str(),
+                    paths.launchd_plist_path.to_string_lossy().as_ref(),
+                ],
+            ))
+        {
+            warnings.push(format!(
+                "warning: could not unload the previous launchd agent before reinstalling: {error}"
+            ));
+        }
+
+        runner
+            .run(&ServiceCommand::new(
+                "launchctl",
+                [
+                    "bootstrap",
+                    launch_domain.as_str(),
+                    paths.launchd_plist_path.to_string_lossy().as_ref(),
+                ],
+            ))
+            .with_context(|| format!("bootstrap launchd agent {SERVICE_LABEL}"))?;
+        runner
+            .run(&ServiceCommand::new(
+                "launchctl",
+                [
+                    "enable".to_string(),
+                    format!("{launch_domain}/{SERVICE_LABEL}"),
+                ],
+            ))
+            .with_context(|| format!("enable launchd agent {SERVICE_LABEL}"))?;
+        runner
+            .run(&ServiceCommand::new(
+                "launchctl",
+                [
+                    "kickstart".to_string(),
+                    "-k".to_string(),
+                    format!("{launch_domain}/{SERVICE_LABEL}"),
+                ],
+            ))
+            .with_context(|| format!("kickstart launchd agent {SERVICE_LABEL}"))?;
+        true
+    } else {
+        false
+    };
+
+    let mut messages = Vec::new();
+    if started {
+        messages.push(format!(
+            "Installed and started launchd agent: {SERVICE_LABEL}"
+        ));
+    } else {
+        messages.push(format!("Installed {}", paths.launchd_plist_path.display()));
+        messages.push(manual_start_hint.clone());
+    }
+    messages.extend(warnings);
+    messages.push(format!(
+        "Startup models: {}",
+        paths.mesh_config_file.display()
+    ));
+    messages.push(format!(
+        "Optional env: {}",
+        paths.service_env_file.display()
+    ));
+    messages.push(format!(
+        "Logs: {} and {}",
+        paths.launchd_stdout_log.display(),
+        paths.launchd_stderr_log.display()
+    ));
+
+    Ok(ServiceInstallReport {
+        summary: if started {
+            "installed and started".to_string()
+        } else {
+            "installed; automatic start needs manual follow-up".to_string()
+        },
+        messages,
+        service_file: paths.launchd_plist_path,
+        env_file: paths.service_env_file,
+        runner_file: Some(paths.service_runner),
+    })
+}

--- a/crates/mesh-llm-commands/src/setup/service.rs
+++ b/crates/mesh-llm-commands/src/setup/service.rs
@@ -10,11 +10,18 @@ use std::fs;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ServiceInstallReport {
+    pub(crate) status: ServiceInstallStatus,
     pub(crate) summary: String,
     pub(crate) messages: Vec<String>,
     pub(crate) service_file: std::path::PathBuf,
     pub(crate) env_file: std::path::PathBuf,
     pub(crate) runner_file: Option<std::path::PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ServiceInstallStatus {
+    Started,
+    NeedsManualStart,
 }
 
 pub(crate) fn install_service(
@@ -107,6 +114,11 @@ fn install_systemd_service(
     messages.push("Boot without login (optional): sudo loginctl enable-linger $USER".to_string());
 
     Ok(ServiceInstallReport {
+        status: if started {
+            ServiceInstallStatus::Started
+        } else {
+            ServiceInstallStatus::NeedsManualStart
+        },
         summary: if started {
             "installed and started".to_string()
         } else {
@@ -226,6 +238,11 @@ fn install_launchd_service(
     ));
 
     Ok(ServiceInstallReport {
+        status: if started {
+            ServiceInstallStatus::Started
+        } else {
+            ServiceInstallStatus::NeedsManualStart
+        },
         summary: if started {
             "installed and started".to_string()
         } else {

--- a/crates/mesh-llm-commands/src/setup/service_files.rs
+++ b/crates/mesh-llm-commands/src/setup/service_files.rs
@@ -1,0 +1,60 @@
+use super::service_templates::{render_service_env_file, render_service_runner};
+use anyhow::{Result, anyhow};
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub(crate) fn ensure_service_env_file(service_env_file: &Path) -> Result<()> {
+    if service_env_file.exists() {
+        return Ok(());
+    }
+
+    let parent = service_env_file.parent().ok_or_else(|| {
+        anyhow!(
+            "service env file path has no parent: {}",
+            service_env_file.display()
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    fs::write(service_env_file, render_service_env_file())?;
+    Ok(())
+}
+
+pub(crate) fn write_service_runner(
+    service_runner: &Path,
+    binary_path: &Path,
+    env_file: &Path,
+) -> Result<()> {
+    let parent = service_runner.parent().ok_or_else(|| {
+        anyhow!(
+            "service runner path has no parent: {}",
+            service_runner.display()
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    fs::write(service_runner, render_service_runner(binary_path, env_file))?;
+    set_runner_permissions(service_runner)?;
+    Ok(())
+}
+
+pub(crate) fn shell_quote(path: &Path) -> String {
+    let escaped = path
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "$$")
+        .replace('%', "%%");
+    format!("\"{escaped}\"")
+}
+
+fn set_runner_permissions(service_runner: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(service_runner)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(service_runner, permissions)?;
+    }
+
+    Ok(())
+}

--- a/crates/mesh-llm-commands/src/setup/service_files.rs
+++ b/crates/mesh-llm-commands/src/setup/service_files.rs
@@ -1,15 +1,12 @@
 use super::service_templates::{render_service_env_file, render_service_runner};
 use anyhow::{Result, anyhow};
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 pub(crate) fn ensure_service_env_file(service_env_file: &Path) -> Result<()> {
-    if service_env_file.exists() {
-        return Ok(());
-    }
-
     let parent = service_env_file.parent().ok_or_else(|| {
         anyhow!(
             "service env file path has no parent: {}",
@@ -17,7 +14,15 @@ pub(crate) fn ensure_service_env_file(service_env_file: &Path) -> Result<()> {
         )
     })?;
     fs::create_dir_all(parent)?;
-    fs::write(service_env_file, render_service_env_file())?;
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(service_env_file)
+    {
+        Ok(mut file) => file.write_all(render_service_env_file().as_bytes())?,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error.into()),
+    }
     Ok(())
 }
 

--- a/crates/mesh-llm-commands/src/setup/service_paths.rs
+++ b/crates/mesh-llm-commands/src/setup/service_paths.rs
@@ -1,0 +1,95 @@
+use super::SetupPlatform;
+use super::service_templates::{SERVICE_LABEL, SERVICE_NAME};
+use anyhow::{Context, Result, bail};
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ServiceInstallContext {
+    pub(crate) platform: SetupPlatform,
+    pub(crate) home_dir: PathBuf,
+    pub(crate) config_root: PathBuf,
+    pub(crate) binary_path: PathBuf,
+    pub(crate) user_id: String,
+    pub(crate) start_service: bool,
+}
+
+impl ServiceInstallContext {
+    pub(crate) fn detect(platform: SetupPlatform, start_service: bool) -> Result<Self> {
+        let home_dir = dirs::home_dir()
+            .context("could not determine the home directory for service installation")?;
+        let config_root = dirs::config_dir().unwrap_or_else(|| home_dir.join(".config"));
+        let binary_path = std::env::current_exe()
+            .context("could not determine the installed mesh-llm binary path")?;
+        let user_id = if matches!(platform, SetupPlatform::MacOs) {
+            detect_user_id()?
+        } else {
+            String::new()
+        };
+
+        Ok(Self {
+            platform,
+            home_dir,
+            config_root,
+            binary_path,
+            user_id,
+            start_service,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ServicePaths {
+    pub(crate) mesh_config_file: PathBuf,
+    pub(crate) service_config_dir: PathBuf,
+    pub(crate) service_env_file: PathBuf,
+    pub(crate) service_runner: PathBuf,
+    pub(crate) systemd_unit_dir: PathBuf,
+    pub(crate) systemd_unit_path: PathBuf,
+    pub(crate) launchd_agent_dir: PathBuf,
+    pub(crate) launchd_plist_path: PathBuf,
+    pub(crate) launchd_log_dir: PathBuf,
+    pub(crate) launchd_stdout_log: PathBuf,
+    pub(crate) launchd_stderr_log: PathBuf,
+}
+
+impl ServicePaths {
+    pub(crate) fn from_context(context: &ServiceInstallContext) -> Self {
+        let service_config_dir = context.config_root.join("mesh-llm");
+        Self {
+            mesh_config_file: context.home_dir.join(".mesh-llm/config.toml"),
+            service_env_file: service_config_dir.join("service.env"),
+            service_runner: service_config_dir.join("run-service.sh"),
+            systemd_unit_dir: context.config_root.join("systemd/user"),
+            systemd_unit_path: context
+                .config_root
+                .join("systemd/user")
+                .join(format!("{SERVICE_NAME}.service")),
+            launchd_agent_dir: context.home_dir.join("Library/LaunchAgents"),
+            launchd_plist_path: context
+                .home_dir
+                .join("Library/LaunchAgents")
+                .join(format!("{SERVICE_LABEL}.plist")),
+            launchd_log_dir: context.home_dir.join("Library/Logs/mesh-llm"),
+            launchd_stdout_log: context.home_dir.join("Library/Logs/mesh-llm/stdout.log"),
+            launchd_stderr_log: context.home_dir.join("Library/Logs/mesh-llm/stderr.log"),
+            service_config_dir,
+        }
+    }
+}
+
+fn detect_user_id() -> Result<String> {
+    let output = Command::new("id")
+        .arg("-u")
+        .output()
+        .context("failed to run `id -u` for launchd service installation")?;
+    if !output.status.success() {
+        bail!("`id -u` exited with status {}", output.status);
+    }
+    let user_id = String::from_utf8(output.stdout).context("`id -u` emitted non-UTF-8 output")?;
+    let trimmed = user_id.trim();
+    if trimmed.is_empty() {
+        bail!("`id -u` returned an empty user id");
+    }
+    Ok(trimmed.to_string())
+}

--- a/crates/mesh-llm-commands/src/setup/service_runner.rs
+++ b/crates/mesh-llm-commands/src/setup/service_runner.rs
@@ -1,0 +1,50 @@
+use anyhow::{Context, Result, anyhow};
+use std::process::Command;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ServiceCommand {
+    pub(crate) program: String,
+    pub(crate) args: Vec<String>,
+}
+
+impl ServiceCommand {
+    pub(crate) fn new(
+        program: impl Into<String>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        Self {
+            program: program.into(),
+            args: args.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub(crate) fn display(&self) -> String {
+        let mut rendered = Vec::with_capacity(self.args.len() + 1);
+        rendered.push(self.program.clone());
+        rendered.extend(self.args.iter().cloned());
+        rendered.join(" ")
+    }
+}
+
+pub(crate) trait ServiceCommandRunner {
+    fn run(&mut self, command: &ServiceCommand) -> Result<()>;
+}
+
+pub(crate) struct CliServiceCommandRunner;
+
+impl ServiceCommandRunner for CliServiceCommandRunner {
+    fn run(&mut self, command: &ServiceCommand) -> Result<()> {
+        let status = Command::new(&command.program)
+            .args(&command.args)
+            .status()
+            .with_context(|| format!("failed to run `{}`", command.display()))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "`{}` exited with status {status}",
+                command.display()
+            ))
+        }
+    }
+}

--- a/crates/mesh-llm-commands/src/setup/service_templates.rs
+++ b/crates/mesh-llm-commands/src/setup/service_templates.rs
@@ -1,0 +1,65 @@
+use std::path::Path;
+
+pub(crate) const SERVICE_NAME: &str = "mesh-llm";
+pub(crate) const SERVICE_LABEL: &str = "com.mesh-llm.mesh-llm";
+
+pub(crate) fn render_service_env_file() -> String {
+    [
+        "# Optional environment variables for mesh-llm.",
+        "# Use plain KEY=value lines.",
+        "# Example:",
+        "# RUST_LOG=mesh_inference=debug",
+        "",
+    ]
+    .join("\n")
+}
+
+pub(crate) fn render_service_runner(binary_path: &Path, env_file: &Path) -> String {
+    format!(
+        "#!/usr/bin/env bash\n\nset -euo pipefail\n\nBIN=\"{}\"\nENV_FILE=\"{}\"\n\nif [[ ! -x \"$BIN\" ]]; then\n    echo \"mesh-llm binary not found or not executable: $BIN\" >&2\n    exit 1\nfi\n\nif [[ -f \"$ENV_FILE\" ]]; then\n    set -a\n    # shellcheck source=/dev/null\n    . \"$ENV_FILE\"\n    set +a\nfi\n\nexec \"$BIN\" serve\n",
+        binary_path.display(),
+        env_file.display()
+    )
+}
+
+pub(crate) fn render_systemd_unit(
+    binary_path: &Path,
+    service_env_file: &Path,
+    mesh_config_file: &Path,
+) -> String {
+    let exec_line = format!(
+        "ExecStart={} serve",
+        systemd_quote_token(&binary_path.to_string_lossy())
+    );
+    format!(
+        "# mesh-llm serve (startup models come from {mesh_config_file})\n[Unit]\nDescription=Mesh LLM user service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nEnvironmentFile=-{service_env_file}\n\n{exec_line}\nWorkingDirectory=%h\nRestart=on-failure\nRestartSec=5\n\n[Install]\nWantedBy=default.target\n",
+        mesh_config_file = mesh_config_file.display(),
+        service_env_file = service_env_file.display(),
+        exec_line = exec_line,
+    )
+}
+
+pub(crate) fn render_launchd_plist(
+    service_runner: &Path,
+    home_dir: &Path,
+    stdout_log: &Path,
+    stderr_log: &Path,
+) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"https://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>{service_label}</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>{service_runner}</string>\n    </array>\n    <key>WorkingDirectory</key>\n    <string>{home_dir}</string>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <dict>\n        <key>SuccessfulExit</key>\n        <false/>\n    </dict>\n    <key>ProcessType</key>\n    <string>Background</string>\n    <key>StandardOutPath</key>\n    <string>{stdout_log}</string>\n    <key>StandardErrorPath</key>\n    <string>{stderr_log}</string>\n</dict>\n</plist>\n",
+        service_label = SERVICE_LABEL,
+        service_runner = service_runner.display(),
+        home_dir = home_dir.display(),
+        stdout_log = stdout_log.display(),
+        stderr_log = stderr_log.display(),
+    )
+}
+
+fn systemd_quote_token(value: &str) -> String {
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "$$")
+        .replace('%', "%%");
+    format!("\"{escaped}\"")
+}

--- a/crates/mesh-llm-commands/src/setup/service_templates.rs
+++ b/crates/mesh-llm-commands/src/setup/service_templates.rs
@@ -31,10 +31,11 @@ pub(crate) fn render_systemd_unit(
         "ExecStart={} serve",
         systemd_quote_token(&binary_path.to_string_lossy())
     );
+    let service_env_file = systemd_escape_token(&service_env_file.to_string_lossy());
     format!(
         "# mesh-llm serve (startup models come from {mesh_config_file})\n[Unit]\nDescription=Mesh LLM user service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nEnvironmentFile=-{service_env_file}\n\n{exec_line}\nWorkingDirectory=%h\nRestart=on-failure\nRestartSec=5\n\n[Install]\nWantedBy=default.target\n",
         mesh_config_file = mesh_config_file.display(),
-        service_env_file = service_env_file.display(),
+        service_env_file = service_env_file,
         exec_line = exec_line,
     )
 }
@@ -71,10 +72,14 @@ fn xml_escape(value: &str) -> String {
 }
 
 fn systemd_quote_token(value: &str) -> String {
-    let escaped = value
+    let escaped = systemd_escape_token(value);
+    format!("\"{escaped}\"")
+}
+
+fn systemd_escape_token(value: &str) -> String {
+    value
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
         .replace('$', "$$")
-        .replace('%', "%%");
-    format!("\"{escaped}\"")
+        .replace('%', "%%")
 }

--- a/crates/mesh-llm-commands/src/setup/service_templates.rs
+++ b/crates/mesh-llm-commands/src/setup/service_templates.rs
@@ -17,8 +17,8 @@ pub(crate) fn render_service_env_file() -> String {
 pub(crate) fn render_service_runner(binary_path: &Path, env_file: &Path) -> String {
     format!(
         "#!/usr/bin/env bash\n\nset -euo pipefail\n\nBIN=\"{}\"\nENV_FILE=\"{}\"\n\nif [[ ! -x \"$BIN\" ]]; then\n    echo \"mesh-llm binary not found or not executable: $BIN\" >&2\n    exit 1\nfi\n\nif [[ -f \"$ENV_FILE\" ]]; then\n    set -a\n    # shellcheck source=/dev/null\n    . \"$ENV_FILE\"\n    set +a\nfi\n\nexec \"$BIN\" serve\n",
-        binary_path.display(),
-        env_file.display()
+        shell_double_quote(&binary_path.to_string_lossy()),
+        shell_double_quote(&env_file.to_string_lossy()),
     )
 }
 
@@ -48,11 +48,26 @@ pub(crate) fn render_launchd_plist(
     format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"https://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>{service_label}</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>{service_runner}</string>\n    </array>\n    <key>WorkingDirectory</key>\n    <string>{home_dir}</string>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <dict>\n        <key>SuccessfulExit</key>\n        <false/>\n    </dict>\n    <key>ProcessType</key>\n    <string>Background</string>\n    <key>StandardOutPath</key>\n    <string>{stdout_log}</string>\n    <key>StandardErrorPath</key>\n    <string>{stderr_log}</string>\n</dict>\n</plist>\n",
         service_label = SERVICE_LABEL,
-        service_runner = service_runner.display(),
-        home_dir = home_dir.display(),
-        stdout_log = stdout_log.display(),
-        stderr_log = stderr_log.display(),
+        service_runner = xml_escape(&service_runner.to_string_lossy()),
+        home_dir = xml_escape(&home_dir.to_string_lossy()),
+        stdout_log = xml_escape(&stdout_log.to_string_lossy()),
+        stderr_log = xml_escape(&stderr_log.to_string_lossy()),
     )
+}
+
+fn shell_double_quote(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "\\$")
+        .replace('`', "\\`")
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 fn systemd_quote_token(value: &str) -> String {

--- a/crates/mesh-llm-commands/src/setup/service_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/service_tests.rs
@@ -31,10 +31,10 @@ impl ServiceCommandRunner for FakeRunner {
         let rendered = command.display();
         self.commands.push(command.clone());
         for (prefix, failures) in &mut self.failures {
-            if rendered.starts_with(prefix) {
-                if let Some(message) = failures.pop_front() {
-                    return Err(anyhow!(message));
-                }
+            if rendered.starts_with(prefix)
+                && let Some(message) = failures.pop_front()
+            {
+                return Err(anyhow!(message));
             }
         }
         Ok(())

--- a/crates/mesh-llm-commands/src/setup/service_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/service_tests.rs
@@ -1,0 +1,240 @@
+use super::SetupPlatform;
+use super::service::install_service;
+use super::service_paths::ServiceInstallContext;
+use super::service_runner::{ServiceCommand, ServiceCommandRunner};
+use super::service_templates::{
+    SERVICE_LABEL, render_launchd_plist, render_service_env_file, render_service_runner,
+    render_systemd_unit,
+};
+use anyhow::{Result, anyhow};
+use std::collections::{HashMap, VecDeque};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Default)]
+struct FakeRunner {
+    commands: Vec<ServiceCommand>,
+    failures: HashMap<String, VecDeque<String>>,
+}
+
+impl FakeRunner {
+    fn fail_once(&mut self, starts_with: &str, message: &str) {
+        self.failures
+            .entry(starts_with.to_string())
+            .or_default()
+            .push_back(message.to_string());
+    }
+}
+
+impl ServiceCommandRunner for FakeRunner {
+    fn run(&mut self, command: &ServiceCommand) -> Result<()> {
+        let rendered = command.display();
+        self.commands.push(command.clone());
+        for (prefix, failures) in &mut self.failures {
+            if rendered.starts_with(prefix) {
+                if let Some(message) = failures.pop_front() {
+                    return Err(anyhow!(message));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn rendered_templates_match_existing_unix_service_behavior() {
+    let binary_path = PathBuf::from("/Users/example/.local/bin/mesh-llm");
+    let env_file = PathBuf::from("/Users/example/.config/mesh-llm/service.env");
+    let mesh_config = PathBuf::from("/Users/example/.mesh-llm/config.toml");
+    let service_runner = PathBuf::from("/Users/example/.config/mesh-llm/run-service.sh");
+    let home_dir = PathBuf::from("/Users/example");
+    let stdout_log = PathBuf::from("/Users/example/Library/Logs/mesh-llm/stdout.log");
+    let stderr_log = PathBuf::from("/Users/example/Library/Logs/mesh-llm/stderr.log");
+
+    assert_eq!(
+        render_service_env_file(),
+        "# Optional environment variables for mesh-llm.\n# Use plain KEY=value lines.\n# Example:\n# RUST_LOG=mesh_inference=debug\n"
+    );
+    assert_eq!(
+        render_service_runner(&binary_path, &env_file),
+        format!(
+            "#!/usr/bin/env bash\n\nset -euo pipefail\n\nBIN=\"{}\"\nENV_FILE=\"{}\"\n\nif [[ ! -x \"$BIN\" ]]; then\n    echo \"mesh-llm binary not found or not executable: $BIN\" >&2\n    exit 1\nfi\n\nif [[ -f \"$ENV_FILE\" ]]; then\n    set -a\n    # shellcheck source=/dev/null\n    . \"$ENV_FILE\"\n    set +a\nfi\n\nexec \"$BIN\" serve\n",
+            binary_path.display(),
+            env_file.display()
+        )
+    );
+    assert_eq!(
+        render_systemd_unit(&binary_path, &env_file, &mesh_config),
+        format!(
+            "# mesh-llm serve (startup models come from {mesh_config})\n[Unit]\nDescription=Mesh LLM user service\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nEnvironmentFile=-{env_file}\n\nExecStart=\"/Users/example/.local/bin/mesh-llm\" serve\nWorkingDirectory=%h\nRestart=on-failure\nRestartSec=5\n\n[Install]\nWantedBy=default.target\n",
+            mesh_config = mesh_config.display(),
+            env_file = env_file.display(),
+        )
+    );
+    assert_eq!(
+        render_launchd_plist(&service_runner, &home_dir, &stdout_log, &stderr_log),
+        format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"https://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>{SERVICE_LABEL}</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>{service_runner}</string>\n    </array>\n    <key>WorkingDirectory</key>\n    <string>{home_dir}</string>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <dict>\n        <key>SuccessfulExit</key>\n        <false/>\n    </dict>\n    <key>ProcessType</key>\n    <string>Background</string>\n    <key>StandardOutPath</key>\n    <string>{stdout_log}</string>\n    <key>StandardErrorPath</key>\n    <string>{stderr_log}</string>\n</dict>\n</plist>\n",
+            service_runner = service_runner.display(),
+            home_dir = home_dir.display(),
+            stdout_log = stdout_log.display(),
+            stderr_log = stderr_log.display(),
+        )
+    );
+}
+
+#[test]
+fn linux_service_install_writes_systemd_files_and_runs_expected_commands() {
+    let temp = tempfile::tempdir().expect("tempdir should exist");
+    let home_dir = temp.path().join("home");
+    let config_root = temp.path().join("config");
+    let binary_path = temp.path().join("bin/mesh-llm");
+    fs::create_dir_all(binary_path.parent().expect("binary parent should exist"))
+        .expect("binary dir should exist");
+    fs::write(&binary_path, "binary").expect("binary should write");
+
+    let context = ServiceInstallContext {
+        platform: SetupPlatform::Linux,
+        home_dir,
+        config_root,
+        binary_path: binary_path.clone(),
+        user_id: String::new(),
+        start_service: true,
+    };
+    let mut runner = FakeRunner::default();
+
+    let report = install_service(&context, &mut runner).expect("systemd install should succeed");
+
+    assert_eq!(report.summary, "installed and started");
+    assert_eq!(
+        fs::read_to_string(&report.env_file).expect("env file should exist"),
+        render_service_env_file()
+    );
+    assert!(report.runner_file.is_none());
+    assert!(
+        fs::read_to_string(&report.service_file)
+            .expect("unit file should exist")
+            .contains("ExecStart=")
+    );
+    assert_eq!(
+        runner.commands,
+        vec![
+            ServiceCommand::new("systemctl", ["--user", "daemon-reload"]),
+            ServiceCommand::new("systemctl", ["--user", "enable", "mesh-llm.service"]),
+            ServiceCommand::new("systemctl", ["--user", "restart", "mesh-llm.service"]),
+        ]
+    );
+}
+
+#[test]
+fn macos_service_install_writes_runner_and_plist_and_preserves_manual_start_guidance() {
+    let temp = tempfile::tempdir().expect("tempdir should exist");
+    let home_dir = temp.path().join("home");
+    let config_root = temp.path().join("config");
+    let binary_path = temp.path().join("bin/mesh-llm");
+    fs::create_dir_all(binary_path.parent().expect("binary parent should exist"))
+        .expect("binary dir should exist");
+    fs::write(&binary_path, "binary").expect("binary should write");
+
+    let context = ServiceInstallContext {
+        platform: SetupPlatform::MacOs,
+        home_dir: home_dir.clone(),
+        config_root,
+        binary_path: binary_path.clone(),
+        user_id: "501".to_string(),
+        start_service: false,
+    };
+    let mut runner = FakeRunner::default();
+
+    let report = install_service(&context, &mut runner).expect("launchd install should succeed");
+
+    assert_eq!(
+        report.summary,
+        "installed; automatic start needs manual follow-up"
+    );
+    let runner_file = report
+        .runner_file
+        .expect("launchd runner should be recorded");
+    assert_eq!(
+        fs::read_to_string(&runner_file).expect("runner should exist"),
+        render_service_runner(&binary_path, &report.env_file)
+    );
+    assert!(
+        fs::read_to_string(&report.service_file)
+            .expect("plist should exist")
+            .contains(SERVICE_LABEL)
+    );
+    assert!(
+        report
+            .messages
+            .iter()
+            .any(|line| line.contains("Start it with: launchctl bootstrap gui/501"))
+    );
+}
+
+#[test]
+fn linux_service_command_failure_is_a_setup_failure_when_starting_service() {
+    let temp = tempfile::tempdir().expect("tempdir should exist");
+    let home_dir = temp.path().join("home");
+    let config_root = temp.path().join("config");
+    let binary_path = temp.path().join("bin/mesh-llm");
+    fs::create_dir_all(binary_path.parent().expect("binary parent should exist"))
+        .expect("binary dir should exist");
+    fs::write(&binary_path, "binary").expect("binary should write");
+
+    let context = ServiceInstallContext {
+        platform: SetupPlatform::Linux,
+        home_dir,
+        config_root,
+        binary_path,
+        user_id: String::new(),
+        start_service: true,
+    };
+    let mut runner = FakeRunner::default();
+    runner.fail_once(
+        "systemctl --user enable",
+        "systemd user manager unavailable",
+    );
+
+    let error =
+        install_service(&context, &mut runner).expect_err("systemd enable failure should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("enable systemd user service mesh-llm.service"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn macos_service_command_failure_is_a_setup_failure_when_starting_service() {
+    let temp = tempfile::tempdir().expect("tempdir should exist");
+    let home_dir = temp.path().join("home");
+    let config_root = temp.path().join("config");
+    let binary_path = temp.path().join("bin/mesh-llm");
+    fs::create_dir_all(binary_path.parent().expect("binary parent should exist"))
+        .expect("binary dir should exist");
+    fs::write(&binary_path, "binary").expect("binary should write");
+
+    let context = ServiceInstallContext {
+        platform: SetupPlatform::MacOs,
+        home_dir,
+        config_root,
+        binary_path,
+        user_id: "501".to_string(),
+        start_service: true,
+    };
+    let mut runner = FakeRunner::default();
+    runner.fail_once("launchctl bootstrap gui/501", "launchd bootstrap denied");
+
+    let error =
+        install_service(&context, &mut runner).expect_err("launchd bootstrap failure should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("bootstrap launchd agent com.mesh-llm.mesh-llm"),
+        "{error:#}"
+    );
+}

--- a/crates/mesh-llm-commands/src/setup/service_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/service_tests.rs
@@ -84,6 +84,34 @@ fn rendered_templates_match_existing_unix_service_behavior() {
 }
 
 #[test]
+fn launchd_runner_escapes_shell_specials_in_paths() {
+    let rendered = render_service_runner(
+        &PathBuf::from("/Users/example/mesh \"bin\"/$HOME/`mesh`/mesh-llm"),
+        &PathBuf::from("/Users/example/config\\dir/service.env"),
+    );
+
+    assert!(
+        rendered.contains("BIN=\"/Users/example/mesh \\\"bin\\\"/\\$HOME/\\`mesh\\`/mesh-llm\"")
+    );
+    assert!(rendered.contains("ENV_FILE=\"/Users/example/config\\\\dir/service.env\""));
+}
+
+#[test]
+fn launchd_plist_escapes_xml_specials_in_paths() {
+    let rendered = render_launchd_plist(
+        &PathBuf::from("/Users/example/A&B/run-service.sh"),
+        &PathBuf::from("/Users/example/<home>"),
+        &PathBuf::from("/Users/example/logs/stdout>log"),
+        &PathBuf::from("/Users/example/logs/stderr<log"),
+    );
+
+    assert!(rendered.contains("<string>/Users/example/A&amp;B/run-service.sh</string>"));
+    assert!(rendered.contains("<string>/Users/example/&lt;home&gt;</string>"));
+    assert!(rendered.contains("<string>/Users/example/logs/stdout&gt;log</string>"));
+    assert!(rendered.contains("<string>/Users/example/logs/stderr&lt;log</string>"));
+}
+
+#[test]
 fn linux_service_install_writes_systemd_files_and_runs_expected_commands() {
     let temp = tempfile::tempdir().expect("tempdir should exist");
     let home_dir = temp.path().join("home");

--- a/crates/mesh-llm-commands/src/setup/service_tests.rs
+++ b/crates/mesh-llm-commands/src/setup/service_tests.rs
@@ -1,5 +1,5 @@
 use super::SetupPlatform;
-use super::service::install_service;
+use super::service::{ServiceInstallStatus, install_service};
 use super::service_paths::ServiceInstallContext;
 use super::service_runner::{ServiceCommand, ServiceCommandRunner};
 use super::service_templates::{
@@ -134,6 +134,7 @@ fn linux_service_install_writes_systemd_files_and_runs_expected_commands() {
     let report = install_service(&context, &mut runner).expect("systemd install should succeed");
 
     assert_eq!(report.summary, "installed and started");
+    assert_eq!(report.status, ServiceInstallStatus::Started);
     assert_eq!(
         fs::read_to_string(&report.env_file).expect("env file should exist"),
         render_service_env_file()
@@ -151,6 +152,22 @@ fn linux_service_install_writes_systemd_files_and_runs_expected_commands() {
             ServiceCommand::new("systemctl", ["--user", "enable", "mesh-llm.service"]),
             ServiceCommand::new("systemctl", ["--user", "restart", "mesh-llm.service"]),
         ]
+    );
+}
+
+#[test]
+fn systemd_unit_escapes_percent_in_environment_file_path() {
+    let rendered = render_systemd_unit(
+        &PathBuf::from("/Users/example/.local/bin/mesh-llm"),
+        &PathBuf::from("/Users/example/.config/mesh-llm/%service.env"),
+        &PathBuf::from("/Users/example/.mesh-llm/config.toml"),
+    );
+
+    assert!(rendered.contains("EnvironmentFile=-/Users/example/.config/mesh-llm/%%service.env"));
+    assert!(
+        !rendered
+            .lines()
+            .any(|line| line == "EnvironmentFile=-/Users/example/.config/mesh-llm/%service.env")
     );
 }
 

--- a/crates/mesh-llm-commands/src/setup/summary.rs
+++ b/crates/mesh-llm-commands/src/setup/summary.rs
@@ -1,0 +1,112 @@
+use super::SetupPlan;
+use super::command::{CliSetupActions, SetupServiceOutcome};
+use crate::runtime_native::{
+    SetupNativeRuntimeOutcome, SetupNativeRuntimePruneResult, SetupNativeRuntimeStatus,
+};
+use mesh_llm_runtime_install::NativeRuntimeInstallStatus;
+
+pub(crate) fn print_runtime_install_result(outcome: &SetupNativeRuntimeOutcome) {
+    match &outcome.status {
+        SetupNativeRuntimeStatus::Skipped => {}
+        SetupNativeRuntimeStatus::Installed(installed) => match installed.status {
+            NativeRuntimeInstallStatus::Installed => eprintln!(
+                "✅ Installed native runtime {} for mesh version {}",
+                installed.runtime.native_runtime_id, installed.runtime.mesh_version
+            ),
+            NativeRuntimeInstallStatus::AlreadyInstalled => eprintln!(
+                "✅ Native runtime {} is already installed for mesh version {}",
+                installed.runtime.native_runtime_id, installed.runtime.mesh_version
+            ),
+        },
+    }
+}
+
+pub(crate) fn print_service_install_result(report: &crate::setup::service::ServiceInstallReport) {
+    for line in &report.messages {
+        eprintln!("{line}");
+    }
+}
+
+pub(crate) fn print_setup_summary(plan: &SetupPlan, actions: &CliSetupActions<'_>) {
+    eprintln!();
+    eprintln!("Setup summary");
+    eprintln!("- Runtime: {}", runtime_summary(plan, actions));
+    eprintln!("- Service: {}", service_summary(plan, actions));
+    eprintln!(
+        "- GitHub: {}",
+        super::github::github_summary(plan, &actions.github_outcome)
+    );
+}
+
+fn runtime_summary(plan: &SetupPlan, actions: &CliSetupActions<'_>) -> String {
+    match plan.runtime {
+        super::SetupRuntimePlan::Skip => "skipped by --skip-runtime".to_string(),
+        super::SetupRuntimePlan::InstallAndPrune => match actions.runtime_outcome.as_ref() {
+            Some(SetupNativeRuntimeOutcome {
+                status: SetupNativeRuntimeStatus::Installed(installed),
+                prune: SetupNativeRuntimePruneResult::Pruned(plan),
+            }) => {
+                let install_status = match installed.status {
+                    NativeRuntimeInstallStatus::Installed => "installed",
+                    NativeRuntimeInstallStatus::AlreadyInstalled => "already installed",
+                };
+                if plan.remove_dirs.is_empty() {
+                    format!("{install_status}; cache already clean")
+                } else {
+                    format!(
+                        "{install_status}; pruned {} inactive cache entr{}",
+                        plan.remove_dirs.len(),
+                        if plan.remove_dirs.len() == 1 {
+                            "y"
+                        } else {
+                            "ies"
+                        }
+                    )
+                }
+            }
+            Some(SetupNativeRuntimeOutcome {
+                status: SetupNativeRuntimeStatus::Installed(installed),
+                prune: SetupNativeRuntimePruneResult::Warning(_),
+            }) => match installed.status {
+                NativeRuntimeInstallStatus::Installed => {
+                    "installed; cache prune warning reported above".to_string()
+                }
+                NativeRuntimeInstallStatus::AlreadyInstalled => {
+                    "already installed; cache prune warning reported above".to_string()
+                }
+            },
+            Some(SetupNativeRuntimeOutcome {
+                status: SetupNativeRuntimeStatus::Installed(installed),
+                prune: SetupNativeRuntimePruneResult::Skipped,
+            }) => match installed.status {
+                NativeRuntimeInstallStatus::Installed => "installed".to_string(),
+                NativeRuntimeInstallStatus::AlreadyInstalled => "already installed".to_string(),
+            },
+            Some(SetupNativeRuntimeOutcome {
+                status: SetupNativeRuntimeStatus::Skipped,
+                ..
+            }) => "skipped".to_string(),
+            None => "not recorded".to_string(),
+        },
+    }
+}
+
+pub(crate) fn service_summary(plan: &SetupPlan, actions: &CliSetupActions<'_>) -> String {
+    match plan.service {
+        super::SetupServicePlan::Skip => "not requested".to_string(),
+        super::SetupServicePlan::Install => match actions.service_outcome {
+            SetupServiceOutcome::Installed(ref report) => report.summary.clone(),
+            SetupServiceOutcome::NotRequested | SetupServiceOutcome::PrintedGuidance => {
+                "not recorded".to_string()
+            }
+        },
+        super::SetupServicePlan::PrintGuidance => match actions.service_outcome {
+            SetupServiceOutcome::PrintedGuidance => {
+                "not installed; printed follow-up guidance".to_string()
+            }
+            SetupServiceOutcome::NotRequested | SetupServiceOutcome::Installed(_) => {
+                "not recorded".to_string()
+            }
+        },
+    }
+}

--- a/crates/mesh-llm-commands/src/setup/summary.rs
+++ b/crates/mesh-llm-commands/src/setup/summary.rs
@@ -3,20 +3,24 @@ use super::command::{CliSetupActions, SetupServiceOutcome};
 use crate::runtime_native::{
     SetupNativeRuntimeOutcome, SetupNativeRuntimePruneResult, SetupNativeRuntimeStatus,
 };
+use crate::terminal::{style_muted, style_ok, style_warn};
 use mesh_llm_runtime_install::NativeRuntimeInstallStatus;
-use std::io::IsTerminal;
 
 pub(crate) fn print_runtime_install_result(outcome: &SetupNativeRuntimeOutcome) {
     match &outcome.status {
         SetupNativeRuntimeStatus::Skipped => {}
         SetupNativeRuntimeStatus::Installed(installed) => match installed.status {
             NativeRuntimeInstallStatus::Installed => eprintln!(
-                "✅ Installed native runtime {} for mesh version {}",
-                installed.runtime.native_runtime_id, installed.runtime.mesh_version
+                "{} Installed native runtime {} for mesh version {}",
+                style_ok("✓"),
+                installed.runtime.native_runtime_id,
+                installed.runtime.mesh_version
             ),
             NativeRuntimeInstallStatus::AlreadyInstalled => eprintln!(
-                "✅ Native runtime {} is already installed for mesh version {}",
-                installed.runtime.native_runtime_id, installed.runtime.mesh_version
+                "{} Native runtime {} is already installed for mesh version {}",
+                style_ok("✓"),
+                installed.runtime.native_runtime_id,
+                installed.runtime.mesh_version
             ),
         },
     }
@@ -168,26 +172,6 @@ fn github_brief(actions: &CliSetupActions<'_>) -> Option<String> {
             Some(style_warn("not starred"))
         }
         _ => None,
-    }
-}
-
-fn style_ok(text: &str) -> String {
-    style(text, "32")
-}
-
-fn style_warn(text: &str) -> String {
-    style(text, "33")
-}
-
-fn style_muted(text: &str) -> String {
-    style(text, "2")
-}
-
-fn style(text: &str, ansi_code: &str) -> String {
-    if std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
-        format!("\x1b[{ansi_code}m{text}\x1b[0m")
-    } else {
-        text.to_string()
     }
 }
 

--- a/crates/mesh-llm-commands/src/setup/summary.rs
+++ b/crates/mesh-llm-commands/src/setup/summary.rs
@@ -4,6 +4,7 @@ use crate::runtime_native::{
     SetupNativeRuntimeOutcome, SetupNativeRuntimePruneResult, SetupNativeRuntimeStatus,
 };
 use mesh_llm_runtime_install::NativeRuntimeInstallStatus;
+use std::io::IsTerminal;
 
 pub(crate) fn print_runtime_install_result(outcome: &SetupNativeRuntimeOutcome) {
     match &outcome.status {
@@ -21,21 +22,36 @@ pub(crate) fn print_runtime_install_result(outcome: &SetupNativeRuntimeOutcome) 
     }
 }
 
-pub(crate) fn print_service_install_result(report: &crate::setup::service::ServiceInstallReport) {
-    for line in &report.messages {
-        eprintln!("{line}");
+pub(crate) fn print_service_install_result(
+    report: &crate::setup::service::ServiceInstallReport,
+    verbose: bool,
+) {
+    if verbose {
+        for line in &report.messages {
+            eprintln!("{line}");
+        }
     }
 }
 
-pub(crate) fn print_setup_summary(plan: &SetupPlan, actions: &CliSetupActions<'_>) {
+pub(crate) fn print_setup_summary(plan: &SetupPlan, actions: &CliSetupActions<'_>, verbose: bool) {
     eprintln!();
-    eprintln!("Setup summary");
-    eprintln!("- Runtime: {}", runtime_summary(plan, actions));
-    eprintln!("- Service: {}", service_summary(plan, actions));
-    eprintln!(
-        "- GitHub: {}",
-        super::github::github_summary(plan, &actions.github_outcome)
-    );
+    if verbose {
+        eprintln!("Setup summary");
+        eprintln!("- Runtime: {}", runtime_summary(plan, actions));
+        eprintln!("- Service: {}", service_summary(plan, actions));
+        eprintln!(
+            "- GitHub: {}",
+            super::github::github_summary(plan, &actions.github_outcome)
+        );
+        return;
+    }
+
+    eprintln!("{} Mesh setup complete", style_ok("✓"));
+    eprintln!("  Runtime  {}", runtime_brief(plan, actions));
+    eprintln!("  Service  {}", service_brief(plan, actions));
+    if let Some(github) = github_brief(actions) {
+        eprintln!("  GitHub   {github}");
+    }
 }
 
 fn runtime_summary(plan: &SetupPlan, actions: &CliSetupActions<'_>) -> String {
@@ -88,6 +104,90 @@ fn runtime_summary(plan: &SetupPlan, actions: &CliSetupActions<'_>) -> String {
             }) => "skipped".to_string(),
             None => "not recorded".to_string(),
         },
+    }
+}
+
+fn runtime_brief(plan: &SetupPlan, actions: &CliSetupActions<'_>) -> String {
+    match plan.runtime {
+        super::SetupRuntimePlan::Skip => style_muted("skipped (--skip-runtime)"),
+        super::SetupRuntimePlan::InstallAndPrune => match actions.runtime_outcome.as_ref() {
+            Some(SetupNativeRuntimeOutcome {
+                status: SetupNativeRuntimeStatus::Installed(installed),
+                prune: SetupNativeRuntimePruneResult::Warning(_),
+            }) => match installed.status {
+                NativeRuntimeInstallStatus::Installed => style_warn("installed; prune warning"),
+                NativeRuntimeInstallStatus::AlreadyInstalled => {
+                    style_warn("already installed; prune warning")
+                }
+            },
+            Some(SetupNativeRuntimeOutcome {
+                status: SetupNativeRuntimeStatus::Installed(installed),
+                ..
+            }) => match installed.status {
+                NativeRuntimeInstallStatus::Installed => style_ok("ready"),
+                NativeRuntimeInstallStatus::AlreadyInstalled => style_ok("already ready"),
+            },
+            Some(SetupNativeRuntimeOutcome {
+                status: SetupNativeRuntimeStatus::Skipped,
+                ..
+            }) => style_muted("skipped"),
+            None => style_muted("not recorded"),
+        },
+    }
+}
+
+fn service_brief(plan: &SetupPlan, actions: &CliSetupActions<'_>) -> String {
+    match plan.service {
+        super::SetupServicePlan::Skip => style_muted("not installed"),
+        super::SetupServicePlan::Install => match actions.service_outcome {
+            SetupServiceOutcome::Installed(ref report)
+                if report.summary == "installed and started" =>
+            {
+                style_ok("running")
+            }
+            SetupServiceOutcome::Installed(_) => style_warn("installed; start manually"),
+            SetupServiceOutcome::NotRequested | SetupServiceOutcome::PrintedGuidance => {
+                style_muted("not recorded")
+            }
+        },
+        super::SetupServicePlan::PrintGuidance => match actions.service_outcome {
+            SetupServiceOutcome::PrintedGuidance => style_muted("not installed"),
+            SetupServiceOutcome::NotRequested | SetupServiceOutcome::Installed(_) => {
+                style_muted("not recorded")
+            }
+        },
+    }
+}
+
+fn github_brief(actions: &CliSetupActions<'_>) -> Option<String> {
+    match actions.github_outcome {
+        super::github::SetupGitHubOutcome::Starred => Some(style_ok("starred")),
+        super::github::SetupGitHubOutcome::AlreadyStarred => Some(style_ok("already starred")),
+        super::github::SetupGitHubOutcome::StarRequestFailed(_)
+        | super::github::SetupGitHubOutcome::EligibilityCheckFailed(_) => {
+            Some(style_warn("not starred"))
+        }
+        _ => None,
+    }
+}
+
+fn style_ok(text: &str) -> String {
+    style(text, "32")
+}
+
+fn style_warn(text: &str) -> String {
+    style(text, "33")
+}
+
+fn style_muted(text: &str) -> String {
+    style(text, "2")
+}
+
+fn style(text: &str, ansi_code: &str) -> String {
+    if std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+        format!("\x1b[{ansi_code}m{text}\x1b[0m")
+    } else {
+        text.to_string()
     }
 }
 

--- a/crates/mesh-llm-commands/src/setup/summary.rs
+++ b/crates/mesh-llm-commands/src/setup/summary.rs
@@ -1,5 +1,6 @@
 use super::SetupPlan;
 use super::command::{CliSetupActions, SetupServiceOutcome};
+use super::service::ServiceInstallStatus;
 use crate::runtime_native::{
     SetupNativeRuntimeOutcome, SetupNativeRuntimePruneResult, SetupNativeRuntimeStatus,
 };
@@ -144,12 +145,10 @@ fn service_brief(plan: &SetupPlan, actions: &CliSetupActions<'_>) -> String {
     match plan.service {
         super::SetupServicePlan::Skip => style_muted("not installed"),
         super::SetupServicePlan::Install => match actions.service_outcome {
-            SetupServiceOutcome::Installed(ref report)
-                if report.summary == "installed and started" =>
-            {
-                style_ok("running")
-            }
-            SetupServiceOutcome::Installed(_) => style_warn("installed; start manually"),
+            SetupServiceOutcome::Installed(ref report) => match report.status {
+                ServiceInstallStatus::Started => style_ok("running"),
+                ServiceInstallStatus::NeedsManualStart => style_warn("installed; start manually"),
+            },
             SetupServiceOutcome::NotRequested | SetupServiceOutcome::PrintedGuidance => {
                 style_muted("not recorded")
             }
@@ -171,6 +170,9 @@ fn github_brief(actions: &CliSetupActions<'_>) -> Option<String> {
         | super::github::SetupGitHubOutcome::EligibilityCheckFailed(_) => {
             Some(style_warn("not starred"))
         }
+        super::github::SetupGitHubOutcome::CliUnavailable => Some(style_muted("gh unavailable")),
+        super::github::SetupGitHubOutcome::NotAuthenticated => Some(style_muted("gh signed out")),
+        super::github::SetupGitHubOutcome::NotEvaluated => Some(style_muted("not recorded")),
         _ => None,
     }
 }
@@ -192,5 +194,41 @@ pub(crate) fn service_summary(plan: &SetupPlan, actions: &CliSetupActions<'_>) -
                 "not recorded".to_string()
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_native::NativeRuntimeConfigSelection;
+    use crate::setup::SetupEnvironment;
+    use crate::setup::SetupPlatform;
+    use crate::setup::github::SetupGitHubOutcome;
+
+    fn actions_with_github_outcome(github_outcome: SetupGitHubOutcome) -> CliSetupActions<'static> {
+        let mut actions = CliSetupActions::new(
+            SetupEnvironment {
+                platform: SetupPlatform::Linux,
+                interactive: false,
+            },
+            NativeRuntimeConfigSelection::default(),
+            false,
+        );
+        actions.github_outcome = github_outcome;
+        actions
+    }
+
+    #[test]
+    fn github_brief_reports_unavailable_cli() {
+        let actions = actions_with_github_outcome(SetupGitHubOutcome::CliUnavailable);
+
+        assert_eq!(github_brief(&actions), Some("gh unavailable".to_string()));
+    }
+
+    #[test]
+    fn github_brief_reports_unauthenticated_cli() {
+        let actions = actions_with_github_outcome(SetupGitHubOutcome::NotAuthenticated);
+
+        assert_eq!(github_brief(&actions), Some("gh signed out".to_string()));
     }
 }

--- a/crates/mesh-llm-commands/src/setup/test_support.rs
+++ b/crates/mesh-llm-commands/src/setup/test_support.rs
@@ -1,0 +1,153 @@
+use super::github_runner::{GhCommand, GhCommandError, GhCommandOutput, GhCommandRunner};
+use super::service_paths::ServiceInstallContext;
+use super::service_runner::{ServiceCommand, ServiceCommandRunner};
+use super::{
+    SetupActions, SetupConfirmPrompt, SetupGitHubStarPlan, SetupPlatform, SetupPrompter, SetupStep,
+};
+use anyhow::anyhow;
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::future::{Ready, ready};
+use std::rc::Rc;
+use tempfile::TempDir;
+
+#[derive(Default)]
+pub(super) struct FakePrompter {
+    pub(super) prompts: Vec<SetupConfirmPrompt>,
+    replies: VecDeque<Option<bool>>,
+}
+
+impl FakePrompter {
+    pub(super) fn with_replies(replies: impl IntoIterator<Item = Option<bool>>) -> Self {
+        Self {
+            prompts: Vec::new(),
+            replies: replies.into_iter().collect(),
+        }
+    }
+}
+
+impl SetupPrompter for FakePrompter {
+    fn confirm(&mut self, prompt: SetupConfirmPrompt) -> Option<bool> {
+        self.prompts.push(prompt);
+        self.replies.pop_front().unwrap_or(None)
+    }
+}
+
+#[derive(Default)]
+pub(super) struct RecordingActions {
+    pub(super) steps: Vec<SetupStep>,
+    pub(super) github: Vec<SetupGitHubStarPlan>,
+    failed_step: Option<SetupStep>,
+}
+
+impl RecordingActions {
+    pub(super) fn failing_on(step: SetupStep) -> Self {
+        Self {
+            steps: Vec::new(),
+            github: Vec::new(),
+            failed_step: Some(step),
+        }
+    }
+}
+
+impl SetupActions for RecordingActions {
+    type Error = anyhow::Error;
+    type GitHubStarFuture<'a>
+        = Ready<Result<(), Self::Error>>
+    where
+        Self: 'a;
+    type StepFuture<'a>
+        = Ready<Result<(), Self::Error>>
+    where
+        Self: 'a;
+
+    fn run_step(&mut self, step: SetupStep) -> Self::StepFuture<'_> {
+        self.steps.push(step);
+        if self.failed_step == Some(step) {
+            return ready(Err(anyhow!("simulated step failure for {step:?}")));
+        }
+        ready(Ok(()))
+    }
+
+    fn handle_github_star<'a>(
+        &'a mut self,
+        plan: SetupGitHubStarPlan,
+        _prompter: &'a mut dyn SetupPrompter,
+    ) -> Self::GitHubStarFuture<'a> {
+        self.github.push(plan);
+        ready(Ok(()))
+    }
+}
+
+#[derive(Default)]
+pub(super) struct SharedGhRunnerState {
+    pub(super) commands: Vec<GhCommand>,
+    responses: VecDeque<Result<GhCommandOutput, GhCommandError>>,
+}
+
+pub(super) struct SharedGhRunner {
+    state: Rc<RefCell<SharedGhRunnerState>>,
+}
+
+impl SharedGhRunner {
+    pub(super) fn new(
+        responses: impl IntoIterator<Item = Result<GhCommandOutput, GhCommandError>>,
+    ) -> (Self, Rc<RefCell<SharedGhRunnerState>>) {
+        let state = Rc::new(RefCell::new(SharedGhRunnerState {
+            commands: Vec::new(),
+            responses: responses.into_iter().collect(),
+        }));
+        (
+            Self {
+                state: Rc::clone(&state),
+            },
+            state,
+        )
+    }
+}
+
+impl GhCommandRunner for SharedGhRunner {
+    fn run(&mut self, command: GhCommand) -> Result<GhCommandOutput, GhCommandError> {
+        let mut state = self.state.borrow_mut();
+        state.commands.push(command);
+        state.responses.pop_front().unwrap_or_else(|| {
+            Err(GhCommandError::WaitFailed(
+                "missing fake gh response".into(),
+            ))
+        })
+    }
+}
+
+#[derive(Default)]
+pub(super) struct FakeServiceRunner;
+
+impl ServiceCommandRunner for FakeServiceRunner {
+    fn run(&mut self, _command: &ServiceCommand) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+pub(super) fn service_context_fixture() -> (TempDir, ServiceInstallContext) {
+    let temp = tempfile::tempdir().expect("tempdir should exist");
+    let binary_path = temp.path().join("bin/mesh-llm");
+    std::fs::create_dir_all(binary_path.parent().expect("binary parent should exist"))
+        .expect("binary dir should exist");
+    std::fs::write(&binary_path, "binary").expect("binary should write");
+    let context = ServiceInstallContext {
+        platform: SetupPlatform::Linux,
+        home_dir: temp.path().join("home"),
+        config_root: temp.path().join("config"),
+        binary_path,
+        user_id: String::new(),
+        start_service: false,
+    };
+    (temp, context)
+}
+
+pub(super) fn success_output(stdout: &str) -> Result<GhCommandOutput, GhCommandError> {
+    Ok(GhCommandOutput {
+        success: true,
+        stdout: stdout.to_string(),
+        stderr: String::new(),
+    })
+}

--- a/crates/mesh-llm-commands/src/setup/tests.rs
+++ b/crates/mesh-llm-commands/src/setup/tests.rs
@@ -1,0 +1,230 @@
+use super::{
+    SetupConfirmPrompt, SetupEnvironment, SetupGitHubStarPlan, SetupGitHubStarSkipReason,
+    SetupOptions, SetupPlanError, SetupPlatform, SetupPrompter, SetupRuntimePlan, SetupServicePlan,
+    SetupStep, plan_setup,
+};
+use std::collections::VecDeque;
+
+#[derive(Default)]
+struct FakePrompter {
+    replies: VecDeque<Option<bool>>,
+    prompts: Vec<SetupConfirmPrompt>,
+}
+
+impl FakePrompter {
+    fn with_replies(replies: impl IntoIterator<Item = Option<bool>>) -> Self {
+        Self {
+            replies: replies.into_iter().collect(),
+            prompts: Vec::new(),
+        }
+    }
+}
+
+impl SetupPrompter for FakePrompter {
+    fn confirm(&mut self, prompt: SetupConfirmPrompt) -> Option<bool> {
+        self.prompts.push(prompt);
+        self.replies.pop_front().unwrap_or(None)
+    }
+}
+
+#[test]
+fn interactive_unix_enter_accepts_default_yes_service_prompt() {
+    let options = SetupOptions::default();
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::with_replies([None]);
+
+    let plan = plan_setup(options, environment, &mut prompter).expect("plan should succeed");
+
+    assert_eq!(plan.runtime, SetupRuntimePlan::InstallAndPrune);
+    assert_eq!(plan.service, SetupServicePlan::Install);
+    assert_eq!(plan.github_star, SetupGitHubStarPlan::PromptIfEligible,);
+    assert_eq!(
+        plan.core_steps,
+        vec![
+            SetupStep::InstallRuntime,
+            SetupStep::PruneInactiveRuntimes,
+            SetupStep::InstallService,
+        ]
+    );
+    assert_eq!(prompter.prompts.len(), 1);
+}
+
+#[test]
+fn interactive_unix_explicit_no_skips_service_prompt() {
+    let options = SetupOptions::default();
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::MacOs,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::with_replies([Some(false)]);
+
+    let plan = plan_setup(options, environment, &mut prompter).expect("plan should succeed");
+
+    assert_eq!(plan.service, SetupServicePlan::Skip);
+    assert_eq!(
+        plan.core_steps,
+        vec![SetupStep::InstallRuntime, SetupStep::PruneInactiveRuntimes]
+    );
+    assert_eq!(prompter.prompts.len(), 1);
+}
+
+#[test]
+fn non_interactive_unix_never_prompts_and_prints_service_guidance() {
+    let options = SetupOptions {
+        no_interactive: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: false,
+    };
+    let mut prompter = FakePrompter::default();
+
+    let plan = plan_setup(options, environment, &mut prompter).expect("plan should succeed");
+
+    assert_eq!(plan.service, SetupServicePlan::PrintGuidance);
+    assert_eq!(
+        plan.github_star,
+        SetupGitHubStarPlan::Skip(SetupGitHubStarSkipReason::HiddenPrompt),
+    );
+    assert_eq!(
+        plan.core_steps,
+        vec![
+            SetupStep::InstallRuntime,
+            SetupStep::PruneInactiveRuntimes,
+            SetupStep::PrintServiceGuidance,
+        ]
+    );
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn service_flag_installs_service_without_prompt() {
+    let options = SetupOptions {
+        service: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: false,
+    };
+    let mut prompter = FakePrompter::default();
+
+    let plan = plan_setup(options, environment, &mut prompter).expect("plan should succeed");
+
+    assert_eq!(plan.service, SetupServicePlan::Install);
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn no_service_flag_skips_service_without_prompt() {
+    let options = SetupOptions {
+        no_service: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+
+    let plan = plan_setup(options, environment, &mut prompter).expect("plan should succeed");
+
+    assert_eq!(plan.service, SetupServicePlan::Skip);
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn windows_service_flag_is_an_unsupported_error() {
+    let options = SetupOptions {
+        service: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Windows,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+
+    let error =
+        plan_setup(options, environment, &mut prompter).expect_err("windows service must fail");
+
+    assert_eq!(
+        error,
+        SetupPlanError::UnsupportedService {
+            platform: SetupPlatform::Windows,
+        }
+    );
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn skip_runtime_omits_install_and_prune_steps() {
+    let options = SetupOptions {
+        skip_runtime: true,
+        service: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+
+    let plan = plan_setup(options, environment, &mut prompter).expect("plan should succeed");
+
+    assert_eq!(plan.runtime, SetupRuntimePlan::Skip);
+    assert_eq!(plan.core_steps, vec![SetupStep::InstallService]);
+}
+
+#[test]
+fn yes_skips_core_prompts_and_github_star_prompt() {
+    let options = SetupOptions {
+        yes: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+
+    let plan = plan_setup(options, environment, &mut prompter).expect("plan should succeed");
+
+    assert_eq!(plan.service, SetupServicePlan::Install);
+    assert_eq!(
+        plan.github_star,
+        SetupGitHubStarPlan::Skip(SetupGitHubStarSkipReason::AutomaticYes),
+    );
+    assert!(prompter.prompts.is_empty());
+}
+
+#[test]
+fn yes_and_no_service_keeps_explicit_service_skip_without_prompt() {
+    let options = SetupOptions {
+        yes: true,
+        no_service: true,
+        ..SetupOptions::default()
+    };
+    let environment = SetupEnvironment {
+        platform: SetupPlatform::Linux,
+        interactive: true,
+    };
+    let mut prompter = FakePrompter::default();
+
+    let plan = plan_setup(options, environment, &mut prompter).expect("plan should succeed");
+
+    assert_eq!(plan.service, SetupServicePlan::Skip);
+    assert_eq!(
+        plan.github_star,
+        SetupGitHubStarPlan::Skip(SetupGitHubStarSkipReason::AutomaticYes),
+    );
+    assert_eq!(
+        plan.core_steps,
+        vec![SetupStep::InstallRuntime, SetupStep::PruneInactiveRuntimes]
+    );
+    assert!(prompter.prompts.is_empty());
+}

--- a/crates/mesh-llm-commands/src/terminal.rs
+++ b/crates/mesh-llm-commands/src/terminal.rs
@@ -1,0 +1,82 @@
+use anyhow::{Context, Result};
+use std::io::{self, IsTerminal, Write};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ConfirmDefault {
+    Yes,
+    No,
+}
+
+impl ConfirmDefault {
+    const fn prompt_suffix(self) -> &'static str {
+        match self {
+            Self::Yes => "[Y/n]",
+            Self::No => "[y/N]",
+        }
+    }
+
+    const fn empty_reply(self) -> bool {
+        match self {
+            Self::Yes => true,
+            Self::No => false,
+        }
+    }
+}
+
+pub(crate) fn confirm_yes_no(message: &str, default: ConfirmDefault) -> Result<Option<bool>> {
+    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        return Ok(None);
+    }
+
+    loop {
+        eprint!(
+            "{} {} {} ",
+            prompt_marker(),
+            message,
+            default.prompt_suffix()
+        );
+        io::stderr()
+            .flush()
+            .context("failed to flush confirmation prompt")?;
+
+        let mut reply = String::new();
+        io::stdin()
+            .read_line(&mut reply)
+            .context("failed to read confirmation")?;
+
+        match reply.trim().to_ascii_lowercase().as_str() {
+            "" => return Ok(Some(default.empty_reply())),
+            "y" | "yes" => return Ok(Some(true)),
+            "n" | "no" => return Ok(Some(false)),
+            _ => eprintln!("Please answer y or n."),
+        }
+    }
+}
+
+fn prompt_marker() -> String {
+    if io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+        "\x1b[36m?\x1b[0m".to_string()
+    } else {
+        "?".to_string()
+    }
+}
+
+pub(crate) fn style_ok(text: &str) -> String {
+    style(text, "32")
+}
+
+pub(crate) fn style_warn(text: &str) -> String {
+    style(text, "33")
+}
+
+pub(crate) fn style_muted(text: &str) -> String {
+    style(text, "2")
+}
+
+fn style(text: &str, ansi_code: &str) -> String {
+    if io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+        format!("\x1b[{ansi_code}m{text}\x1b[0m")
+    } else {
+        text.to_string()
+    }
+}

--- a/crates/mesh-llm-commands/src/terminal.rs
+++ b/crates/mesh-llm-commands/src/terminal.rs
@@ -40,9 +40,12 @@ pub(crate) fn confirm_yes_no(message: &str, default: ConfirmDefault) -> Result<O
             .context("failed to flush confirmation prompt")?;
 
         let mut reply = String::new();
-        io::stdin()
+        let bytes_read = io::stdin()
             .read_line(&mut reply)
             .context("failed to read confirmation")?;
+        if bytes_read == 0 {
+            return Ok(Some(false));
+        }
 
         match reply.trim().to_ascii_lowercase().as_str() {
             "" => return Ok(Some(default.empty_reply())),

--- a/crates/mesh-llm-commands/src/uninstall.rs
+++ b/crates/mesh-llm-commands/src/uninstall.rs
@@ -1,0 +1,948 @@
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use std::{
+    fs,
+    io::{self, IsTerminal, Write},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const SERVICE_NAME: &str = "mesh-llm";
+const LAUNCHD_LABEL: &str = "com.mesh-llm.mesh-llm";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UninstallOptions {
+    pub dry_run: bool,
+    pub yes: bool,
+    pub keep_cache: bool,
+    pub keep_service_files: bool,
+    pub purge_config: bool,
+    pub keep_config: bool,
+    pub binary_path: Option<PathBuf>,
+    pub json: bool,
+    pub verbose: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UninstallEnvironment {
+    pub platform: UninstallPlatform,
+    pub home_dir: PathBuf,
+    pub config_root: PathBuf,
+    pub cache_root: PathBuf,
+    pub binary_path: PathBuf,
+    pub user_id: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UninstallPlatform {
+    Linux,
+    MacOs,
+    Windows,
+    Other,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum UninstallStep {
+    StopProcesses,
+    DisableSystemdUserService,
+    ReloadSystemdUser,
+    BootoutLaunchdAgent {
+        user_id: String,
+        plist_path: PathBuf,
+    },
+    RemovePath {
+        path: PathBuf,
+        purpose: RemovePurpose,
+    },
+    RemoveBinary {
+        path: PathBuf,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemovePurpose {
+    SystemdUnit,
+    LaunchdPlist,
+    ServiceEnv,
+    ServiceRunner,
+    ServiceConfigDir,
+    LaunchdLogs,
+    NativeRuntimeCache,
+    ConfigAndIdentity,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UninstallPlan {
+    pub dry_run: bool,
+    pub requires_confirmation: bool,
+    pub platform: UninstallPlatform,
+    pub steps: Vec<UninstallStep>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UninstallOutcome {
+    pub dry_run: bool,
+    pub removed: Vec<PathBuf>,
+    pub scheduled_removal: Vec<PathBuf>,
+    pub already_absent: Vec<PathBuf>,
+    pub warnings: Vec<String>,
+}
+
+pub fn detect_uninstall_environment(binary_path: Option<PathBuf>) -> Result<UninstallEnvironment> {
+    let home_dir =
+        dirs::home_dir().context("could not determine the home directory for uninstall")?;
+    let config_root = dirs::config_dir().unwrap_or_else(|| home_dir.join(".config"));
+    let cache_root = dirs::cache_dir().unwrap_or_else(|| home_dir.join(".cache"));
+    let binary_path = match binary_path {
+        Some(path) => path,
+        None => std::env::current_exe()
+            .context("could not determine the running mesh-llm executable path")?,
+    };
+    let user_id = if cfg!(target_os = "macos") {
+        detect_user_id().unwrap_or_default()
+    } else {
+        String::new()
+    };
+    Ok(UninstallEnvironment {
+        platform: current_platform(),
+        home_dir,
+        config_root,
+        cache_root,
+        binary_path,
+        user_id,
+    })
+}
+
+pub fn plan_uninstall(options: &UninstallOptions, env: &UninstallEnvironment) -> UninstallPlan {
+    let mut steps = vec![UninstallStep::StopProcesses];
+    match env.platform {
+        UninstallPlatform::Linux => {
+            steps.push(UninstallStep::DisableSystemdUserService);
+            steps.push(UninstallStep::RemovePath {
+                path: env
+                    .config_root
+                    .join("systemd/user")
+                    .join(format!("{SERVICE_NAME}.service")),
+                purpose: RemovePurpose::SystemdUnit,
+            });
+            steps.push(UninstallStep::ReloadSystemdUser);
+        }
+        UninstallPlatform::MacOs => {
+            let plist_path = env
+                .home_dir
+                .join("Library/LaunchAgents")
+                .join(format!("{LAUNCHD_LABEL}.plist"));
+            steps.push(UninstallStep::BootoutLaunchdAgent {
+                user_id: env.user_id.clone(),
+                plist_path: plist_path.clone(),
+            });
+            steps.push(UninstallStep::RemovePath {
+                path: plist_path,
+                purpose: RemovePurpose::LaunchdPlist,
+            });
+            steps.push(UninstallStep::RemovePath {
+                path: env.home_dir.join("Library/Logs/mesh-llm"),
+                purpose: RemovePurpose::LaunchdLogs,
+            });
+        }
+        UninstallPlatform::Windows | UninstallPlatform::Other => {}
+    }
+    if !options.keep_service_files {
+        let service_config_dir = env.config_root.join("mesh-llm");
+        steps.extend([
+            UninstallStep::RemovePath {
+                path: service_config_dir.join("service.env"),
+                purpose: RemovePurpose::ServiceEnv,
+            },
+            UninstallStep::RemovePath {
+                path: service_config_dir.join("run-service.sh"),
+                purpose: RemovePurpose::ServiceRunner,
+            },
+            UninstallStep::RemovePath {
+                path: service_config_dir,
+                purpose: RemovePurpose::ServiceConfigDir,
+            },
+        ]);
+    }
+    if !options.keep_cache {
+        steps.push(UninstallStep::RemovePath {
+            path: env.cache_root.join("mesh-llm/native-runtimes"),
+            purpose: RemovePurpose::NativeRuntimeCache,
+        });
+    }
+    if options.purge_config && !options.keep_config {
+        steps.push(UninstallStep::RemovePath {
+            path: env.home_dir.join(".mesh-llm"),
+            purpose: RemovePurpose::ConfigAndIdentity,
+        });
+    }
+    steps.push(UninstallStep::RemoveBinary {
+        path: env.binary_path.clone(),
+    });
+    UninstallPlan {
+        dry_run: options.dry_run,
+        requires_confirmation: !options.dry_run && !options.yes,
+        platform: env.platform,
+        steps,
+    }
+}
+
+pub fn run_uninstall_command<F>(options: UninstallOptions, mut stop_processes: F) -> Result<()>
+where
+    F: FnMut() -> Result<()>,
+{
+    let env = detect_uninstall_environment(options.binary_path.clone())?;
+    let plan = plan_uninstall(&options, &env);
+    if options.dry_run {
+        render_plan(&plan, options.json, options.verbose)?;
+        return Ok(());
+    }
+    if plan.requires_confirmation && !confirm_uninstall()? {
+        bail!("uninstall cancelled");
+    }
+    let outcome = execute_uninstall_plan(&plan, &mut stop_processes)?;
+    render_outcome(&outcome, options.json, options.verbose)
+}
+
+pub fn execute_uninstall_plan<F>(
+    plan: &UninstallPlan,
+    stop_processes: &mut F,
+) -> Result<UninstallOutcome>
+where
+    F: FnMut() -> Result<()>,
+{
+    let mut outcome = UninstallOutcome {
+        dry_run: plan.dry_run,
+        removed: Vec::new(),
+        scheduled_removal: Vec::new(),
+        already_absent: Vec::new(),
+        warnings: Vec::new(),
+    };
+    if plan.dry_run {
+        return Ok(outcome);
+    }
+    for step in &plan.steps {
+        execute_step(step, stop_processes, &mut outcome)?;
+    }
+    Ok(outcome)
+}
+
+fn execute_step<F>(
+    step: &UninstallStep,
+    stop_processes: &mut F,
+    outcome: &mut UninstallOutcome,
+) -> Result<()>
+where
+    F: FnMut() -> Result<()>,
+{
+    match step {
+        UninstallStep::StopProcesses => {
+            if let Err(error) = stop_processes() {
+                outcome.warnings.push(format!(
+                    "failed to stop tracked mesh-llm processes: {error:#}"
+                ));
+            }
+        }
+        UninstallStep::DisableSystemdUserService => {
+            run_best_effort(
+                Command::new("systemctl").args(["--user", "disable", "--now", "mesh-llm.service"]),
+                outcome,
+            );
+        }
+        UninstallStep::ReloadSystemdUser => {
+            run_best_effort(
+                Command::new("systemctl").args(["--user", "daemon-reload"]),
+                outcome,
+            );
+        }
+        UninstallStep::BootoutLaunchdAgent {
+            user_id,
+            plist_path,
+        } => {
+            if user_id.is_empty() {
+                outcome
+                    .warnings
+                    .push("could not determine user id for launchd bootout".to_string());
+            } else {
+                run_best_effort(
+                    Command::new("launchctl").args([
+                        "bootout",
+                        &format!("gui/{user_id}"),
+                        &plist_path.display().to_string(),
+                    ]),
+                    outcome,
+                );
+            }
+        }
+        UninstallStep::RemovePath { path, purpose } => {
+            remove_path(path, *purpose, outcome)
+                .with_context(|| format!("failed to remove {}", path.display()))?;
+        }
+        UninstallStep::RemoveBinary { path } => remove_binary(path, outcome)
+            .with_context(|| format!("failed to remove {}", path.display()))?,
+    }
+    Ok(())
+}
+
+fn remove_path(path: &Path, purpose: RemovePurpose, outcome: &mut UninstallOutcome) -> Result<()> {
+    if purpose == RemovePurpose::ServiceConfigDir {
+        return remove_empty_dir(path, outcome);
+    }
+    remove_recursively(path, outcome)
+}
+
+fn remove_binary(path: &Path, outcome: &mut UninstallOutcome) -> Result<()> {
+    let current_exe = std::env::current_exe().ok();
+    remove_binary_for_platform(path, current_platform(), current_exe.as_deref(), outcome)
+}
+
+fn remove_binary_for_platform(
+    path: &Path,
+    platform: UninstallPlatform,
+    current_exe: Option<&Path>,
+    outcome: &mut UninstallOutcome,
+) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => {
+            bail!(
+                "refusing to remove binary path because it is a directory: {}",
+                path.display()
+            );
+        }
+        Ok(_)
+            if binary_removal_action(path, platform, current_exe) == BinaryRemovalAction::Defer =>
+        {
+            schedule_windows_deferred_binary_delete(path)?;
+            outcome.scheduled_removal.push(path.to_path_buf());
+        }
+        Ok(_) => {
+            fs::remove_file(path)?;
+            outcome.removed.push(path.to_path_buf());
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            outcome.already_absent.push(path.to_path_buf());
+        }
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BinaryRemovalAction {
+    RemoveNow,
+    Defer,
+}
+
+fn binary_removal_action(
+    path: &Path,
+    platform: UninstallPlatform,
+    current_exe: Option<&Path>,
+) -> BinaryRemovalAction {
+    if platform == UninstallPlatform::Windows
+        && current_exe.is_some_and(|current_exe| paths_match(path, current_exe))
+    {
+        return BinaryRemovalAction::Defer;
+    }
+    BinaryRemovalAction::RemoveNow
+}
+
+fn paths_match(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
+#[cfg(windows)]
+fn schedule_windows_deferred_binary_delete(path: &Path) -> Result<()> {
+    Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "Start-Sleep -Seconds 1; Remove-Item -LiteralPath $args[0] -Force",
+            "--",
+        ])
+        .arg(path)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to schedule deferred removal for {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn schedule_windows_deferred_binary_delete(path: &Path) -> Result<()> {
+    let _ = fs::metadata(path)?;
+    Ok(())
+}
+
+fn remove_empty_dir(path: &Path, outcome: &mut UninstallOutcome) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => match fs::remove_dir(path) {
+            Ok(()) => outcome.removed.push(path.to_path_buf()),
+            Err(error) if error.kind() == io::ErrorKind::DirectoryNotEmpty => {
+                outcome.warnings.push(format!(
+                    "leaving non-empty service config directory {}",
+                    path.display()
+                ));
+            }
+            Err(error) => return Err(error.into()),
+        },
+        Ok(_) => {
+            fs::remove_file(path)?;
+            outcome.removed.push(path.to_path_buf());
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            outcome.already_absent.push(path.to_path_buf());
+        }
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
+fn remove_recursively(path: &Path, outcome: &mut UninstallOutcome) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => match fs::remove_dir(path) {
+            Ok(()) => outcome.removed.push(path.to_path_buf()),
+            Err(error) if error.kind() == io::ErrorKind::DirectoryNotEmpty => {
+                fs::remove_dir_all(path)?;
+                outcome.removed.push(path.to_path_buf());
+            }
+            Err(error) => return Err(error.into()),
+        },
+        Ok(_) => {
+            fs::remove_file(path)?;
+            outcome.removed.push(path.to_path_buf());
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            outcome.already_absent.push(path.to_path_buf());
+        }
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
+fn run_best_effort(command: &mut Command, outcome: &mut UninstallOutcome) {
+    match command.output() {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => outcome.warnings.push(format!(
+            "`{:?}` exited with status {}",
+            command, output.status
+        )),
+        Err(error) => outcome
+            .warnings
+            .push(format!("failed to run `{:?}`: {error}", command)),
+    }
+}
+
+fn render_plan(plan: &UninstallPlan, json: bool, verbose: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(plan)?);
+        return Ok(());
+    }
+    for line in plan_lines(plan, verbose) {
+        eprintln!("{line}");
+    }
+    Ok(())
+}
+
+fn render_outcome(outcome: &UninstallOutcome, json: bool, verbose: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+        return Ok(());
+    }
+    eprintln!();
+    for line in outcome_lines(outcome, verbose) {
+        eprintln!("{line}");
+    }
+    Ok(())
+}
+
+fn plan_lines(plan: &UninstallPlan, verbose: bool) -> Vec<String> {
+    if verbose {
+        let mut lines = vec!["Uninstall dry run".to_string()];
+        lines.extend(
+            plan.steps
+                .iter()
+                .map(|step| format!("  - {}", step_label(step))),
+        );
+        return lines;
+    }
+
+    let mut lines = vec![format!("{} Mesh uninstall dry run", style_warn("!"))];
+    lines.push(format!("  Steps    {} planned", plan.steps.len()));
+    lines.push(format!("  Config   {}", config_plan_label(plan)));
+    if let Some(binary_path) = binary_path_from_plan(plan) {
+        lines.push(format!("  Binary   {}", binary_path.display()));
+    }
+    lines.push("Run with `--yes` to uninstall, or `--verbose` to inspect every step.".to_string());
+    lines
+}
+
+fn outcome_lines(outcome: &UninstallOutcome, verbose: bool) -> Vec<String> {
+    let mut lines = Vec::new();
+    for warning in &outcome.warnings {
+        lines.push(format!("{} {warning}", style_warn("warning:")));
+    }
+    if verbose {
+        lines.push("Mesh uninstall complete".to_string());
+        push_path_group(&mut lines, "Removed", &outcome.removed);
+        push_path_group(
+            &mut lines,
+            "Scheduled for removal after exit",
+            &outcome.scheduled_removal,
+        );
+        push_path_group(&mut lines, "Already absent", &outcome.already_absent);
+        return lines;
+    }
+
+    lines.push(format!("{} Mesh uninstall complete", style_ok("✓")));
+    lines.push(format!(
+        "  Removed  {}",
+        style_ok(&item_count(outcome.removed.len()))
+    ));
+    if !outcome.scheduled_removal.is_empty() {
+        lines.push(format!(
+            "  Deferred {}",
+            style_warn(&item_count(outcome.scheduled_removal.len()))
+        ));
+    }
+    if !outcome.already_absent.is_empty() {
+        lines.push(format!(
+            "  Skipped  {}",
+            style_muted(&format!("{} already absent", outcome.already_absent.len()))
+        ));
+    }
+    if !outcome.warnings.is_empty() {
+        lines.push(format!(
+            "  Warnings {}",
+            style_warn(&outcome.warnings.len().to_string())
+        ));
+    }
+    lines
+}
+
+fn push_path_group(lines: &mut Vec<String>, title: &str, paths: &[PathBuf]) {
+    if paths.is_empty() {
+        return;
+    }
+    lines.push(format!("{title}:"));
+    lines.extend(paths.iter().map(|path| format!("  - {}", path.display())));
+}
+
+fn item_count(count: usize) -> String {
+    format!("{count} {}", if count == 1 { "item" } else { "items" })
+}
+
+fn binary_path_from_plan(plan: &UninstallPlan) -> Option<&Path> {
+    plan.steps.iter().find_map(|step| match step {
+        UninstallStep::RemoveBinary { path } => Some(path.as_path()),
+        _ => None,
+    })
+}
+
+fn config_plan_label(plan: &UninstallPlan) -> &'static str {
+    if plan.steps.iter().any(|step| {
+        matches!(
+            step,
+            UninstallStep::RemovePath {
+                purpose: RemovePurpose::ConfigAndIdentity,
+                ..
+            }
+        )
+    }) {
+        "will be removed"
+    } else {
+        "preserved"
+    }
+}
+
+fn step_label(step: &UninstallStep) -> String {
+    match step {
+        UninstallStep::StopProcesses => "stop tracked mesh-llm processes".to_string(),
+        UninstallStep::DisableSystemdUserService => {
+            "disable and stop systemd user service".to_string()
+        }
+        UninstallStep::ReloadSystemdUser => "reload systemd user units".to_string(),
+        UninstallStep::BootoutLaunchdAgent { .. } => "boot out launchd agent".to_string(),
+        UninstallStep::RemovePath { path, purpose } => {
+            format!("remove {}: {}", purpose_label(*purpose), path.display())
+        }
+        UninstallStep::RemoveBinary { path } => format!("remove binary: {}", path.display()),
+    }
+}
+
+fn purpose_label(purpose: RemovePurpose) -> &'static str {
+    match purpose {
+        RemovePurpose::SystemdUnit => "systemd unit",
+        RemovePurpose::LaunchdPlist => "launchd plist",
+        RemovePurpose::ServiceEnv => "service environment file",
+        RemovePurpose::ServiceRunner => "service runner",
+        RemovePurpose::ServiceConfigDir => "service config directory if empty",
+        RemovePurpose::LaunchdLogs => "launchd logs",
+        RemovePurpose::NativeRuntimeCache => "native runtime cache",
+        RemovePurpose::ConfigAndIdentity => "configuration and identity",
+    }
+}
+
+fn confirm_uninstall() -> Result<bool> {
+    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        return Ok(false);
+    }
+
+    loop {
+        eprint!(
+            "{} Remove mesh-llm from this machine? [y/N] ",
+            prompt_marker()
+        );
+        io::stderr()
+            .flush()
+            .context("failed to flush uninstall confirmation prompt")?;
+
+        let mut reply = String::new();
+        io::stdin()
+            .read_line(&mut reply)
+            .context("failed to read uninstall confirmation")?;
+
+        match reply.trim().to_ascii_lowercase().as_str() {
+            "" | "n" | "no" => return Ok(false),
+            "y" | "yes" => return Ok(true),
+            _ => eprintln!("Please answer y or n."),
+        }
+    }
+}
+
+fn prompt_marker() -> String {
+    if io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+        "\x1b[36m?\x1b[0m".to_string()
+    } else {
+        "?".to_string()
+    }
+}
+
+fn style_ok(text: &str) -> String {
+    style(text, "32")
+}
+
+fn style_warn(text: &str) -> String {
+    style(text, "33")
+}
+
+fn style_muted(text: &str) -> String {
+    style(text, "2")
+}
+
+fn style(text: &str, ansi_code: &str) -> String {
+    if io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+        format!("\x1b[{ansi_code}m{text}\x1b[0m")
+    } else {
+        text.to_string()
+    }
+}
+
+fn current_platform() -> UninstallPlatform {
+    if cfg!(target_os = "linux") {
+        UninstallPlatform::Linux
+    } else if cfg!(target_os = "macos") {
+        UninstallPlatform::MacOs
+    } else if cfg!(target_os = "windows") {
+        UninstallPlatform::Windows
+    } else {
+        UninstallPlatform::Other
+    }
+}
+
+fn detect_user_id() -> Result<String> {
+    let output = Command::new("id")
+        .arg("-u")
+        .output()
+        .context("failed to run `id -u` for launchd cleanup")?;
+    if !output.status.success() {
+        bail!("`id -u` exited with status {}", output.status);
+    }
+    Ok(String::from_utf8(output.stdout)
+        .context("`id -u` emitted non-UTF-8 output")?
+        .trim()
+        .to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(temp: &Path, platform: UninstallPlatform) -> UninstallEnvironment {
+        UninstallEnvironment {
+            platform,
+            home_dir: temp.join("home"),
+            config_root: temp.join("config"),
+            cache_root: temp.join("cache"),
+            binary_path: temp.join("bin/mesh-llm"),
+            user_id: "501".to_string(),
+        }
+    }
+
+    fn options() -> UninstallOptions {
+        UninstallOptions {
+            dry_run: false,
+            yes: true,
+            keep_cache: false,
+            keep_service_files: false,
+            purge_config: false,
+            keep_config: false,
+            binary_path: None,
+            json: false,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn linux_plan_removes_service_cache_and_binary_but_preserves_config_by_default() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let plan = plan_uninstall(&options(), &env(temp.path(), UninstallPlatform::Linux));
+
+        assert!(
+            plan.steps
+                .contains(&UninstallStep::DisableSystemdUserService)
+        );
+        assert!(plan.steps.contains(&UninstallStep::ReloadSystemdUser));
+        assert!(plan.steps.iter().any(|step| matches!(
+            step,
+            UninstallStep::RemovePath {
+                purpose: RemovePurpose::NativeRuntimeCache,
+                ..
+            }
+        )));
+        assert!(
+            plan.steps
+                .iter()
+                .any(|step| matches!(step, UninstallStep::RemoveBinary { .. }))
+        );
+        assert!(!plan.steps.iter().any(|step| matches!(
+            step,
+            UninstallStep::RemovePath {
+                purpose: RemovePurpose::ConfigAndIdentity,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn keep_flags_omit_cache_and_service_helper_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let opts = UninstallOptions {
+            keep_cache: true,
+            keep_service_files: true,
+            ..options()
+        };
+        let plan = plan_uninstall(&opts, &env(temp.path(), UninstallPlatform::Linux));
+
+        assert!(!plan.steps.iter().any(|step| matches!(
+            step,
+            UninstallStep::RemovePath {
+                purpose: RemovePurpose::NativeRuntimeCache
+                    | RemovePurpose::ServiceEnv
+                    | RemovePurpose::ServiceRunner
+                    | RemovePurpose::ServiceConfigDir,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn purge_config_adds_identity_config_removal() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let opts = UninstallOptions {
+            purge_config: true,
+            ..options()
+        };
+        let plan = plan_uninstall(&opts, &env(temp.path(), UninstallPlatform::MacOs));
+
+        assert!(plan.steps.iter().any(|step| matches!(
+            step,
+            UninstallStep::RemovePath {
+                purpose: RemovePurpose::ConfigAndIdentity,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn execute_plan_removes_files_and_directories() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env = env(temp.path(), UninstallPlatform::Other);
+        fs::create_dir_all(env.binary_path.parent().expect("binary parent")).expect("bin dir");
+        fs::write(&env.binary_path, "binary").expect("binary");
+        let cache = env.cache_root.join("mesh-llm/native-runtimes");
+        fs::create_dir_all(&cache).expect("cache dir");
+        fs::write(cache.join("manifest.json"), "{}").expect("cache file");
+        let plan = plan_uninstall(&options(), &env);
+        let mut stopped = false;
+
+        let outcome = execute_uninstall_plan(&plan, &mut || {
+            stopped = true;
+            Ok(())
+        })
+        .expect("uninstall should execute");
+
+        assert!(stopped);
+        assert!(!env.binary_path.exists());
+        assert!(!cache.exists());
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn binary_removal_rejects_directory_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut outcome = UninstallOutcome {
+            dry_run: false,
+            removed: Vec::new(),
+            scheduled_removal: Vec::new(),
+            already_absent: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let error = remove_binary_for_platform(
+            temp.path(),
+            UninstallPlatform::Linux,
+            Some(temp.path()),
+            &mut outcome,
+        )
+        .expect_err("directories are not valid binary paths");
+
+        assert!(
+            error
+                .to_string()
+                .contains("refusing to remove binary path because it is a directory")
+        );
+        assert!(temp.path().exists());
+    }
+
+    #[test]
+    fn windows_current_exe_binary_removal_is_deferred() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let binary = temp.path().join("mesh-llm.exe");
+        fs::write(&binary, "binary").expect("binary");
+
+        assert_eq!(
+            binary_removal_action(&binary, UninstallPlatform::Windows, Some(&binary)),
+            BinaryRemovalAction::Defer
+        );
+        assert_eq!(
+            binary_removal_action(&binary, UninstallPlatform::Linux, Some(&binary)),
+            BinaryRemovalAction::RemoveNow
+        );
+    }
+
+    #[test]
+    fn execute_plan_leaves_non_empty_service_config_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env = env(temp.path(), UninstallPlatform::Other);
+        let service_config_dir = env.config_root.join("mesh-llm");
+        fs::create_dir_all(&service_config_dir).expect("service config dir");
+        fs::write(service_config_dir.join("service.env"), "MESH=1").expect("service env");
+        fs::write(service_config_dir.join("custom.toml"), "owned_by=user").expect("custom file");
+        fs::create_dir_all(env.binary_path.parent().expect("binary parent")).expect("bin dir");
+        fs::write(&env.binary_path, "binary").expect("binary");
+        let plan = plan_uninstall(&options(), &env);
+
+        let outcome = execute_uninstall_plan(&plan, &mut || Ok(())).expect("uninstall");
+
+        assert!(!service_config_dir.join("service.env").exists());
+        assert!(service_config_dir.join("custom.toml").exists());
+        assert!(service_config_dir.exists());
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("leaving non-empty service config directory"))
+        );
+    }
+
+    #[test]
+    fn compact_dry_run_summarizes_without_listing_every_step() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let plan = plan_uninstall(&options(), &env(temp.path(), UninstallPlatform::Linux));
+
+        let lines = plan_lines(&plan, false);
+
+        assert_eq!(lines[0], "! Mesh uninstall dry run");
+        assert!(lines.iter().any(|line| line == "  Config   preserved"));
+        assert!(lines.iter().any(|line| line.starts_with("  Binary   ")));
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.contains("disable and stop systemd user service"))
+        );
+    }
+
+    #[test]
+    fn verbose_dry_run_lists_cleanup_steps() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let plan = plan_uninstall(&options(), &env(temp.path(), UninstallPlatform::Linux));
+
+        let lines = plan_lines(&plan, true);
+
+        assert_eq!(lines[0], "Uninstall dry run");
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("disable and stop systemd user service"))
+        );
+    }
+
+    #[test]
+    fn compact_outcome_summarizes_counts_without_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let removed = temp.path().join("bin/mesh-llm");
+        let outcome = UninstallOutcome {
+            dry_run: false,
+            removed: vec![removed.clone()],
+            scheduled_removal: Vec::new(),
+            already_absent: vec![temp.path().join("missing")],
+            warnings: Vec::new(),
+        };
+
+        let lines = outcome_lines(&outcome, false);
+
+        assert_eq!(lines[0], "✓ Mesh uninstall complete");
+        assert!(lines.iter().any(|line| line == "  Removed  1 item"));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == "  Skipped  1 already absent")
+        );
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.contains(&removed.display().to_string()))
+        );
+    }
+
+    #[test]
+    fn verbose_outcome_lists_removed_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let removed = temp.path().join("bin/mesh-llm");
+        let outcome = UninstallOutcome {
+            dry_run: false,
+            removed: vec![removed.clone()],
+            scheduled_removal: Vec::new(),
+            already_absent: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let lines = outcome_lines(&outcome, true);
+
+        assert_eq!(lines[0], "Mesh uninstall complete");
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == &format!("  - {}", removed.display()))
+        );
+    }
+}

--- a/crates/mesh-llm-commands/src/uninstall.rs
+++ b/crates/mesh-llm-commands/src/uninstall.rs
@@ -1,8 +1,8 @@
+use crate::terminal::{self, ConfirmDefault, style_muted, style_ok, style_warn};
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use std::{
-    fs,
-    io::{self, IsTerminal, Write},
+    fs, io,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -592,58 +592,8 @@ fn purpose_label(purpose: RemovePurpose) -> &'static str {
 }
 
 fn confirm_uninstall() -> Result<bool> {
-    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
-        return Ok(false);
-    }
-
-    loop {
-        eprint!(
-            "{} Remove mesh-llm from this machine? [y/N] ",
-            prompt_marker()
-        );
-        io::stderr()
-            .flush()
-            .context("failed to flush uninstall confirmation prompt")?;
-
-        let mut reply = String::new();
-        io::stdin()
-            .read_line(&mut reply)
-            .context("failed to read uninstall confirmation")?;
-
-        match reply.trim().to_ascii_lowercase().as_str() {
-            "" | "n" | "no" => return Ok(false),
-            "y" | "yes" => return Ok(true),
-            _ => eprintln!("Please answer y or n."),
-        }
-    }
-}
-
-fn prompt_marker() -> String {
-    if io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
-        "\x1b[36m?\x1b[0m".to_string()
-    } else {
-        "?".to_string()
-    }
-}
-
-fn style_ok(text: &str) -> String {
-    style(text, "32")
-}
-
-fn style_warn(text: &str) -> String {
-    style(text, "33")
-}
-
-fn style_muted(text: &str) -> String {
-    style(text, "2")
-}
-
-fn style(text: &str, ansi_code: &str) -> String {
-    if io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
-        format!("\x1b[{ansi_code}m{text}\x1b[0m")
-    } else {
-        text.to_string()
-    }
+    terminal::confirm_yes_no("Remove mesh-llm from this machine?", ConfirmDefault::No)
+        .map(|reply| reply.unwrap_or(false))
 }
 
 fn current_platform() -> UninstallPlatform {

--- a/crates/mesh-llm-commands/src/uninstall.rs
+++ b/crates/mesh-llm-commands/src/uninstall.rs
@@ -203,7 +203,8 @@ where
     if plan.requires_confirmation && !confirm_uninstall()? {
         bail!("uninstall cancelled");
     }
-    let outcome = execute_uninstall_plan(&plan, &mut stop_processes)?;
+    let mut outcome = execute_uninstall_plan(&plan, &mut stop_processes)?;
+    add_option_warnings(&options, &mut outcome);
     render_outcome(&outcome, options.json, options.verbose)
 }
 
@@ -358,16 +359,17 @@ fn paths_match(left: &Path, right: &Path) -> bool {
 
 #[cfg(windows)]
 fn schedule_windows_deferred_binary_delete(path: &Path) -> Result<()> {
+    let escaped_path = path.to_string_lossy().replace('\'', "''");
+    let script =
+        format!("Start-Sleep -Seconds 1; Remove-Item -LiteralPath '{escaped_path}' -Force");
     Command::new("powershell.exe")
         .args([
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
             "-Command",
-            "Start-Sleep -Seconds 1; Remove-Item -LiteralPath $args[0] -Force",
-            "--",
+            &script,
         ])
-        .arg(path)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -438,6 +440,15 @@ fn run_best_effort(command: &mut Command, outcome: &mut UninstallOutcome) {
         Err(error) => outcome
             .warnings
             .push(format!("failed to run `{:?}`: {error}", command)),
+    }
+}
+
+fn add_option_warnings(options: &UninstallOptions, outcome: &mut UninstallOutcome) {
+    if options.purge_config && options.keep_config {
+        outcome.warnings.push(
+            "--purge-config was ignored because --keep-config was also set; preserving configuration"
+                .to_string(),
+        );
     }
 }
 
@@ -720,6 +731,32 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[test]
+    fn purge_config_keep_config_conflict_reports_warning() {
+        let mut outcome = UninstallOutcome {
+            dry_run: false,
+            removed: Vec::new(),
+            scheduled_removal: Vec::new(),
+            already_absent: Vec::new(),
+            warnings: Vec::new(),
+        };
+        let opts = UninstallOptions {
+            purge_config: true,
+            keep_config: true,
+            ..options()
+        };
+
+        add_option_warnings(&opts, &mut outcome);
+
+        assert_eq!(
+            outcome.warnings,
+            vec![
+                "--purge-config was ignored because --keep-config was also set; preserving configuration"
+                    .to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/mesh-llm/src/commands/discover.rs
+++ b/crates/mesh-llm/src/commands/discover.rs
@@ -220,19 +220,16 @@ pub(crate) fn run_stop() -> Result<()> {
             match outcome {
                 backend::TerminationOutcome::Graceful => {
                     eprintln!(
-                        "🧹 Terminated owner pid={} gracefully ({})",
+                        "  Terminated owner pid={} gracefully ({})",
                         target.pid, target.label
                     );
                 }
                 backend::TerminationOutcome::Killed => {
-                    eprintln!(
-                        "🧹 Force-killed owner pid={} ({})",
-                        target.pid, target.label
-                    );
+                    eprintln!("  Force-killed owner pid={} ({})", target.pid, target.label);
                 }
                 backend::TerminationOutcome::NotRunning => {
                     eprintln!(
-                        "🧹 Owner pid={} was already stopped ({})",
+                        "  Owner pid={} was already stopped ({})",
                         target.pid, target.label
                     );
                 }

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod download;
 mod models;
 mod plugin_cli;
 mod runtime;
+mod setup;
 
 use anyhow::Result;
 use mesh_llm_cli::{Cli, Command};
@@ -16,6 +17,7 @@ use self::download::dispatch_download_command;
 use self::models::dispatch_models_command;
 use self::plugin_cli::run_external_plugin_command;
 use self::runtime::{dispatch_runtime_command, run_drop, run_load, run_status};
+use self::setup::dispatch_setup_command;
 
 pub async fn dispatch(cli: &Cli) -> Result<bool> {
     let Some(cmd) = cli.command.as_ref() else {
@@ -50,6 +52,7 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
         Command::Runtime { command } => {
             dispatch_runtime_command(command.as_ref(), cli.config.as_deref()).await
         }
+        Command::Setup { .. } => dispatch_setup_command(cmd, cli.config.as_deref()).await,
         Command::Config { command } => dispatch_config_command(cli, command),
         Command::Doctor { command, json } => {
             dispatch_doctor_command(command.as_ref(), cli.config.as_deref(), *json).await

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -53,6 +53,30 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
             dispatch_runtime_command(command.as_ref(), cli.config.as_deref()).await
         }
         Command::Setup { .. } => dispatch_setup_command(cmd, cli.config.as_deref()).await,
+        Command::Uninstall {
+            dry_run,
+            yes,
+            keep_cache,
+            keep_service_files,
+            purge_config,
+            keep_config,
+            binary_path,
+            json,
+            verbose,
+        } => mesh_llm_commands::uninstall::run_uninstall_command(
+            mesh_llm_commands::uninstall::UninstallOptions {
+                dry_run: *dry_run,
+                yes: *yes,
+                keep_cache: *keep_cache,
+                keep_service_files: *keep_service_files,
+                purge_config: *purge_config,
+                keep_config: *keep_config,
+                binary_path: binary_path.clone(),
+                json: *json,
+                verbose: *verbose,
+            },
+            run_stop,
+        ),
         Command::Config { command } => dispatch_config_command(cli, command),
         Command::Doctor { command, json } => {
             dispatch_doctor_command(command.as_ref(), cli.config.as_deref(), *json).await

--- a/crates/mesh-llm/src/commands/runtime.rs
+++ b/crates/mesh-llm/src/commands/runtime.rs
@@ -114,13 +114,13 @@ pub(crate) async fn dispatch_runtime_command(
     }
 }
 
-struct NativeRuntimeConfigSelector {
+pub(crate) struct NativeRuntimeConfigSelector {
     mesh_version: String,
     skippy_abi: Option<String>,
     selection: Option<String>,
 }
 
-fn native_runtime_config_selector(
+pub(crate) fn native_runtime_config_selector(
     config_path: Option<&Path>,
 ) -> Result<Option<NativeRuntimeConfigSelector>> {
     let config = load_config(config_path)?;
@@ -134,7 +134,7 @@ fn native_runtime_config_selector(
     })
 }
 
-fn native_runtime_command_selection<'a>(
+pub(crate) fn native_runtime_command_selection<'a>(
     selector: Option<&'a NativeRuntimeConfigSelector>,
 ) -> NativeRuntimeConfigSelection<'a> {
     NativeRuntimeConfigSelection {

--- a/crates/mesh-llm/src/commands/setup.rs
+++ b/crates/mesh-llm/src/commands/setup.rs
@@ -1,0 +1,104 @@
+use super::runtime::{native_runtime_command_selection, native_runtime_config_selector};
+use anyhow::{Result, bail};
+use mesh_llm_cli::Command;
+use mesh_llm_commands::setup::{SetupCommandArgs, SetupEnvironment, SetupOptions, SetupPlatform};
+use std::io::IsTerminal;
+use std::path::Path;
+
+pub(crate) async fn dispatch_setup_command(
+    cmd: &Command,
+    config_path: Option<&Path>,
+) -> Result<()> {
+    let selector = native_runtime_config_selector(config_path)?;
+    let args = setup_command_args(cmd, native_runtime_command_selection(selector.as_ref()))?;
+    mesh_llm_commands::setup::run_setup_command(args).await
+}
+
+fn setup_command_args<'a>(
+    cmd: &Command,
+    configured: mesh_llm_commands::runtime_native::NativeRuntimeConfigSelection<'a>,
+) -> Result<SetupCommandArgs<'a>> {
+    let Command::Setup {
+        yes,
+        no_interactive,
+        service,
+        no_service,
+        skip_runtime,
+    } = cmd
+    else {
+        bail!("dispatch_setup_command called for non-setup command");
+    };
+
+    Ok(SetupCommandArgs {
+        options: SetupOptions {
+            yes: *yes,
+            no_interactive: *no_interactive,
+            service: *service,
+            no_service: *no_service,
+            skip_runtime: *skip_runtime,
+        },
+        environment: SetupEnvironment {
+            platform: current_setup_platform(),
+            interactive: std::io::stdin().is_terminal() && std::io::stderr().is_terminal(),
+        },
+        configured,
+    })
+}
+
+fn current_setup_platform() -> SetupPlatform {
+    match std::env::consts::OS {
+        "linux" => SetupPlatform::Linux,
+        "macos" => SetupPlatform::MacOs,
+        "windows" => SetupPlatform::Windows,
+        _ => SetupPlatform::Linux,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_dispatch_maps_cli_booleans_directly_into_setup_options() {
+        let args = setup_command_args(
+            &Command::Setup {
+                yes: true,
+                no_interactive: false,
+                service: true,
+                no_service: false,
+                skip_runtime: true,
+            },
+            mesh_llm_commands::runtime_native::NativeRuntimeConfigSelection::default(),
+        )
+        .expect("setup args should build");
+
+        assert_eq!(
+            args.options,
+            SetupOptions {
+                yes: true,
+                no_interactive: false,
+                service: true,
+                no_service: false,
+                skip_runtime: true,
+            }
+        );
+    }
+
+    #[test]
+    fn setup_dispatch_rejects_doctor_commands_instead_of_falling_through() {
+        let error = setup_command_args(
+            &Command::Doctor {
+                json: false,
+                command: None,
+            },
+            mesh_llm_commands::runtime_native::NativeRuntimeConfigSelection::default(),
+        )
+        .expect_err("doctor command must not route through setup dispatch");
+
+        assert!(
+            error
+                .to_string()
+                .contains("dispatch_setup_command called for non-setup command")
+        );
+    }
+}

--- a/crates/mesh-llm/src/commands/setup.rs
+++ b/crates/mesh-llm/src/commands/setup.rs
@@ -24,6 +24,7 @@ fn setup_command_args<'a>(
         service,
         no_service,
         skip_runtime,
+        verbose,
     } = cmd
     else {
         bail!("dispatch_setup_command called for non-setup command");
@@ -36,6 +37,7 @@ fn setup_command_args<'a>(
             service: *service,
             no_service: *no_service,
             skip_runtime: *skip_runtime,
+            verbose: *verbose,
         },
         environment: SetupEnvironment {
             platform: current_setup_platform(),
@@ -67,6 +69,7 @@ mod tests {
                 service: true,
                 no_service: false,
                 skip_runtime: true,
+                verbose: true,
             },
             mesh_llm_commands::runtime_native::NativeRuntimeConfigSelection::default(),
         )
@@ -80,6 +83,7 @@ mod tests {
                 service: true,
                 no_service: false,
                 skip_runtime: true,
+                verbose: true,
             }
         );
     }

--- a/crates/mesh-llm/src/commands/setup.rs
+++ b/crates/mesh-llm/src/commands/setup.rs
@@ -40,19 +40,23 @@ fn setup_command_args<'a>(
             verbose: *verbose,
         },
         environment: SetupEnvironment {
-            platform: current_setup_platform(),
+            platform: current_setup_platform()?,
             interactive: std::io::stdin().is_terminal() && std::io::stderr().is_terminal(),
         },
         configured,
     })
 }
 
-fn current_setup_platform() -> SetupPlatform {
-    match std::env::consts::OS {
-        "linux" => SetupPlatform::Linux,
-        "macos" => SetupPlatform::MacOs,
-        "windows" => SetupPlatform::Windows,
-        _ => SetupPlatform::Linux,
+fn current_setup_platform() -> Result<SetupPlatform> {
+    setup_platform_from_os(std::env::consts::OS)
+}
+
+fn setup_platform_from_os(os: &str) -> Result<SetupPlatform> {
+    match os {
+        "linux" => Ok(SetupPlatform::Linux),
+        "macos" => Ok(SetupPlatform::MacOs),
+        "windows" => Ok(SetupPlatform::Windows),
+        _ => bail!("mesh-llm setup is not supported on {os}"),
     }
 }
 
@@ -103,6 +107,17 @@ mod tests {
             error
                 .to_string()
                 .contains("dispatch_setup_command called for non-setup command")
+        );
+    }
+
+    #[test]
+    fn setup_platform_rejects_unknown_operating_systems() {
+        let error = setup_platform_from_os("freebsd").expect_err("unsupported OS should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("mesh-llm setup is not supported on freebsd")
         );
     }
 }

--- a/crates/mesh-llm/tests/virtual_llm_injection.rs
+++ b/crates/mesh-llm/tests/virtual_llm_injection.rs
@@ -311,7 +311,7 @@ async fn test_injection_framing() {
         let display = if content.is_empty() {
             format!(
                 "(reasoning only) {}",
-                &reasoning.chars().take(100).collect::<String>()
+                reasoning.chars().take(100).collect::<String>()
             )
         } else {
             content.chars().take(100).collect::<String>()
@@ -349,7 +349,7 @@ async fn test_injection_framing() {
             let display = if content.is_empty() {
                 format!(
                     "(reasoning only) {}",
-                    &reasoning.chars().take(100).collect::<String>()
+                    reasoning.chars().take(100).collect::<String>()
                 )
             } else {
                 content.chars().take(100).collect::<String>()

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -10,6 +10,8 @@ Catalog id definition: a catalog id is the model id shown in `mesh-llm models re
 ```bash
 mesh-llm --help
 mesh-llm <command> --help
+mesh-llm setup --help
+mesh-llm doctor --help
 mesh-llm models --help
 mesh-llm models <subcommand> --help
 ```
@@ -18,32 +20,44 @@ mesh-llm models <subcommand> --help
 
 If you want to:
 
-1. Start serving right away:
+1. Finish a fresh install:
+
+```bash
+mesh-llm setup
+```
+
+2. Start serving on this machine:
+
+```bash
+mesh-llm serve --model Qwen3-0.6B-Q4_K_M
+```
+
+3. Join the public mesh:
 
 ```bash
 mesh-llm serve --auto
 ```
 
-2. Find a model you can run:
+4. Find a model you can run:
 
 ```bash
 mesh-llm models search gemma --gguf
 mesh-llm models search smoll --mlx
 ```
 
-3. Inspect a model before downloading:
+5. Inspect a model before downloading:
 
 ```bash
 mesh-llm models show unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL
 ```
 
-4. Download a model:
+6. Download a model:
 
 ```bash
 mesh-llm models download unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL
 ```
 
-5. Check what is already installed:
+7. Check what is already installed:
 
 ```bash
 mesh-llm models installed
@@ -56,10 +70,54 @@ If you want to start serving, join a mesh, or run as an API-only client, start h
 Examples:
 
 ```bash
+mesh-llm setup
 mesh-llm serve
 mesh-llm serve --model Qwen3-0.6B-Q4_K_M
 mesh-llm client --auto
 ```
+
+### `setup`
+
+Use this to finish a fresh install after the executable is on your `PATH`.
+
+`mesh-llm setup` downloads and configures the native runtime, can install and
+enable the background service on supported macOS and Linux machines, and only
+shows the GitHub star prompt when it is interactive and eligible. The star
+prompt defaults to Yes, and `--yes` or `--no-interactive` skip it without
+starring anything.
+
+Usage:
+
+```bash
+mesh-llm setup
+mesh-llm setup --service
+mesh-llm setup --no-service --skip-runtime
+mesh-llm setup --yes
+```
+
+Switches:
+
+- `--yes`: automatically answer yes to setup prompts. This accepts the service prompt and skips the GitHub star prompt.
+- `--no-interactive`: run without prompting. When service is not requested, setup prints guidance to rerun with `--service`.
+- `--service`: install and enable the background service.
+- `--no-service`: skip installing and enabling the background service.
+- `--skip-runtime`: skip downloading or configuring the native runtime.
+
+On Windows, `--service` is unsupported.
+
+### `doctor`
+
+Use this only when troubleshooting a failed install or runtime problem. It gathers local status, runtime diagnostics, and logs.
+
+Usage:
+
+```bash
+mesh-llm doctor
+```
+
+Switches:
+
+- `--json`: machine-readable output.
 
 Runtime switches:
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -11,6 +11,7 @@ Catalog id definition: a catalog id is the model id shown in `mesh-llm models re
 mesh-llm --help
 mesh-llm <command> --help
 mesh-llm setup --help
+mesh-llm uninstall --help
 mesh-llm doctor --help
 mesh-llm models --help
 mesh-llm models <subcommand> --help
@@ -63,6 +64,13 @@ mesh-llm models download unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL
 mesh-llm models installed
 ```
 
+8. Remove the executable and setup-owned files:
+
+```bash
+mesh-llm uninstall --dry-run
+mesh-llm uninstall --yes
+```
+
 ## Runtime entrypoints (`serve` / `client`)
 
 If you want to start serving, join a mesh, or run as an API-only client, start here.
@@ -84,7 +92,8 @@ Use this to finish a fresh install after the executable is on your `PATH`.
 enable the background service on supported macOS and Linux machines, and only
 shows the GitHub star prompt when it is interactive and eligible. The star
 prompt defaults to Yes, and `--yes` or `--no-interactive` skip it without
-starring anything.
+starring anything. Default output is concise; use `--verbose` when you want
+service paths, commands, log locations, and detailed setup status.
 
 Usage:
 
@@ -93,6 +102,7 @@ mesh-llm setup
 mesh-llm setup --service
 mesh-llm setup --no-service --skip-runtime
 mesh-llm setup --yes
+mesh-llm setup --verbose
 ```
 
 Switches:
@@ -102,8 +112,46 @@ Switches:
 - `--service`: install and enable the background service.
 - `--no-service`: skip installing and enabling the background service.
 - `--skip-runtime`: skip downloading or configuring the native runtime.
+- `--verbose`: print detailed service paths, commands, log locations, and setup status.
 
 On Windows, `--service` is unsupported.
+
+### `uninstall`
+
+Use this to remove a Mesh executable install and setup-owned service/runtime files from a machine.
+
+By default, uninstall stops tracked `mesh-llm` processes, disables and removes
+the per-user service when present, removes setup-owned service helper files,
+removes the native-runtime cache, and removes the executable last. It preserves
+`~/.mesh-llm` configuration and identity data unless you explicitly pass
+`--purge-config`.
+
+Usage:
+
+```bash
+mesh-llm uninstall --dry-run
+mesh-llm uninstall --yes
+mesh-llm uninstall --yes --keep-cache
+mesh-llm uninstall --yes --purge-config
+mesh-llm uninstall --verbose --dry-run
+```
+
+Switches:
+
+- `--dry-run`: print the cleanup plan without changing the machine.
+- `--yes`: run without a confirmation prompt.
+- `--json`: print dry-run plans and outcomes as JSON.
+- `--verbose`: print detailed cleanup steps and removed paths.
+- `--keep-cache`: preserve downloaded native runtimes.
+- `--keep-service-files`: preserve setup-owned service helper files.
+- `--purge-config`: remove `~/.mesh-llm` configuration and identity data.
+- `--keep-config`: explicitly preserve configuration and identity data.
+- `--binary-path <PATH>`: remove a specific executable path.
+
+If the setup service configuration directory contains unrelated files,
+uninstall leaves that directory in place and reports a warning instead of
+recursively deleting it. Default text output is concise; use `--verbose` when
+you want the full cleanup plan or exact removed paths.
 
 ### `doctor`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Use this hub to find project guides that are not owned by a single Rust crate.
 | [skippy/DATA_FLOW.md](skippy/DATA_FLOW.md) | Stage data flow and transport details |
 | [skippy/LLAMA_PARITY.md](skippy/LLAMA_PARITY.md) | Remaining llama.cpp parity queue |
 | [specs/layer-package-repos.md](specs/layer-package-repos.md) | Manifest schema and package artifact rules |
+| [specs/mesh-setup-installer.md](specs/mesh-setup-installer.md) | Bootstrap installer and `mesh-llm setup` ownership boundary |
 | [SKIPPY.md](SKIPPY.md) | Skippy integration readiness and parity notes |
 
 Use [SKIPPY_SPLITS.md](SKIPPY_SPLITS.md) for Skippy split-serving workflows.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,13 +1,13 @@
 # Usage Guide
 
-Use this operational reference for installation details, service mode, model
-storage, and runtime control.
+Use this operational reference for installation details, setup, service mode,
+model storage, and runtime control.
 
 For command-by-command CLI usage, model resolution rules, and JSON automation examples, see [CLI.md](./CLI.md).
 
 ## Installation details
 
-Install the latest release bundle:
+Install the latest release executable:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash
@@ -25,34 +25,9 @@ To opt into the latest published prerelease bundle instead:
 curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash -s -- --pre-release
 ```
 
-The installer probes your machine, recommends a flavor, and asks what to install.
-
-For a non-interactive install, set the flavor explicitly:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | MESH_LLM_INSTALL_FLAVOR=vulkan bash
-```
-
-On Windows:
-
-```powershell
-$env:MESH_LLM_INSTALL_FLAVOR = "vulkan"
-irm https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.ps1 | iex
-```
-
-Release bundles install the `mesh-llm` host binary plus the flavor-specific
-native runtime libraries it embeds. Normal serving runs inside the `mesh-llm`
-host process, which loads the Skippy/llama.cpp stage runtime directly.
-
-Published bundle flavors include macOS, Linux CPU, Linux ARM64 CPU, Linux ARM64
-CUDA, Linux CUDA, Linux CUDA Blackwell, Linux ROCm, Linux Vulkan, Windows CPU,
-Windows CUDA, Windows ROCm, and Windows Vulkan. Metal remains macOS-only.
-
-If you keep more than one flavor in the same `bin` directory, choose one explicitly:
-
-```bash
-mesh-llm serve --llama-flavor vulkan --model Qwen2.5-32B
-```
+The installer puts `mesh-llm` on your `PATH`. After install, run `mesh-llm setup`
+to finish runtime configuration and, on supported macOS and Linux machines,
+optionally install the background service.
 
 Source builds must use `just`:
 
@@ -81,6 +56,7 @@ For full build details, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 ## Common commands
 
 ```bash
+mesh-llm setup
 mesh-llm serve --auto
 mesh-llm serve --model Qwen2.5-32B
 mesh-llm serve --join <token>
@@ -126,46 +102,11 @@ Use `--debug-telemetry` when proving speculative decoding behavior: each trial l
 
 Use `mesh-llm gpus detect` when you want to refresh the raw hardware fingerprint, bandwidth, and compute hints rather than benchmark model-serving throughput.
 
-## Background service
+## Setup
 
-To install Mesh LLM as a per-user background service:
+Use `mesh-llm setup` after the executable is installed. It configures the native runtime and can install the background service on supported macOS and Linux machines.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash -s -- --service
-```
-
-Service installs are user-scoped:
-
-- macOS installs a `launchd` agent at `~/Library/LaunchAgents/com.mesh-llm.mesh-llm.plist`
-- Linux installs a `systemd --user` unit at `~/.config/systemd/user/mesh-llm.service`
-- Shared environment config lives in `~/.config/mesh-llm/service.env`
-- Startup models live in `~/.mesh-llm/config.toml`
-
-Platform behavior:
-
-- macOS loads `service.env` and then executes `mesh-llm serve`
-- Linux writes `mesh-llm serve` directly into `ExecStart=`
-
-The background service reads startup models from `~/.mesh-llm/config.toml`.
-
-Optional shared environment file example:
-
-```text
-MESH_LLM_NO_SELF_UPDATE=1
-```
-
-If you edit the Linux unit manually:
-
-```bash
-systemctl --user daemon-reload
-systemctl --user restart mesh-llm.service
-```
-
-If you want the service to survive reboot before login:
-
-```bash
-sudo loginctl enable-linger "$USER"
-```
+See [CLI.md](./CLI.md) for the setup flags and the service options.
 
 ## Model catalog
 

--- a/docs/specs/mesh-setup-installer.md
+++ b/docs/specs/mesh-setup-installer.md
@@ -30,6 +30,8 @@ command instead.
 - detect the host platform and architecture
 - download the matching release archive
 - verify checksum sidecars when available
+- warn and continue when a `.sha256` checksum sidecar is missing by default;
+  fail closed only when `MESH_LLM_REQUIRE_CHECKSUM=1` is set
 - install the `mesh-llm` executable into the selected directory
 - update or print PATH guidance
 - run or print `mesh-llm setup`

--- a/docs/specs/mesh-setup-installer.md
+++ b/docs/specs/mesh-setup-installer.md
@@ -55,6 +55,8 @@ Supported flags:
 - `--service`: request background service setup where supported.
 - `--no-service`: skip background service setup.
 - `--skip-runtime`: skip native-runtime install and prune.
+- `--verbose`: print detailed setup paths, commands, log locations, and
+  status. Default setup output is concise and formatted for interactive use.
 
 Unsupported in v1:
 
@@ -112,7 +114,7 @@ Eligibility:
 The prompt defaults to Yes:
 
 ```text
-Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account? [Y/n]
+Star Mesh-LLM/mesh-llm on GitHub? [Y/n]
 ```
 
 `--yes`, `--no-interactive`, hidden prompts, missing `gh`, unauthenticated
@@ -122,11 +124,49 @@ starring only happens after the visible prompt is accepted.
 
 ## Final Summary
 
-Setup output must separate:
+Default setup output must provide a concise formatted completion summary. The
+summary must separate:
 
 - runtime installed, skipped, or installed-with-prune-warning
 - service installed, skipped, guidance-only, or failed
-- GitHub star completed, skipped, already present, or non-fatally failed
+- GitHub star completed, already present, or non-fatally failed when those
+  outcomes occur
+
+Detailed paths, generated service commands, log commands, and follow-up
+diagnostic status, including exact GitHub skip reasons, belong behind
+`--verbose`.
 
 `mesh-llm doctor` remains a separate troubleshooting command and is not part of
 normal setup.
+
+## Uninstall Command
+
+`mesh-llm uninstall` owns automated cleanup after the executable has been
+installed. It is intentionally implemented in Rust, not in the bootstrap
+scripts, so it can reuse the same platform path decisions as setup and remove
+the running binary last.
+
+Supported flags:
+
+- `--yes`: run without confirmation.
+- `--dry-run`: print the planned cleanup without changing the machine.
+- `--json`: print dry-run plans and outcomes as JSON.
+- `--verbose`: print detailed cleanup steps and removed paths. Default text
+  output is concise and formatted for interactive use.
+- `--keep-cache`: preserve downloaded native runtimes.
+- `--keep-service-files`: preserve setup-owned service helper files.
+- `--purge-config`: remove `~/.mesh-llm` configuration and identity data.
+- `--keep-config`: explicitly preserve configuration and identity data.
+  `--purge-config` and `--keep-config` are mutually exclusive; CLI parsing must
+  reject invocations that provide both flags.
+- `--binary-path <PATH>`: remove a specific executable path.
+
+Default uninstall behavior stops tracked `mesh-llm` processes, disables and
+removes the per-user Linux systemd unit or macOS launchd agent when present,
+removes setup-owned service helper files, removes the native-runtime cache, and
+then removes the executable. It preserves `~/.mesh-llm` by default so keys,
+identity, and user configuration are not deleted accidentally.
+
+The command removes only known setup-owned service files. If the setup service
+configuration directory contains unrelated files, uninstall leaves that
+directory in place and reports a warning instead of recursively deleting it.

--- a/docs/specs/mesh-setup-installer.md
+++ b/docs/specs/mesh-setup-installer.md
@@ -1,0 +1,132 @@
+# Mesh Setup Installer
+
+This spec defines the v1 install and setup boundary for Mesh LLM.
+
+## User Flow
+
+The public install flow is two-stage:
+
+```sh
+curl -fsSL https://meshllm.cloud/install.sh | bash
+mesh-llm setup
+```
+
+On Windows:
+
+```powershell
+irm https://meshllm.cloud/install.ps1 | iex
+mesh-llm.exe setup
+```
+
+The bootstrap scripts may run setup automatically when attached to an
+interactive terminal. In non-interactive contexts they print the exact setup
+command instead.
+
+## Bootstrap Scripts
+
+`install.sh` and `install.ps1` own only first-stage executable installation:
+
+- parse minimal bootstrap flags
+- detect the host platform and architecture
+- download the matching release archive
+- verify checksum sidecars when available
+- install the `mesh-llm` executable into the selected directory
+- update or print PATH guidance
+- run or print `mesh-llm setup`
+
+They must not own native-runtime flavor selection, GPU/backend detection,
+runtime install or prune, service setup, doctor/readiness interpretation, or
+GitHub account mutations.
+
+Legacy script service/runtime flags may emit compatibility warnings or forward
+direct setup flags, but they must not reintroduce shell or PowerShell-owned
+runtime or service policy.
+
+## Setup Command
+
+`mesh-llm setup` owns machine setup after the executable exists. CLI parsing
+lives in `crates/mesh-llm-cli`, binary dispatch in `crates/mesh-llm`, and setup
+orchestration in `crates/mesh-llm-commands`.
+
+Supported flags:
+
+- `--yes`: accept recommended core setup defaults without prompting.
+- `--no-interactive`: never prompt; use non-interactive defaults.
+- `--service`: request background service setup where supported.
+- `--no-service`: skip background service setup.
+- `--skip-runtime`: skip native-runtime install and prune.
+
+Unsupported in v1:
+
+- `--skip-doctor`
+- setup-owned doctor/readiness flow
+- Windows service creation
+- startup model, public/private mesh, or telemetry prompts
+- a separate installer binary
+
+## Runtime Setup
+
+Unless `--skip-runtime` is passed, setup installs the recommended or configured
+native runtime and then prunes inactive runtime artifacts.
+
+Runtime selection must reuse `mesh-llm-runtime-install` and the existing
+`runtime_native` resolver/config-selection plumbing. Setup and scripts must not
+duplicate native runtime candidate scoring or hardware detection.
+
+Runtime install failure is a core setup failure. Runtime prune failure after a
+successful install is reported as a warning because the installed runtime is
+usable.
+
+## Service Setup
+
+Service setup is supported for:
+
+- Linux systemd user units
+- macOS launchd agents
+
+Windows `mesh-llm setup --service` is a hard unsupported-service error. Default
+Windows setup and `--no-service` continue without service setup.
+
+Interactive Unix setup prompts for service installation and defaults to Yes.
+`--yes` accepts service setup unless `--no-service` is also present.
+Non-interactive setup prints service opt-in guidance unless `--service` is
+explicitly supplied.
+
+When service setup is requested or accepted, service installation, enablement,
+and startup failures are core setup failures. Setup must not silently escalate
+privileges; it writes per-user service files and surfaces permission or command
+failures.
+
+## GitHub Star Prompt
+
+After successful core setup, an interactive setup may offer to star
+`Mesh-LLM/mesh-llm` using the already-authenticated GitHub CLI account.
+
+Eligibility:
+
+- `gh` is on PATH
+- `gh auth status --active --hostname github.com` succeeds
+- the authenticated viewer has not already starred the repo
+- a visible interactive prompt is shown
+
+The prompt defaults to Yes:
+
+```text
+Star Mesh-LLM/mesh-llm on GitHub using your authenticated GitHub CLI account? [Y/n]
+```
+
+`--yes`, `--no-interactive`, hidden prompts, missing `gh`, unauthenticated
+`gh`, eligibility-check failures, already-starred state, and star-request
+failures must not fail core setup. No hidden account mutation is allowed:
+starring only happens after the visible prompt is accepted.
+
+## Final Summary
+
+Setup output must separate:
+
+- runtime installed, skipped, or installed-with-prune-warning
+- service installed, skipped, guidance-only, or failed
+- GitHub star completed, skipped, already present, or non-fatally failed
+
+`mesh-llm doctor` remains a separate troubleshooting command and is not part of
+normal setup.

--- a/install.ps1
+++ b/install.ps1
@@ -3,6 +3,7 @@ param(
     [string]$InstallDir = $env:MESH_LLM_INSTALL_DIR,
     [string]$Flavor,
     [switch]$NoPathUpdate,
+    [switch]$NoSetup,
     [switch]$Help
 )
 
@@ -10,12 +11,16 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 $Repo = if ($env:MESH_LLM_INSTALL_REPO) { $env:MESH_LLM_INSTALL_REPO } else { "Mesh-LLM/mesh-llm" }
+$HostArchive = "mesh-llm-x86_64-pc-windows-msvc.zip"
+$ReleaseUrlBase = $env:MESH_LLM_INSTALL_URL_BASE
 
 function Test-Truthy {
     param([string]$Value)
+
     if (-not $Value) {
         return $false
     }
+
     return @("1", "true", "yes", "on") -contains $Value.Trim().ToLowerInvariant()
 }
 
@@ -36,13 +41,14 @@ if (-not $InstallDir) {
 
 function Show-Usage {
     @"
-Usage: install.ps1 [-PreRelease] [-InstallDir <DIR>] [-Flavor <FLAVOR>] [-NoPathUpdate]
+Usage: install.ps1 [-PreRelease] [-InstallDir <DIR>] [-Flavor <FLAVOR>] [-NoPathUpdate] [-NoSetup]
 
 Options:
   -PreRelease             Install the latest published GitHub prerelease instead of the latest stable release.
   -InstallDir <DIR>       Install directory. Defaults to %LOCALAPPDATA%\mesh-llm\bin.
-  -Flavor <FLAVOR>        Release bundle flavor: cpu, cuda, cuda-blackwell, rocm, or vulkan.
+  -Flavor <FLAVOR>        Legacy compatibility flag. The installer always installs the Windows x64 host binary and `mesh-llm.exe setup` now chooses the runtime.
   -NoPathUpdate           Do not add the install directory to the user Path.
+  -NoSetup                Do not run `mesh-llm.exe setup`; print the exact command instead.
   -Help                   Show this help text.
 
 Environment overrides:
@@ -60,6 +66,10 @@ if ($Help) {
 }
 
 function Require-WindowsX64 {
+    if (Test-Truthy $env:MESH_LLM_INSTALL_TEST_ALLOW_NONWINDOWS) {
+        return
+    }
+
     if (-not $IsWindows -and $PSVersionTable.PSEdition -eq "Core") {
         throw "install.ps1 only supports native Windows. Use install.sh on macOS or Linux."
     }
@@ -68,190 +78,6 @@ function Require-WindowsX64 {
     if ($arch -ne "X64") {
         throw "unsupported Windows architecture: $arch. Published Windows release bundles target x86_64."
     }
-}
-
-function Test-Command {
-    param([string]$Name)
-    return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
-}
-
-function Normalize-CudaCapability {
-    param([string]$Value)
-    return ($Value -replace "[^0-9]", "")
-}
-
-function Test-CudaBlackwell {
-    if (Test-Command "nvidia-smi") {
-        try {
-            $caps = & nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>$null
-            foreach ($cap in $caps) {
-                $normalized = Normalize-CudaCapability $cap
-                if ($normalized -match "^[0-9]+$" -and [int]$normalized -ge 100 -and [int]$normalized -lt 200) {
-                    return $true
-                }
-            }
-        } catch {
-        }
-
-        try {
-            $names = & nvidia-smi --query-gpu=name --format=csv,noheader 2>$null
-            foreach ($name in $names) {
-                if (Test-NvidiaModelBlackwell $name) {
-                    return $true
-                }
-            }
-        } catch {
-        }
-    }
-
-    try {
-        $controllers = Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue
-        foreach ($controller in $controllers) {
-            if ($controller.Name -and (Test-NvidiaModelBlackwell $controller.Name)) {
-                return $true
-            }
-        }
-    } catch {
-    }
-
-    return $false
-}
-
-function Test-NvidiaModelBlackwell {
-    param([string]$Name)
-    $upper = $Name.ToUpperInvariant()
-    return $upper -match "BLACKWELL|GB300|B300|GB200|B200|B100|GB10|THOR|RTX 5090|RTX 5080|RTX 5070|RTX 5060|RTX 5050|RTX PRO 6000"
-}
-
-function Test-Nvidia {
-    if ((Test-Command "nvidia-smi") -or (Test-Command "nvcc")) {
-        return $true
-    }
-
-    try {
-        $controllers = Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue
-        foreach ($controller in $controllers) {
-            if ($controller.Name -and $controller.Name.ToUpperInvariant().Contains("NVIDIA")) {
-                return $true
-            }
-        }
-    } catch {
-    }
-
-    return $false
-}
-
-function Test-Rocm {
-    if ((Test-Command "rocm-smi") -or (Test-Command "rocminfo") -or (Test-Command "hipcc")) {
-        return $true
-    }
-
-    foreach ($path in @(
-        "$env:ProgramFiles\AMD\ROCm",
-        "$env:ProgramFiles\AMD\ROCm*\bin\hipcc.exe",
-        "$env:ProgramFiles\AMD\ROCm*\bin\rocminfo.exe"
-    )) {
-        if ($path -and (Test-Path $path)) {
-            return $true
-        }
-    }
-
-    return $false
-}
-
-function Test-Vulkan {
-    if ((Test-Command "vulkaninfo") -or (Test-Command "glslc")) {
-        return $true
-    }
-    if ($env:VULKAN_SDK -and (Test-Path $env:VULKAN_SDK)) {
-        return $true
-    }
-    return $false
-}
-
-function Get-SupportedFlavors {
-    return @("cuda-blackwell", "cuda", "rocm", "vulkan", "cpu")
-}
-
-function Get-RecommendedFlavor {
-    if (Test-CudaBlackwell) {
-        return "cuda-blackwell"
-    }
-    if (Test-Nvidia) {
-        return "cuda"
-    }
-    if (Test-Rocm) {
-        return "rocm"
-    }
-    if (Test-Vulkan) {
-        return "vulkan"
-    }
-    return "cpu"
-}
-
-function Get-RecommendationReason {
-    param([string]$SelectedFlavor)
-    switch ($SelectedFlavor) {
-        "cuda-blackwell" { return "Blackwell NVIDIA hardware was detected." }
-        "cuda" { return "NVIDIA tooling or devices were detected." }
-        "rocm" { return "ROCm/HIP tooling was detected." }
-        "vulkan" { return "Vulkan tooling was detected." }
-        "cpu" { return "No supported GPU runtime was detected." }
-        default { return "Flavor was selected explicitly." }
-    }
-}
-
-function Choose-Flavor {
-    if ($Flavor) {
-        if ((Get-SupportedFlavors) -notcontains $Flavor) {
-            throw "unsupported Windows flavor '$Flavor'"
-        }
-        return $Flavor
-    }
-
-    $recommended = Get-RecommendedFlavor
-    if ([Console]::IsInputRedirected -or [Console]::IsOutputRedirected) {
-        return $recommended
-    }
-
-    $flavors = Get-SupportedFlavors
-    Write-Host "Mesh LLM installer"
-    Write-Host "Platform: Windows/x86_64"
-    Write-Host "Recommended flavor: $recommended"
-    Write-Host "Reason: $(Get-RecommendationReason $recommended)"
-    Write-Host ""
-    Write-Host "Available flavors:"
-    for ($i = 0; $i -lt $flavors.Count; $i++) {
-        $label = $flavors[$i]
-        if ($label -eq $recommended) {
-            $label = "$label (recommended)"
-        }
-        Write-Host ("  {0}. {1}" -f ($i + 1), $label)
-    }
-    Write-Host ""
-
-    $reply = Read-Host "Install which flavor? [$recommended]"
-    if (-not $reply) {
-        return $recommended
-    }
-    if ($reply -match "^[0-9]+$") {
-        $index = [int]$reply - 1
-        if ($index -ge 0 -and $index -lt $flavors.Count) {
-            return $flavors[$index]
-        }
-    }
-    if ($flavors -contains $reply) {
-        return $reply
-    }
-    throw "unsupported Windows flavor '$reply'"
-}
-
-function Get-AssetName {
-    param([string]$SelectedFlavor)
-    if ($SelectedFlavor -eq "cpu") {
-        return "mesh-llm-x86_64-pc-windows-msvc.zip"
-    }
-    return "mesh-llm-x86_64-pc-windows-msvc-$SelectedFlavor.zip"
 }
 
 function Get-GitHubHeaders {
@@ -279,12 +105,30 @@ function Get-LatestPrereleaseTag {
     throw "could not find a published prerelease for $Repo"
 }
 
+function Join-UrlPath {
+    param(
+        [string]$Base,
+        [string]$Child
+    )
+
+    if ($Base.EndsWith("/")) {
+        return "$Base$Child"
+    }
+    return "$Base/$Child"
+}
+
 function Get-ReleaseUrl {
     param([string]$Asset)
+
+    if ($ReleaseUrlBase) {
+        return Join-UrlPath -Base $ReleaseUrlBase -Child $Asset
+    }
+
     if ($PreRelease) {
         $tag = Get-LatestPrereleaseTag
         return "https://github.com/$Repo/releases/download/$tag/$Asset"
     }
+
     return "https://github.com/$Repo/releases/latest/download/$Asset"
 }
 
@@ -295,6 +139,7 @@ function Get-ChecksumUrl {
 
 function Read-ExpectedSha256 {
     param([string]$Path)
+
     $content = Get-Content -Path $Path -Raw
     $match = [regex]::Match($content, "[A-Fa-f0-9]{64}")
     if (-not $match.Success) {
@@ -308,13 +153,6 @@ function Test-MissingChecksumResponse {
 
     $response = $ErrorRecord.Exception.Response
     if (-not $response) {
-        # Windows PowerShell 5.1 follows the GitHub release redirect and then,
-        # on a 404 target, surfaces the failure as a response-less WebException
-        # ("The request was aborted: The connection was closed unexpectedly.")
-        # rather than a clean 404 HttpWebResponse. Treat a response-less
-        # WebException as a missing sidecar so the warn-and-continue path
-        # remains reachable on 5.1. A genuinely required checksum is still
-        # enforced by the caller via $RequireSidecar.
         return $ErrorRecord.Exception -is [System.Net.WebException]
     }
 
@@ -346,6 +184,7 @@ function Assert-DownloadedFileChecksum {
         }
         throw "could not download checksum sidecar: $checksumUrl"
     }
+
     $expected = Read-ExpectedSha256 $checksumPath
     $actual = (Get-FileHash -Path $Path -Algorithm SHA256).Hash.ToLowerInvariant()
     if ($actual -ne $expected) {
@@ -354,29 +193,31 @@ function Assert-DownloadedFileChecksum {
     Write-Host "Verified checksum: $(Split-Path -Leaf $Path)"
 }
 
-function Get-StaleBinaryNames {
-    $names = @(
-        "mesh-llm",
-        "mesh-llm-cpu",
-        "mesh-llm-cuda",
-        "mesh-llm-cuda-blackwell",
-        "mesh-llm-rocm",
-        "mesh-llm-vulkan",
-        "rpc-server",
-        "llama-server",
-        "llama-moe-split",
-        "rpc-server-cpu",
-        "llama-server-cpu",
-        "rpc-server-cuda",
-        "llama-server-cuda",
-        "rpc-server-rocm",
-        "llama-server-rocm",
-        "rpc-server-vulkan",
-        "llama-server-vulkan"
-    )
-    foreach ($name in $names) {
-        "$name.exe"
+function Write-FlavorCompatibilityWarning {
+    if (-not $Flavor) {
+        return
     }
+
+    $legacyFlavor = $Flavor.Trim().ToLowerInvariant()
+    if (-not $legacyFlavor) {
+        return
+    }
+
+    Write-Warning "Ignoring legacy -Flavor '$legacyFlavor'. The Windows installer now always installs the x64 host binary; run `mesh-llm.exe setup` to choose the recommended runtime."
+}
+
+function Get-StaleBinaryNames {
+    @(
+        "mesh-llm.exe",
+        "mesh-llm-cpu.exe",
+        "mesh-llm-cuda.exe",
+        "mesh-llm-cuda-blackwell.exe",
+        "mesh-llm-rocm.exe",
+        "mesh-llm-vulkan.exe",
+        "rpc-server.exe",
+        "llama-server.exe",
+        "llama-moe-split.exe"
+    )
 }
 
 function Remove-StaleBinaries {
@@ -389,42 +230,21 @@ function Remove-StaleBinaries {
     }
 }
 
-function Install-Bundle {
+function Install-MeshBinary {
     param([string]$BundleDir)
+
+    $meshBinarySource = Join-Path $BundleDir "mesh-llm.exe"
+    if (-not (Test-Path $meshBinarySource)) {
+        throw "release archive did not contain mesh-bundle/mesh-llm.exe"
+    }
+
     Remove-StaleBinaries
-    Get-ChildItem -Path $BundleDir -Force | ForEach-Object {
-        Copy-Item -Path $_.FullName -Destination (Join-Path $InstallDir $_.Name) -Recurse -Force
-    }
-}
-
-function Install-RecommendedNativeRuntime {
-    param([string]$TempDir)
-    $meshBinary = Join-Path $InstallDir "mesh-llm.exe"
-    if (-not (Test-Path $meshBinary)) {
-        return
-    }
-
-    $manifestPath = Join-Path $TempDir "native-runtimes.json"
-    $manifestUrl = Get-ReleaseUrl "native-runtimes.json"
-    try {
-        Invoke-WebRequest -Uri $manifestUrl -OutFile $manifestPath
-        Assert-DownloadedFileChecksum -Path $manifestPath -Url $manifestUrl -RequireSidecar $true
-    } catch {
-        Write-Warning "Native runtime manifest was not available or could not be verified; skipping runtime install. $_"
-        return
-    }
-
-    & $meshBinary runtime install --manifest $manifestPath
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Native runtime install did not complete successfully."
-        return
-    }
-    & $meshBinary runtime prune --active-only
+    Copy-Item -Path $meshBinarySource -Destination (Join-Path $InstallDir "mesh-llm.exe") -Force
 }
 
 function Add-InstallDirToPath {
     if ($NoPathUpdate) {
-        return
+        return $false
     }
 
     $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -432,27 +252,59 @@ function Add-InstallDirToPath {
     if ($userPath) {
         $parts = $userPath -split ";"
     }
-    $alreadyPresent = $false
+
     foreach ($part in $parts) {
         if ($part.TrimEnd([char]'\') -ieq $InstallDir.TrimEnd([char]'\')) {
-            $alreadyPresent = $true
-            break
+            return $false
         }
     }
 
-    if (-not $alreadyPresent) {
-        $newPath = if ($userPath) { "$InstallDir;$userPath" } else { $InstallDir }
-        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
-        $env:Path = "$InstallDir;$env:Path"
-        Write-Host "Added $InstallDir to your user Path."
-        Write-Host "Open a new PowerShell session before running mesh-llm from PATH."
+    $newPath = if ($userPath) { "$InstallDir;$userPath" } else { $InstallDir }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    $env:Path = "$InstallDir;$env:Path"
+    Write-Host "Added $InstallDir to your user Path."
+    Write-Host "Open a new PowerShell session before running mesh-llm from PATH."
+    return $true
+}
+
+function Test-InteractiveSession {
+    if ($env:MESH_LLM_INSTALL_INTERACTIVE) {
+        return Test-Truthy $env:MESH_LLM_INSTALL_INTERACTIVE
+    }
+
+    if (-not [Environment]::UserInteractive) {
+        return $false
+    }
+
+    return -not [Console]::IsInputRedirected -and -not [Console]::IsOutputRedirected
+}
+
+function Format-SetupCommand {
+    param([string]$MeshBinary)
+    return "& `"$MeshBinary`" setup"
+}
+
+function Invoke-SetupOrPrint {
+    param([string]$MeshBinary)
+
+    $setupCommand = Format-SetupCommand -MeshBinary $MeshBinary
+    if ($NoSetup -or -not (Test-InteractiveSession)) {
+        Write-Host "Run this next:"
+        Write-Host $setupCommand
+        return
+    }
+
+    Write-Host "Running: $setupCommand"
+    & $MeshBinary setup
+    if ($LASTEXITCODE -ne 0) {
+        throw "mesh-llm.exe setup exited with code $LASTEXITCODE"
     }
 }
 
 Require-WindowsX64
+Write-FlavorCompatibilityWarning
 
-$selectedFlavor = Choose-Flavor
-$asset = Get-AssetName $selectedFlavor
+$asset = $HostArchive
 $url = Get-ReleaseUrl $asset
 $tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mesh-llm-install-" + [System.Guid]::NewGuid().ToString("N"))
 $archive = Join-Path $tmpRoot $asset
@@ -460,7 +312,7 @@ $archive = Join-Path $tmpRoot $asset
 New-Item -ItemType Directory -Path $tmpRoot -Force | Out-Null
 
 try {
-    Write-Host "Installing flavor: $selectedFlavor"
+    Write-Host "Installing Windows x64 host binary"
     if ($PreRelease) {
         Write-Host "Release channel: prerelease"
     } else {
@@ -477,15 +329,18 @@ try {
         throw "release archive did not contain mesh-bundle/"
     }
 
-    Install-Bundle $bundleDir
-    Install-RecommendedNativeRuntime $tmpRoot
-    Add-InstallDirToPath
+    Install-MeshBinary -BundleDir $bundleDir
+    $pathUpdated = Add-InstallDirToPath
 
-    Write-Host "Installed $asset to $InstallDir"
     $meshBinary = Join-Path $InstallDir "mesh-llm.exe"
-    if (Test-Path $meshBinary) {
-        & $meshBinary --version
+    Write-Host "Installed $asset to $InstallDir"
+    & $meshBinary --version
+
+    if ($NoPathUpdate -and -not $pathUpdated) {
+        Write-Host "Install directory was not added to PATH. Use the full command below until you add $InstallDir to PATH."
     }
+
+    Invoke-SetupOrPrint -MeshBinary $meshBinary
 } finally {
     if (Test-Path $tmpRoot) {
         Remove-Item $tmpRoot -Recurse -Force

--- a/install.ps1
+++ b/install.ps1
@@ -46,9 +46,9 @@ Usage: install.ps1 [-PreRelease] [-InstallDir <DIR>] [-Flavor <FLAVOR>] [-NoPath
 Options:
   -PreRelease             Install the latest published GitHub prerelease instead of the latest stable release.
   -InstallDir <DIR>       Install directory. Defaults to %LOCALAPPDATA%\mesh-llm\bin.
-  -Flavor <FLAVOR>        Legacy compatibility flag. The installer always installs the Windows x64 host binary and `mesh-llm.exe setup` now chooses the runtime.
+  -Flavor <FLAVOR>        Legacy compatibility flag. The installer always installs the Windows x64 host binary and ``mesh-llm.exe setup`` now chooses the runtime.
   -NoPathUpdate           Do not add the install directory to the user Path.
-  -NoSetup                Do not run `mesh-llm.exe setup`; print the exact command instead.
+  -NoSetup                Do not run ``mesh-llm.exe setup``; print the exact command instead.
   -Help                   Show this help text.
 
 Environment overrides:
@@ -203,7 +203,7 @@ function Write-FlavorCompatibilityWarning {
         return
     }
 
-    Write-Warning "Ignoring legacy -Flavor '$legacyFlavor'. The Windows installer now always installs the x64 host binary; run `mesh-llm.exe setup` to choose the recommended runtime."
+    Write-Warning "Ignoring legacy -Flavor '$legacyFlavor'. The Windows installer now always installs the x64 host binary; run ``mesh-llm.exe setup`` to choose the recommended runtime."
 }
 
 function Get-StaleBinaryNames {

--- a/install.sh
+++ b/install.sh
@@ -165,12 +165,32 @@ platform_arch() {
     case "$os/$arch" in
         Linux/amd64) printf 'x86_64\n' ;;
         Linux/arm64|Linux/aarch64) printf 'aarch64\n' ;;
+        Linux/arm|Linux/armv6l|Linux/armv6hf|Linux/armv7l|Linux/armv7hf) printf 'arm\n' ;;
         *) printf '%s\n' "$arch" ;;
     esac
 }
 
 platform_id() {
     printf '%s/%s\n' "$(platform_os)" "$(platform_arch)"
+}
+
+platform_support_status() {
+    case "$(platform_id)" in
+        Darwin/arm64|Linux/aarch64|Linux/x86_64) printf 'supported\n' ;;
+        Linux/arm) printf 'recognized-unsupported\n' ;;
+        *) printf 'unsupported\n' ;;
+    esac
+}
+
+platform_error_message() {
+    case "$(platform_support_status)" in
+        recognized-unsupported)
+            printf 'error: recognized but unsupported platform: %s (32-bit ARM release bundles are not published)\n' "$(platform_id)"
+            ;;
+        *)
+            printf 'error: unsupported platform: %s\n' "$(platform_id)"
+            ;;
+    esac
 }
 
 platform_asset_name() {
@@ -182,6 +202,188 @@ platform_asset_name() {
         *)
             echo "error: unsupported platform: $(platform_id)" >&2
             exit 1
+            ;;
+    esac
+}
+
+tegra_model_text() {
+    if [[ -n "${MESH_LLM_TEST_TEGRA_MODEL:-}" ]]; then
+        printf '%s\n' "$MESH_LLM_TEST_TEGRA_MODEL"
+        return 0
+    fi
+
+    local path
+    for path in \
+        /proc/device-tree/model \
+        /proc/device-tree/compatible \
+        /sys/firmware/devicetree/base/model \
+        /sys/firmware/devicetree/base/compatible; do
+        [[ -r "$path" ]] || continue
+        tr '\0' '\n' <"$path" 2>/dev/null || true
+        printf '\n'
+    done
+}
+
+probe_tegra_nvidia() {
+    local model
+    model="$(tegra_model_text | tr '[:lower:]' '[:upper:]')"
+    case "$model" in
+        *JETSON*|*TEGRA*|*ORIN*|*NVGPU*|*THOR*) return 0 ;;
+    esac
+
+    [[ -e /dev/nvhost-gpu ]] || [[ -e /dev/nvhost-ctrl-gpu ]]
+}
+
+probe_nvidia() {
+    command -v nvidia-smi >/dev/null 2>&1 ||
+        command -v nvcc >/dev/null 2>&1 ||
+        [[ -e /dev/nvidiactl ]] ||
+        [[ -d /proc/driver/nvidia/gpus ]] ||
+        probe_tegra_nvidia
+}
+
+probe_rocm() {
+    command -v rocm-smi >/dev/null 2>&1 ||
+        command -v rocminfo >/dev/null 2>&1 ||
+        command -v hipcc >/dev/null 2>&1 ||
+        [[ -x /opt/rocm/bin/hipcc ]]
+}
+
+probe_vulkan() {
+    if command -v vulkaninfo >/dev/null 2>&1 && vulkaninfo --summary >/dev/null 2>&1; then
+        return 0
+    fi
+    if command -v glslc >/dev/null 2>&1; then
+        if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists vulkan 2>/dev/null; then
+            return 0
+        fi
+        if [[ -f /usr/include/vulkan/vulkan.h || -f /usr/local/include/vulkan/vulkan.h ]]; then
+            return 0
+        fi
+        if [[ -n "${VULKAN_SDK:-}" ]]; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+supported_flavors() {
+    case "$(platform_support_status)" in
+        supported)
+            case "$(platform_id)" in
+                Darwin/arm64) printf 'metal\n' ;;
+                Linux/aarch64) printf 'cuda cpu\n' ;;
+                Linux/x86_64) printf 'cuda rocm vulkan cpu\n' ;;
+                *) platform_error_message >&2; return 1 ;;
+            esac
+            ;;
+        *)
+            platform_error_message >&2
+            return 1
+            ;;
+    esac
+}
+
+recommended_flavor() {
+    case "$(platform_support_status)" in
+        supported)
+            case "$(platform_id)" in
+                Darwin/arm64) printf 'metal\n' ;;
+                Linux/aarch64)
+                    if probe_nvidia; then
+                        printf 'cuda\n'
+                    else
+                        printf 'cpu\n'
+                    fi
+                    ;;
+                Linux/x86_64)
+                    if probe_nvidia; then
+                        printf 'cuda\n'
+                    elif probe_rocm; then
+                        printf 'rocm\n'
+                    elif probe_vulkan; then
+                        printf 'vulkan\n'
+                    else
+                        printf 'cpu\n'
+                    fi
+                    ;;
+                *) platform_error_message >&2; return 1 ;;
+            esac
+            ;;
+        *)
+            platform_error_message >&2
+            return 1
+            ;;
+    esac
+}
+
+detect_cuda_major() {
+    local ver=""
+    if command -v nvcc >/dev/null 2>&1; then
+        ver="$(nvcc --version 2>/dev/null | grep -oE 'release [0-9]+' | awk '{print $2}' | head -n 1)"
+    fi
+    if [[ -z "$ver" ]]; then
+        local lib
+        for lib in /usr/local/cuda*/targets/*/lib/libcudart.so.* /usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
+            if [[ -f "$lib" ]]; then
+                ver="$(basename "$lib" | grep -oE 'libcudart\\.so\\.[0-9]+' | awk -F. '{print $3}' | head -n 1)"
+                break
+            fi
+        done
+    fi
+    if [[ -z "$ver" ]]; then
+        ver="$(ldconfig -p 2>/dev/null | grep -oE 'libcudart\\.so\\.[0-9]+' | awk -F. '{print $3}' | sort -rn | head -n 1)"
+    fi
+    case "$ver" in
+        12|13) printf '%s\n' "$ver" ;;
+        *) printf '\n' ;;
+    esac
+}
+
+asset_name() {
+    local flavor="$1"
+    case "$(platform_support_status)" in
+        supported)
+            case "$(platform_id)" in
+                Darwin/arm64) printf 'mesh-llm-aarch64-apple-darwin.tar.gz\n' ;;
+                Linux/aarch64)
+                    case "$flavor" in
+                        cpu) printf 'mesh-llm-aarch64-unknown-linux-gnu.tar.gz\n' ;;
+                        cuda)
+                            local cuda_major
+                            cuda_major="$(detect_cuda_major)"
+                            if [[ -n "$cuda_major" ]]; then
+                                printf 'mesh-llm-aarch64-unknown-linux-gnu-cuda-%s.tar.gz\n' "$cuda_major"
+                            else
+                                printf 'mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz\n'
+                            fi
+                            ;;
+                        *) echo "error: unsupported aarch64 flavor '$flavor'" >&2; return 1 ;;
+                    esac
+                    ;;
+                Linux/x86_64)
+                    case "$flavor" in
+                        cpu) printf 'mesh-llm-x86_64-unknown-linux-gnu.tar.gz\n' ;;
+                        cuda)
+                            local cuda_major
+                            cuda_major="$(detect_cuda_major)"
+                            if [[ -n "$cuda_major" ]]; then
+                                printf 'mesh-llm-x86_64-unknown-linux-gnu-cuda-%s.tar.gz\n' "$cuda_major"
+                            else
+                                printf 'mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz\n'
+                            fi
+                            ;;
+                        rocm) printf 'mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz\n' ;;
+                        vulkan) printf 'mesh-llm-x86_64-unknown-linux-gnu-vulkan.tar.gz\n' ;;
+                        *) echo "error: unsupported Linux flavor '$flavor'" >&2; return 1 ;;
+                    esac
+                    ;;
+                *) platform_error_message >&2; return 1 ;;
+            esac
+            ;;
+        *)
+            platform_error_message >&2
+            return 1
             ;;
     esac
 }

--- a/install.sh
+++ b/install.sh
@@ -482,7 +482,7 @@ sha256_file() {
 checksum_from_sidecar() {
     local sidecar="$1"
     local expected
-    expected="$(awk 'match($0, /[A-Fa-f0-9]{64}/) { print substr($0, RSTART, RLENGTH); exit }' "$sidecar" | tr '[:upper:]' '[:lower:]')"
+    expected="$(LC_ALL=C grep -Eio '[[:xdigit:]]{64}' "$sidecar" | head -n 1 | tr '[:upper:]' '[:lower:]' || true)"
     if [[ -z "$expected" ]]; then
         echo "error: checksum sidecar did not contain a SHA-256 digest: $sidecar" >&2
         return 1

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ INSTALL_PRERELEASE="${MESH_LLM_INSTALL_PRERELEASE:-0}"
 INSTALL_SERVICE="${MESH_LLM_INSTALL_SERVICE:-0}"
 INSTALL_SERVICE_ARGS="${MESH_LLM_INSTALL_SERVICE_ARGS:-}"
 INSTALL_SERVICE_START="${MESH_LLM_INSTALL_SERVICE_START:-1}"
+RELEASE_URL_BASE="${MESH_LLM_INSTALL_URL_BASE:-}"
 REQUIRE_CHECKSUM="${MESH_LLM_REQUIRE_CHECKSUM:-0}"
 AUTO_SETUP=1
 DOWNLOADED_ARCHIVE=""
@@ -61,6 +62,7 @@ mesh-llm setup instead of installing services in shell.
 
 Environment overrides:
   MESH_LLM_INSTALL_DIR
+  MESH_LLM_INSTALL_URL_BASE  Override release asset base URL for testing.
   MESH_LLM_INSTALL_PRERELEASE=1
   MESH_LLM_INSTALL_FLAVOR    Legacy compatibility variable. Ignored with a warning.
   MESH_LLM_INSTALL_SERVICE=1 Legacy compatibility variable. Passed through as --service.
@@ -219,6 +221,10 @@ latest_prerelease_tag() {
 
 release_url() {
     local asset="$1"
+    if [[ -n "$RELEASE_URL_BASE" ]]; then
+        printf '%s/%s\n' "${RELEASE_URL_BASE%/}" "$asset"
+        return 0
+    fi
     if bool_is_true "$INSTALL_PRERELEASE"; then
         local tag
         tag="$(latest_prerelease_tag)"

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ INSTALL_SERVICE_ARGS="${MESH_LLM_INSTALL_SERVICE_ARGS:-}"
 INSTALL_SERVICE_START="${MESH_LLM_INSTALL_SERVICE_START:-1}"
 RELEASE_URL_BASE="${MESH_LLM_INSTALL_URL_BASE:-}"
 REQUIRE_CHECKSUM="${MESH_LLM_REQUIRE_CHECKSUM:-0}"
+INSTALL_VERBOSE="${MESH_LLM_INSTALL_VERBOSE:-0}"
 AUTO_SETUP=1
 DOWNLOADED_ARCHIVE=""
 DOWNLOADED_ASSET=""
@@ -25,6 +26,21 @@ need_cmd() {
 
 warn() {
     echo "warning: $*" >&2
+}
+
+info() {
+    if bool_is_true "$INSTALL_VERBOSE"; then
+        echo "$@"
+    fi
+}
+
+style_ok() {
+    local text="$1"
+    if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+        printf '\033[32m%s\033[0m' "$text"
+    else
+        printf '%s' "$text"
+    fi
 }
 
 bool_is_true() {
@@ -45,7 +61,7 @@ path_contains_install_dir() {
 
 usage() {
     cat <<EOF
-Usage: install.sh [--pre-release] [--install-dir DIR] [--no-setup]
+Usage: install.sh [--pre-release] [--install-dir DIR] [--no-setup] [--verbose]
 
 Options:
   --pre-release              Install the latest published GitHub prerelease instead of the latest stable release.
@@ -58,6 +74,7 @@ mesh-llm setup automatically after install.
 mesh-llm setup instead of installing services in shell.
   --no-start-service         Legacy compatibility flag. Ignored with a warning.
   --service-args VALUE       Legacy compatibility flag. Ignored with a warning.
+  --verbose                  Print detailed download, checksum, and setup command output.
   -h, --help                 Show this help text.
 
 Environment overrides:
@@ -68,6 +85,7 @@ Environment overrides:
   MESH_LLM_INSTALL_SERVICE=1 Legacy compatibility variable. Passed through as --service.
   MESH_LLM_INSTALL_SERVICE_START=0 Legacy compatibility variable. Ignored with a warning.
   MESH_LLM_REQUIRE_CHECKSUM=1
+  MESH_LLM_INSTALL_VERBOSE=1
 EOF
 }
 
@@ -98,6 +116,10 @@ parse_args() {
                 ;;
             --no-setup)
                 AUTO_SETUP=0
+                ;;
+            --verbose)
+                INSTALL_VERBOSE=1
+                add_setup_arg "--verbose"
                 ;;
             --service)
                 warn "--service is deprecated in install.sh; forwarding it to \`mesh-llm setup --service\`."
@@ -130,6 +152,9 @@ parse_args() {
 }
 
 apply_legacy_env_compat() {
+    if bool_is_true "$INSTALL_VERBOSE"; then
+        add_setup_arg "--verbose"
+    fi
     if [[ -n "$INSTALL_FLAVOR" ]]; then
         warn "MESH_LLM_INSTALL_FLAVOR is deprecated in install.sh and is ignored; \`mesh-llm setup\` now owns runtime selection."
     fi
@@ -530,7 +555,7 @@ verify_downloaded_file() {
         echo "actual:   $actual" >&2
         return 1
     fi
-    echo "Verified checksum: $(basename "$file")"
+    info "Verified checksum: $(basename "$file")"
 }
 
 download_release_archive() {
@@ -552,7 +577,7 @@ download_release_archive() {
         DOWNLOADED_ASSET="$asset"
         DOWNLOADED_ARCHIVE="$archive"
         if [[ "$asset" == "$fallback_asset" ]]; then
-            echo "Using runtime-enabled mesh bundle fallback: $fallback_asset"
+            info "Using runtime-enabled mesh bundle fallback: $fallback_asset"
         fi
         return 0
     done
@@ -622,9 +647,13 @@ run_or_print_setup() {
     local command
     command="$(setup_command_string)"
 
-    echo
     if (( AUTO_SETUP == 1 )) && shell_is_interactive; then
-        echo "Running post-install setup: $command"
+        if bool_is_true "$INSTALL_VERBOSE"; then
+            echo
+            echo "Running post-install setup: $command"
+        else
+            echo
+        fi
         "$binary" setup "${SETUP_ARGS[@]}"
         return 0
     fi
@@ -640,7 +669,7 @@ main() {
     need_cmd mktemp
 
     local asset
-    asset="$(platform_asset_name)"
+    asset="$(asset_name "$(recommended_flavor)")"
 
     local tmp_dir
     tmp_dir="$(mktemp -d)"
@@ -648,7 +677,10 @@ main() {
     printf -v tmp_dir_escaped '%q' "$tmp_dir"
     trap "rm -rf -- $tmp_dir_escaped" EXIT
 
-    echo "Release channel: $(bool_is_true "$INSTALL_PRERELEASE" && echo prerelease || echo stable)"
+    info "Release channel: $(bool_is_true "$INSTALL_PRERELEASE" && echo prerelease || echo stable)"
+    if ! bool_is_true "$INSTALL_VERBOSE"; then
+        echo "↓ Fetching mesh-llm release..."
+    fi
     download_release_archive "$tmp_dir" "$asset"
 
     tar -xzf "$DOWNLOADED_ARCHIVE" -C "$tmp_dir"
@@ -658,7 +690,11 @@ main() {
     fi
 
     install_bundle "$tmp_dir/mesh-bundle"
-    echo "Installed $DOWNLOADED_ASSET to $INSTALL_DIR"
+    if bool_is_true "$INSTALL_VERBOSE"; then
+        echo "Installed $DOWNLOADED_ASSET to $INSTALL_DIR"
+    else
+        printf '%s Installed mesh-llm to %s\n' "$(style_ok "✓")" "$INSTALL_DIR"
+    fi
 
     if ! path_contains_install_dir; then
         echo

--- a/install.sh
+++ b/install.sh
@@ -326,13 +326,13 @@ detect_cuda_major() {
         local lib
         for lib in /usr/local/cuda*/targets/*/lib/libcudart.so.* /usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
             if [[ -f "$lib" ]]; then
-                ver="$(basename "$lib" | grep -oE 'libcudart\\.so\\.[0-9]+' | awk -F. '{print $3}' | head -n 1)"
+                ver="$(basename "$lib" | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | head -n 1)"
                 break
             fi
         done
     fi
     if [[ -z "$ver" ]]; then
-        ver="$(ldconfig -p 2>/dev/null | grep -oE 'libcudart\\.so\\.[0-9]+' | awk -F. '{print $3}' | sort -rn | head -n 1)"
+        ver="$(ldconfig -p 2>/dev/null | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | sort -rn | head -n 1)"
     fi
     case "$ver" in
         12|13) printf '%s\n' "$ver" ;;

--- a/install.sh
+++ b/install.sh
@@ -218,19 +218,6 @@ platform_error_message() {
     esac
 }
 
-platform_asset_name() {
-    case "$(platform_id)" in
-        Darwin/arm64) printf 'mesh-llm-aarch64-apple-darwin.tar.gz\n' ;;
-        Darwin/x86_64) printf 'mesh-llm-x86_64-apple-darwin.tar.gz\n' ;;
-        Linux/aarch64) printf 'mesh-llm-aarch64-unknown-linux-gnu.tar.gz\n' ;;
-        Linux/x86_64) printf 'mesh-llm-x86_64-unknown-linux-gnu.tar.gz\n' ;;
-        *)
-            echo "error: unsupported platform: $(platform_id)" >&2
-            exit 1
-            ;;
-    esac
-}
-
 tegra_model_text() {
     if [[ -n "${MESH_LLM_TEST_TEGRA_MODEL:-}" ]]; then
         printf '%s\n' "$MESH_LLM_TEST_TEGRA_MODEL"

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 REPO="${MESH_LLM_INSTALL_REPO:-Mesh-LLM/mesh-llm}"
-REPO_REF="${MESH_LLM_INSTALL_REF:-main}"
 INSTALL_DIR="${MESH_LLM_INSTALL_DIR:-$HOME/.local/bin}"
 INSTALL_FLAVOR="${MESH_LLM_INSTALL_FLAVOR:-}"
 INSTALL_PRERELEASE="${MESH_LLM_INSTALL_PRERELEASE:-0}"
@@ -11,23 +10,10 @@ INSTALL_SERVICE="${MESH_LLM_INSTALL_SERVICE:-0}"
 INSTALL_SERVICE_ARGS="${MESH_LLM_INSTALL_SERVICE_ARGS:-}"
 INSTALL_SERVICE_START="${MESH_LLM_INSTALL_SERVICE_START:-1}"
 REQUIRE_CHECKSUM="${MESH_LLM_REQUIRE_CHECKSUM:-0}"
-
-SERVICE_NAME="mesh-llm"
-SERVICE_LABEL="com.mesh-llm.mesh-llm"
-MESH_CONFIG_FILE="$HOME/.mesh-llm/config.toml"
-SERVICE_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/mesh-llm"
-SERVICE_ENV_FILE="$SERVICE_CONFIG_DIR/service.env"
-SERVICE_RUNNER="$SERVICE_CONFIG_DIR/run-service.sh"
-SYSTEMD_UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
-SYSTEMD_UNIT_PATH="$SYSTEMD_UNIT_DIR/$SERVICE_NAME.service"
-LAUNCHD_AGENT_DIR="$HOME/Library/LaunchAgents"
-LAUNCHD_PLIST_PATH="$LAUNCHD_AGENT_DIR/$SERVICE_LABEL.plist"
-LAUNCHD_LOG_DIR="$HOME/Library/Logs/mesh-llm"
-LAUNCHD_STDOUT_LOG="$LAUNCHD_LOG_DIR/stdout.log"
-LAUNCHD_STDERR_LOG="$LAUNCHD_LOG_DIR/stderr.log"
-DIST_DIR="dist"
-SYSTEMD_TEMPLATE_PATH="$DIST_DIR/$SERVICE_NAME.service"
-LAUNCHD_TEMPLATE_PATH="$DIST_DIR/$SERVICE_LABEL.plist"
+AUTO_SETUP=1
+DOWNLOADED_ARCHIVE=""
+DOWNLOADED_ASSET=""
+SETUP_ARGS=()
 
 need_cmd() {
     if ! command -v "$1" >/dev/null 2>&1; then
@@ -36,11 +22,8 @@ need_cmd() {
     fi
 }
 
-path_contains_install_dir() {
-    case ":$PATH:" in
-        *":$INSTALL_DIR:"*) return 0 ;;
-        *) return 1 ;;
-    esac
+warn() {
+    echo "warning: $*" >&2
 }
 
 bool_is_true() {
@@ -52,25 +35,49 @@ bool_is_true() {
     esac
 }
 
+path_contains_install_dir() {
+    case ":$PATH:" in
+        *":$INSTALL_DIR:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 usage() {
     cat <<EOF
-Usage: install.sh [--pre-release] [--service] [--no-start-service]
+Usage: install.sh [--pre-release] [--install-dir DIR] [--no-setup]
 
 Options:
   --pre-release              Install the latest published GitHub prerelease instead of the latest stable release.
-  --service                  Install a per-user background service for this platform.
-  --no-start-service         Install the service files but do not start them yet.
+  --install-dir DIR          Install the binary into DIR.
+  --no-setup                 Do not run \
+                             \
+mesh-llm setup automatically after install.
+  --service                  Legacy compatibility flag. Passes --service through to \
+                             \
+mesh-llm setup instead of installing services in shell.
+  --no-start-service         Legacy compatibility flag. Ignored with a warning.
+  --service-args VALUE       Legacy compatibility flag. Ignored with a warning.
   -h, --help                 Show this help text.
 
 Environment overrides:
   MESH_LLM_INSTALL_DIR
-  MESH_LLM_INSTALL_FLAVOR
   MESH_LLM_INSTALL_PRERELEASE=1
-  MESH_LLM_INSTALL_REF=main
-  MESH_LLM_INSTALL_SERVICE=1
-  MESH_LLM_INSTALL_SERVICE_START=0
+  MESH_LLM_INSTALL_FLAVOR    Legacy compatibility variable. Ignored with a warning.
+  MESH_LLM_INSTALL_SERVICE=1 Legacy compatibility variable. Passed through as --service.
+  MESH_LLM_INSTALL_SERVICE_START=0 Legacy compatibility variable. Ignored with a warning.
   MESH_LLM_REQUIRE_CHECKSUM=1
 EOF
+}
+
+add_setup_arg() {
+    local arg="$1"
+    local existing
+    for existing in "${SETUP_ARGS[@]:-}"; do
+        if [[ "$existing" == "$arg" ]]; then
+            return 0
+        fi
+    done
+    SETUP_ARGS+=("$arg")
 }
 
 parse_args() {
@@ -79,16 +86,31 @@ parse_args() {
             --pre-release)
                 INSTALL_PRERELEASE=1
                 ;;
-            --service)
-                INSTALL_SERVICE=1
+            --install-dir)
+                shift
+                if (($# == 0)); then
+                    echo "error: --install-dir requires a directory" >&2
+                    exit 1
+                fi
+                INSTALL_DIR="$1"
                 ;;
-            --service-args)
-                echo "error: background services now run \`mesh-llm serve\` and load startup models from $MESH_CONFIG_FILE" >&2
-                echo "Add startup models under [[models]] instead of passing custom service args." >&2
-                exit 1
+            --no-setup)
+                AUTO_SETUP=0
+                ;;
+            --service)
+                warn "--service is deprecated in install.sh; forwarding it to \`mesh-llm setup --service\`."
+                add_setup_arg "--service"
                 ;;
             --no-start-service)
-                INSTALL_SERVICE_START=0
+                warn "--no-start-service is deprecated in install.sh; service start policy now belongs to \`mesh-llm setup\`."
+                ;;
+            --service-args)
+                shift
+                if (($# == 0)); then
+                    echo "error: --service-args requires a value" >&2
+                    exit 1
+                fi
+                warn "--service-args is deprecated in install.sh and is ignored; configure startup behavior after \`mesh-llm setup\`."
                 ;;
             -h|--help)
                 usage
@@ -105,406 +127,58 @@ parse_args() {
     done
 }
 
+apply_legacy_env_compat() {
+    if [[ -n "$INSTALL_FLAVOR" ]]; then
+        warn "MESH_LLM_INSTALL_FLAVOR is deprecated in install.sh and is ignored; \`mesh-llm setup\` now owns runtime selection."
+    fi
+    if bool_is_true "$INSTALL_SERVICE"; then
+        warn "MESH_LLM_INSTALL_SERVICE is deprecated in install.sh; forwarding it to \`mesh-llm setup --service\`."
+        add_setup_arg "--service"
+    fi
+    if [[ -n "$INSTALL_SERVICE_ARGS" ]]; then
+        warn "MESH_LLM_INSTALL_SERVICE_ARGS is deprecated in install.sh and is ignored; configure startup behavior after \`mesh-llm setup\`."
+    fi
+    if ! bool_is_true "$INSTALL_SERVICE_START"; then
+        warn "MESH_LLM_INSTALL_SERVICE_START is deprecated in install.sh and is ignored; service start policy now belongs to \`mesh-llm setup\`."
+    fi
+}
+
 platform_os() {
     if [[ -n "${MESH_LLM_TEST_UNAME_S:-}" ]]; then
         printf '%s\n' "$MESH_LLM_TEST_UNAME_S"
         return 0
     fi
-
     uname -s
 }
 
 platform_arch() {
     local os
     local arch
-
     os="$(platform_os)"
     if [[ -n "${MESH_LLM_TEST_UNAME_M:-}" ]]; then
         arch="$MESH_LLM_TEST_UNAME_M"
     else
         arch="$(uname -m)"
     fi
-
     case "$os/$arch" in
-        Linux/amd64)
-            printf 'x86_64\n'
-            ;;
-        Linux/arm64|Linux/aarch64)
-            printf 'aarch64\n'
-            ;;
-        Linux/arm|Linux/armv6l|Linux/armv6hf|Linux/armv7l|Linux/armv7hf)
-            printf 'arm\n'
-            ;;
-        *)
-            printf '%s\n' "$arch"
-            ;;
+        Linux/amd64) printf 'x86_64\n' ;;
+        Linux/arm64|Linux/aarch64) printf 'aarch64\n' ;;
+        *) printf '%s\n' "$arch" ;;
     esac
 }
 
 platform_id() {
-    printf "%s/%s\n" "$(platform_os)" "$(platform_arch)"
+    printf '%s/%s\n' "$(platform_os)" "$(platform_arch)"
 }
 
-platform_support_status() {
+platform_asset_name() {
     case "$(platform_id)" in
-        Darwin/arm64|Linux/aarch64|Linux/x86_64)
-            printf 'supported\n'
-            ;;
-        Linux/arm)
-            printf 'recognized-unsupported\n'
-            ;;
+        Darwin/arm64) printf 'mesh-llm-aarch64-apple-darwin.tar.gz\n' ;;
+        Darwin/x86_64) printf 'mesh-llm-x86_64-apple-darwin.tar.gz\n' ;;
+        Linux/aarch64) printf 'mesh-llm-aarch64-unknown-linux-gnu.tar.gz\n' ;;
+        Linux/x86_64) printf 'mesh-llm-x86_64-unknown-linux-gnu.tar.gz\n' ;;
         *)
-            printf 'unsupported\n'
-            ;;
-    esac
-}
-
-platform_error_message() {
-    case "$(platform_support_status)" in
-        recognized-unsupported)
-            printf 'error: recognized but unsupported platform: %s (32-bit ARM release bundles are not published)\n' "$(platform_id)"
-            ;;
-        *)
-            printf 'error: unsupported platform: %s\n' "$(platform_id)"
-            ;;
-    esac
-}
-
-probe_nvidia() {
-    command -v nvidia-smi >/dev/null 2>&1 ||
-        command -v nvcc >/dev/null 2>&1 ||
-        [[ -e /dev/nvidiactl ]] ||
-        [[ -d /proc/driver/nvidia/gpus ]] ||
-        probe_tegra_nvidia
-}
-
-tegra_model_text() {
-    if [[ -n "${MESH_LLM_TEST_TEGRA_MODEL:-}" ]]; then
-        printf '%s\n' "$MESH_LLM_TEST_TEGRA_MODEL"
-        return 0
-    fi
-
-    local path
-    for path in \
-        /proc/device-tree/model \
-        /proc/device-tree/compatible \
-        /sys/firmware/devicetree/base/model \
-        /sys/firmware/devicetree/base/compatible; do
-        [[ -r "$path" ]] || continue
-        tr '\0' '\n' <"$path" 2>/dev/null || true
-        printf '\n'
-    done
-}
-
-probe_tegra_nvidia() {
-    local model
-    model="$(tegra_model_text | tr '[:lower:]' '[:upper:]')"
-    case "$model" in
-        *JETSON*|*TEGRA*|*ORIN*|*NVGPU*|*THOR*)
-            return 0
-            ;;
-    esac
-
-    [[ -e /dev/nvhost-gpu ]] || [[ -e /dev/nvhost-ctrl-gpu ]]
-}
-
-normalize_cuda_sm() {
-    local raw="$1"
-    printf '%s\n' "${raw//[^0-9]/}"
-}
-
-is_blackwell_cuda_sm() {
-    local sm
-    sm="$(normalize_cuda_sm "$1")"
-    [[ "$sm" =~ ^[0-9]+$ ]] && (( sm >= 100 && sm < 200 ))
-}
-
-nvidia_model_is_blackwell() {
-    local model
-    model="$(printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]')"
-    case "$model" in
-        *BLACKWELL*|*GB300*|*B300*|*GB200*|*B200*|*B100*|*GB10*|*THOR*|\
-        *RTX\ 5090*|*RTX\ 5080*|*RTX\ 5070*|*RTX\ 5060*|*RTX\ 5050*|\
-        *RTX\ PRO\ 6000*)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
-probe_rocm() {
-    command -v rocm-smi >/dev/null 2>&1 ||
-        command -v rocminfo >/dev/null 2>&1 ||
-        command -v hipcc >/dev/null 2>&1 ||
-        [[ -x /opt/rocm/bin/hipcc ]]
-}
-
-probe_vulkan() {
-    if command -v vulkaninfo >/dev/null 2>&1 && vulkaninfo --summary >/dev/null 2>&1; then
-        return 0
-    fi
-    if command -v glslc >/dev/null 2>&1; then
-        if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists vulkan 2>/dev/null; then
-            return 0
-        fi
-        if [[ -f /usr/include/vulkan/vulkan.h || -f /usr/local/include/vulkan/vulkan.h ]]; then
-            return 0
-        fi
-        if [[ -n "${VULKAN_SDK:-}" ]]; then
-            return 0
-        fi
-    fi
-    return 1
-}
-
-probe_tegra() {
-    # Detect NVIDIA Tegra / Jetson SoC accelerators (Orin AGX, Orin NX, Xavier, etc.)
-    # These are typically Linux aarch64 devices with an integrated NVIDIA GPU.
-    [[ -f /proc/device-tree/model ]] && grep -qi "tegra\|jetson" /proc/device-tree/model
-}
-
-supported_flavors() {
-    case "$(platform_support_status)" in
-        supported)
-            case "$(platform_id)" in
-        Darwin/arm64)
-            echo "metal"
-            ;;
-        Linux/aarch64)
-            echo "cuda cpu"
-            ;;
-        Linux/x86_64)
-            echo "cuda rocm vulkan cpu"
-            ;;
-        *)
-                platform_error_message >&2
-                exit 1
-                ;;
-            esac
-            ;;
-        *)
-            platform_error_message >&2
-            exit 1
-            ;;
-    esac
-}
-
-# Keep this detection order and the probes above (probe_nvidia, probe_rocm, probe_vulkan, probe_tegra) in sync with the Rust updater flavor selection in crates/mesh-llm-system/src/autoupdate.rs.
-recommended_flavor() {
-    case "$(platform_support_status)" in
-        supported)
-            case "$(platform_id)" in
-        Darwin/arm64)
-            echo "metal"
-            ;;
-        Linux/aarch64)
-            if probe_nvidia; then
-                echo "cuda"
-            else
-                echo "cpu"
-            fi
-            ;;
-        Linux/x86_64)
-            if probe_nvidia; then
-                echo "cuda"
-            elif probe_rocm; then
-                echo "rocm"
-            elif probe_vulkan; then
-                echo "vulkan"
-            else
-                echo "cpu"
-            fi
-            ;;
-        *)
-                platform_error_message >&2
-                exit 1
-                ;;
-            esac
-            ;;
-        *)
-            platform_error_message >&2
-            exit 1
-            ;;
-    esac
-}
-
-recommendation_reason() {
-    case "$(recommended_flavor)" in
-        metal)
-            echo "Apple Silicon host detected."
-            ;;
-        cuda)
-            if probe_tegra; then
-                echo "NVIDIA Tegra/Jetson SoC detected (Orin AGX, Orin NX, Xavier, etc.)."
-            else
-                echo "NVIDIA tooling or devices were detected."
-            fi
-            ;;
-
-        rocm)
-            echo "ROCm/HIP tooling was detected."
-            ;;
-        vulkan)
-            echo "Vulkan tooling was detected."
-            ;;
-        cpu)
-            echo "No supported GPU runtime was detected."
-            ;;
-    esac
-}
-
-validate_flavor() {
-    local flavor="$1"
-    local supported
-    for supported in $(supported_flavors); do
-        if [[ "$supported" == "$flavor" ]]; then
-            return 0
-        fi
-    done
-    echo "error: unsupported flavor '$flavor' for $(platform_id)" >&2
-    exit 1
-}
-
-choose_flavor() {
-    local recommended
-    recommended="$(recommended_flavor)"
-
-    if [[ -n "$INSTALL_FLAVOR" ]]; then
-        validate_flavor "$INSTALL_FLAVOR"
-        echo "$INSTALL_FLAVOR"
-        return 0
-    fi
-
-    if [[ ! -t 0 || ! -t 1 ]]; then
-        echo "$recommended"
-        return 0
-    fi
-
-    local flavors
-    flavors=($(supported_flavors))
-
-    if [[ ${#flavors[@]} -eq 1 ]]; then
-        echo "$recommended"
-        return 0
-    fi
-
-    echo "Mesh LLM installer"
-    echo "Platform: $(platform_id)"
-    echo "Recommended flavor: $recommended"
-    echo "Reason: $(recommendation_reason)"
-    echo
-    echo "Available flavors:"
-
-    local index=1
-    local flavor
-    for flavor in "${flavors[@]}"; do
-        if [[ "$flavor" == "$recommended" ]]; then
-            echo "  $index. $flavor (recommended)"
-        else
-            echo "  $index. $flavor"
-        fi
-        index=$((index + 1))
-    done
-
-    echo
-    local reply
-    read -r -p "Install which flavor? [$recommended] " reply
-    reply="${reply:-$recommended}"
-
-    if [[ "$reply" =~ ^[0-9]+$ ]]; then
-        local selection=$((reply - 1))
-        if (( selection >= 0 && selection < ${#flavors[@]} )); then
-            reply="${flavors[$selection]}"
-        fi
-    fi
-
-    validate_flavor "$reply"
-    echo "$reply"
-}
-
-detect_cuda_major() {
-    # Detect host CUDA major version from nvcc or libcudart.
-    # Only return versions we publish artifacts for (12, 13).
-    local ver=""
-    if command -v nvcc >/dev/null 2>&1; then
-        ver="$(nvcc --version 2>/dev/null | grep -oP 'release \K[0-9]+')"
-    fi
-    if [[ -z "$ver" ]]; then
-        # Try to find libcudart.so and extract version from filename.
-        local lib
-        for lib in /usr/local/cuda*/targets/*/lib/libcudart.so.* /usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
-            if [[ -f "$lib" ]]; then
-                ver="$(basename "$lib" | grep -oP 'libcudart\.so\.\K[0-9]+' | head -n 1)"
-                break
-            fi
-        done
-    fi
-    if [[ -z "$ver" ]]; then
-        # Fallback: check ldconfig for libcudart.
-        ver="$(ldconfig -p 2>/dev/null | grep -oP 'libcudart\.so\.\K[0-9]+' | sort -rn | head -n 1)"
-    fi
-    # Only return versions we publish artifacts for (12, 13).
-    case "$ver" in
-        12|13) echo "$ver" ;;
-        *)     echo "" ;;
-    esac
-}
-
-asset_name() {
-    local flavor="$1"
-    case "$(platform_support_status)" in
-        supported)
-            case "$(platform_id)" in
-        Darwin/arm64)
-            echo "mesh-llm-aarch64-apple-darwin.tar.gz"
-            ;;
-        Linux/aarch64)
-            case "$flavor" in
-                cpu) echo "mesh-llm-aarch64-unknown-linux-gnu.tar.gz" ;;
-                cuda)
-                    local cuda_major="$(detect_cuda_major)"
-                    if [[ -n "$cuda_major" ]]; then
-                        echo "mesh-llm-aarch64-unknown-linux-gnu-cuda-${cuda_major}.tar.gz"
-                    else
-                        # Fallback: try to match any cuda artifact.
-                        echo "mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz"
-                    fi
-                    ;;
-                *)
-                    echo "error: unsupported aarch64 flavor '$flavor'" >&2
-                    exit 1
-                    ;;
-            esac
-            ;;
-        Linux/x86_64)
-            case "$flavor" in
-                cpu) echo "mesh-llm-x86_64-unknown-linux-gnu.tar.gz" ;;
-                cuda)
-                    local cuda_major="$(detect_cuda_major)"
-                    if [[ -n "$cuda_major" ]]; then
-                        echo "mesh-llm-x86_64-unknown-linux-gnu-cuda-${cuda_major}.tar.gz"
-                    else
-                        echo "mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz"
-                    fi
-                    ;;
-                rocm) echo "mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz" ;;
-                vulkan) echo "mesh-llm-x86_64-unknown-linux-gnu-vulkan.tar.gz" ;;
-                *)
-                    echo "error: unsupported Linux flavor '$flavor'" >&2
-                    exit 1
-                    ;;
-            esac
-            ;;
-        *)
-                platform_error_message >&2
-                exit 1
-                ;;
-            esac
-            ;;
-        *)
-            platform_error_message >&2
+            echo "error: unsupported platform: $(platform_id)" >&2
             exit 1
             ;;
     esac
@@ -512,7 +186,6 @@ asset_name() {
 
 latest_prerelease_tag() {
     local api_url="https://api.github.com/repos/${REPO}/releases?per_page=20"
-    local releases_page_url="https://github.com/${REPO}/releases"
     local response
     local -a curl_args=(
         -fsSL
@@ -526,74 +199,32 @@ latest_prerelease_tag() {
         curl_args+=(-H "Authorization: Bearer ${GH_TOKEN}")
     fi
 
-    local tag
-    if response="$(curl "${curl_args[@]}" "$api_url" 2>/dev/null)"; then
-        local compact
-        compact="$(printf '%s' "$response" | tr -d '\n\r\t ')"
-
-        tag="$(
-            printf '%s' "$compact" |
-                sed 's/},{/}\
+    response="$(curl "${curl_args[@]}" "$api_url")"
+    printf '%s' "$response" |
+        tr -d '\n\r\t ' |
+        sed 's/},{/}\
 {/g' |
-                awk '
-                    /"prerelease":true/ && !/"draft":true/ {
-                        if (match($0, /"tag_name":"[^"]+"/)) {
-                            value = substr($0, RSTART, RLENGTH)
-                            sub(/^"tag_name":"/, "", value)
-                            sub(/"$/, "", value)
-                            print value
-                            exit
-                        }
-                    }
-                '
-        )"
-    fi
-
-    if [[ -z "${tag:-}" ]]; then
-        if ! response="$(curl -fsSL "$releases_page_url" 2>/dev/null)"; then
-            echo "error: could not query GitHub releases for ${REPO}" >&2
-            return 1
-        fi
-
-        tag="$(
-            printf '%s' "$response" |
-                tr '\n' ' ' |
-                sed "s#<a href=\"/${REPO}/releases/tag/#\\
-TAG:#g; s#Pre-release#\\
-PRE-RELEASE#g" |
-                awk '
-                    /TAG:/ {
-                        tag = $0
-                        sub(/^.*TAG:/, "", tag)
-                        sub(/".*$/, "", tag)
-                    }
-                    /PRE-RELEASE/ && tag != "" {
-                        print tag
-                        exit
-                    }
-                '
-        )"
-    fi
-
-    if [[ -z "$tag" ]]; then
-        echo "error: could not find a published prerelease for ${REPO}" >&2
-        return 1
-    fi
-
-    printf '%s\n' "$tag"
+        awk '
+            /"prerelease":true/ && !/"draft":true/ {
+                if (match($0, /"tag_name":"[^"]+"/)) {
+                    value = substr($0, RSTART, RLENGTH)
+                    sub(/^"tag_name":"/, "", value)
+                    sub(/"$/, "", value)
+                    print value
+                    exit
+                }
+            }
+        '
 }
 
 release_url() {
     local asset="$1"
     if bool_is_true "$INSTALL_PRERELEASE"; then
         local tag
-        if ! tag="$(latest_prerelease_tag)"; then
-            return 1
-        fi
+        tag="$(latest_prerelease_tag)"
         printf 'https://github.com/%s/releases/download/%s/%s\n' "$REPO" "$tag" "$asset"
         return 0
     fi
-
     printf 'https://github.com/%s/releases/latest/download/%s\n' "$REPO" "$asset"
 }
 
@@ -630,7 +261,6 @@ download_checksum_sidecar() {
     local url="$1"
     local sidecar="$2"
     local status
-
     status="$(curl -sSL -w '%{http_code}' -o "$sidecar" "$url")" || {
         rm -f -- "$sidecar"
         echo "error: could not download checksum sidecar: $url" >&2
@@ -638,8 +268,13 @@ download_checksum_sidecar() {
     }
 
     case "$status" in
-        2*)
-            return 0
+        2*) return 0 ;;
+        000)
+            if [[ -f "$sidecar" ]]; then
+                return 0
+            fi
+            rm -f -- "$sidecar"
+            return 1
             ;;
         404|410)
             rm -f -- "$sidecar"
@@ -659,12 +294,11 @@ verify_downloaded_file() {
     local require_checksum="${3:-$REQUIRE_CHECKSUM}"
     local sidecar="$file.sha256"
     local sidecar_url
-    local sidecar_status
+    local sidecar_status=0
     local expected
     local actual
 
     sidecar_url="$(checksum_url "$url")"
-    sidecar_status=0
     download_checksum_sidecar "$sidecar_url" "$sidecar" || sidecar_status=$?
     if [[ "$sidecar_status" -ne 0 ]]; then
         case "$sidecar_status" in
@@ -676,17 +310,12 @@ verify_downloaded_file() {
                 echo "warning: checksum sidecar not found; continuing without archive verification: $sidecar_url" >&2
                 return 0
                 ;;
-            *)
-                return 1
-                ;;
+            *) return 1 ;;
         esac
     fi
-    if ! expected="$(checksum_from_sidecar "$sidecar")"; then
-        return 1
-    fi
-    if ! actual="$(sha256_file "$file")"; then
-        return 1
-    fi
+
+    expected="$(checksum_from_sidecar "$sidecar")"
+    actual="$(sha256_file "$file")"
     if [[ "$actual" != "$expected" ]]; then
         echo "error: checksum mismatch for $(basename "$file")" >&2
         echo "expected: $expected" >&2
@@ -694,6 +323,34 @@ verify_downloaded_file() {
         return 1
     fi
     echo "Verified checksum: $(basename "$file")"
+}
+
+download_release_archive() {
+    local tmp_dir="$1"
+    local preferred_asset="$2"
+    local fallback_asset="mesh-bundle.tar.gz"
+    local asset
+    local url
+    local archive
+
+    for asset in "$preferred_asset" "$fallback_asset"; do
+        url="$(release_url "$asset")"
+        archive="$tmp_dir/$asset"
+        if ! curl -fsSL "$url" -o "$archive"; then
+            rm -f -- "$archive"
+            continue
+        fi
+        verify_downloaded_file "$archive" "$url"
+        DOWNLOADED_ASSET="$asset"
+        DOWNLOADED_ARCHIVE="$archive"
+        if [[ "$asset" == "$fallback_asset" ]]; then
+            echo "Using runtime-enabled mesh bundle fallback: $fallback_asset"
+        fi
+        return 0
+    done
+
+    echo "error: could not download release archive for $preferred_asset or $fallback_asset" >&2
+    return 1
 }
 
 stale_binary_names() {
@@ -727,286 +384,55 @@ remove_stale_binaries() {
 install_bundle() {
     local bundle_dir="$1"
     remove_stale_binaries
-
     local file
     for file in "$bundle_dir"/*; do
         mv -f "$file" "$INSTALL_DIR/"
     done
 }
 
-install_recommended_native_runtime() {
-    local tmp_dir="$1"
-    local manifest_url
-    local manifest_path="$tmp_dir/native-runtimes.json"
-    local binary="$INSTALL_DIR/mesh-llm"
-
-    if [[ ! -x "$binary" ]]; then
-        return 0
-    fi
-    if ! manifest_url="$(release_url "native-runtimes.json")"; then
-        return 0
-    fi
-    if ! curl -fsSL "$manifest_url" -o "$manifest_path"; then
-        echo "Native runtime manifest was not available for this release; skipping runtime install."
-        return 0
-    fi
-    if ! verify_downloaded_file "$manifest_path" "$manifest_url" 1; then
-        echo "warning: native runtime manifest could not be verified; skipping runtime install." >&2
-        return 0
-    fi
-
-    "$binary" runtime install --manifest "$manifest_path" || {
-        echo "warning: native runtime install did not complete successfully." >&2
-        return 0
-    }
-    "$binary" runtime prune --active-only || true
-}
-
-systemd_escape_assignment_value() {
-    local value="$1"
-    value="${value//\\/\\\\}"
-    value="${value//\"/\\\"}"
-    value="${value//%/%%}"
-    printf '%s' "$value"
-}
-
-systemd_quote_token() {
-    local value="$1"
-    value="${value//\\/\\\\}"
-    value="${value//\"/\\\"}"
-    value="${value//$/$$}"
-    value="${value//%/%%}"
-    printf '"%s"' "$value"
-}
-
-local_template_path() {
-    local rel_path="$1"
-    local source_path="${BASH_SOURCE[0]-}"
-    local script_dir
-
-    if [[ -z "$source_path" || "$source_path" != */* ]]; then
-        return 1
-    fi
-
-    script_dir="$(cd "$(dirname "$source_path")" && pwd)"
-    [[ -f "$script_dir/$rel_path" ]] || return 1
-    printf '%s\n' "$script_dir/$rel_path"
-}
-
-template_stream() {
-    local rel_path="$1"
-    local local_path
-
-    if local_path="$(local_template_path "$rel_path")"; then
-        cat "$local_path"
-        return 0
-    fi
-
-    curl -fsSL "https://raw.githubusercontent.com/${REPO}/${REPO_REF}/${rel_path}"
-}
-
-render_template_to_file() {
-    local template_path="$1"
-    local output_path="$2"
-    shift 2
-
-    local -a replacements=("$@")
-    local -a env_vars=()
-    local pair
-    local key
-    local value
-    for pair in "${replacements[@]}"; do
-        key="${pair%%=*}"
-        value="${pair#*=}"
-        env_vars+=("TPL_${key}=${value}")
-    done
-
-    env "${env_vars[@]}" awk '
-        BEGIN {
-            split("ARGS_METADATA ENV_LINES", multiline_keys, " ");
-            for (i in multiline_keys) {
-                multiline[multiline_keys[i]] = 1;
-            }
-        }
-        {
-            line = $0;
-            for (name in multiline) {
-                marker = "@" name "@";
-                if (line == marker) {
-                    print ENVIRON["TPL_" name];
-                    next;
-                }
-            }
-            for (var in ENVIRON) {
-                if (index(var, "TPL_") != 1) {
-                    continue;
-                }
-                name = substr(var, 5);
-                if (name in multiline) {
-                    continue;
-                }
-                marker = "@" name "@";
-                gsub(marker, ENVIRON[var], line);
-            }
-            print line;
-        }
-    ' < <(template_stream "$template_path") > "$output_path"
-}
-
-ensure_service_env_file() {
-    if [[ -f "$SERVICE_ENV_FILE" ]]; then
+shell_is_interactive() {
+    if [[ -n "${MESH_LLM_TEST_INTERACTIVE:-}" ]]; then
+        bool_is_true "$MESH_LLM_TEST_INTERACTIVE"
         return
     fi
-
-    mkdir -p "$(dirname "$SERVICE_ENV_FILE")"
-    {
-        echo "# Optional environment variables for mesh-llm."
-        echo "# Use plain KEY=value lines."
-        echo "# Example:"
-        echo "# RUST_LOG=mesh_inference=debug"
-    } > "$SERVICE_ENV_FILE"
+    [[ -t 0 && -t 1 ]]
 }
 
-write_service_runner() {
-    mkdir -p "$(dirname "$SERVICE_RUNNER")"
-
-    cat > "$SERVICE_RUNNER" <<EOF
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-BIN="$INSTALL_DIR/mesh-llm"
-ENV_FILE="$SERVICE_ENV_FILE"
-
-if [[ ! -x "\$BIN" ]]; then
-    echo "mesh-llm binary not found or not executable: \$BIN" >&2
-    exit 1
-fi
-
-if [[ -f "\$ENV_FILE" ]]; then
-    set -a
-    # shellcheck source=/dev/null
-    . "\$ENV_FILE"
-    set +a
-fi
-
-exec "\$BIN" serve
-EOF
-
-    chmod +x "$SERVICE_RUNNER"
+setup_command_string() {
+    local -a command=("$INSTALL_DIR/mesh-llm" setup)
+    local token
+    local rendered=""
+    command+=("${SETUP_ARGS[@]}")
+    for token in "${command[@]}"; do
+        printf -v rendered '%s%q ' "$rendered" "$token"
+    done
+    printf '%s\n' "${rendered% }"
 }
 
-ensure_launchd_service_files() {
-    mkdir -p "$SERVICE_CONFIG_DIR"
-    ensure_service_env_file
-    write_service_runner
-}
+run_or_print_setup() {
+    local binary="$INSTALL_DIR/mesh-llm"
+    local command
+    command="$(setup_command_string)"
 
-install_systemd_service() {
-    need_cmd systemctl
-    mkdir -p "$SERVICE_CONFIG_DIR" "$SYSTEMD_UNIT_DIR"
-    ensure_service_env_file
-    local exec_line
-    exec_line="ExecStart=$(systemd_quote_token "$INSTALL_DIR/mesh-llm") serve"
-
-    render_template_to_file "$SYSTEMD_TEMPLATE_PATH" "$SYSTEMD_UNIT_PATH" \
-        "ARGS_METADATA=# mesh-llm serve (startup models come from $MESH_CONFIG_FILE)" \
-        "SERVICE_ENV_FILE=$SERVICE_ENV_FILE" \
-        "ENV_LINES=" \
-        "EXEC_LINE=$exec_line"
-
-    systemctl --user daemon-reload || true
-
-    if bool_is_true "$INSTALL_SERVICE_START"; then
-        if systemctl --user enable "$SERVICE_NAME.service" &&
-            (systemctl --user restart "$SERVICE_NAME.service" ||
-                systemctl --user start "$SERVICE_NAME.service"); then
-            echo "Installed and started systemd user service: $SERVICE_NAME.service"
-        else
-            echo "Installed $SYSTEMD_UNIT_PATH" >&2
-            echo "warning: could not start the systemd user service automatically." >&2
-            echo "Start it with: systemctl --user enable --now $SERVICE_NAME.service" >&2
-        fi
-    else
-        echo "Installed $SYSTEMD_UNIT_PATH"
-        echo "Start it with: systemctl --user enable --now $SERVICE_NAME.service"
+    echo
+    if (( AUTO_SETUP == 1 )) && shell_is_interactive; then
+        echo "Running post-install setup: $command"
+        "$binary" setup "${SETUP_ARGS[@]}"
+        return 0
     fi
 
-    echo "Command: $exec_line"
-    echo "Optional env: $SERVICE_ENV_FILE"
-    echo "Edit startup models: $MESH_CONFIG_FILE"
-    echo "Logs: journalctl --user -u $SERVICE_NAME.service -f"
-    echo "Boot without login (optional): sudo loginctl enable-linger \$USER"
-}
-
-install_launchd_service() {
-    need_cmd launchctl
-    ensure_launchd_service_files
-    mkdir -p "$LAUNCHD_AGENT_DIR" "$LAUNCHD_LOG_DIR"
-
-    render_template_to_file "$LAUNCHD_TEMPLATE_PATH" "$LAUNCHD_PLIST_PATH" \
-        "SERVICE_LABEL=$SERVICE_LABEL" \
-        "SERVICE_RUNNER=$SERVICE_RUNNER" \
-        "HOME_DIR=$HOME" \
-        "STDOUT_LOG=$LAUNCHD_STDOUT_LOG" \
-        "STDERR_LOG=$LAUNCHD_STDERR_LOG"
-
-    local launch_domain="gui/$(id -u)"
-    if bool_is_true "$INSTALL_SERVICE_START"; then
-        launchctl bootout "$launch_domain" "$LAUNCHD_PLIST_PATH" >/dev/null 2>&1 || true
-        if launchctl bootstrap "$launch_domain" "$LAUNCHD_PLIST_PATH"; then
-            launchctl enable "$launch_domain/$SERVICE_LABEL" >/dev/null 2>&1 || true
-            launchctl kickstart -k "$launch_domain/$SERVICE_LABEL" >/dev/null 2>&1 || true
-            echo "Installed and started launchd agent: $SERVICE_LABEL"
-        else
-            echo "Installed $LAUNCHD_PLIST_PATH" >&2
-            echo "warning: could not start the launchd agent automatically." >&2
-            echo "Start it with: launchctl bootstrap $launch_domain $LAUNCHD_PLIST_PATH" >&2
-        fi
-    else
-        echo "Installed $LAUNCHD_PLIST_PATH"
-        echo "Start it with: launchctl bootstrap $launch_domain $LAUNCHD_PLIST_PATH"
-    fi
-
-    echo "Startup models: $MESH_CONFIG_FILE"
-    echo "Optional env: $SERVICE_ENV_FILE"
-    echo "Logs: $LAUNCHD_STDOUT_LOG and $LAUNCHD_STDERR_LOG"
-}
-
-install_service() {
-    case "$(uname -s)" in
-        Darwin)
-            install_launchd_service
-            ;;
-        Linux)
-            install_systemd_service
-            ;;
-        *)
-            echo "error: service install is not supported on $(uname -s)" >&2
-            exit 1
-            ;;
-    esac
+    echo "Run this next: $command"
 }
 
 main() {
     parse_args "$@"
-    if [[ -n "$INSTALL_SERVICE_ARGS" ]]; then
-        echo "error: background services now run \`mesh-llm serve\` and load startup models from $MESH_CONFIG_FILE" >&2
-        echo "Add startup models under [[models]] instead of using MESH_LLM_INSTALL_SERVICE_ARGS." >&2
-        exit 1
-    fi
+    apply_legacy_env_compat
     need_cmd curl
     need_cmd tar
     need_cmd mktemp
 
-    local flavor
-    flavor="$(choose_flavor)"
     local asset
-    asset="$(asset_name "$flavor")"
-    local url
-    if ! url="$(release_url "$asset")"; then
-        exit 1
-    fi
+    asset="$(platform_asset_name)"
 
     local tmp_dir
     tmp_dir="$(mktemp -d)"
@@ -1014,33 +440,17 @@ main() {
     printf -v tmp_dir_escaped '%q' "$tmp_dir"
     trap "rm -rf -- $tmp_dir_escaped" EXIT
 
-    local archive="$tmp_dir/$asset"
-    echo "Installing flavor: $flavor"
-    if bool_is_true "$INSTALL_PRERELEASE"; then
-        echo "Release channel: prerelease"
-    else
-        echo "Release channel: stable"
-    fi
-    echo "Downloading $url"
-    curl -fsSL "$url" -o "$archive"
-    verify_downloaded_file "$archive" "$url"
+    echo "Release channel: $(bool_is_true "$INSTALL_PRERELEASE" && echo prerelease || echo stable)"
+    download_release_archive "$tmp_dir" "$asset"
 
-    tar -xzf "$archive" -C "$tmp_dir"
-
+    tar -xzf "$DOWNLOADED_ARCHIVE" -C "$tmp_dir"
     if [[ ! -d "$tmp_dir/mesh-bundle" ]]; then
         echo "error: release archive did not contain mesh-bundle/" >&2
         exit 1
     fi
 
     install_bundle "$tmp_dir/mesh-bundle"
-    install_recommended_native_runtime "$tmp_dir"
-
-    echo "Installed $asset to $INSTALL_DIR"
-
-    if bool_is_true "$INSTALL_SERVICE"; then
-        echo
-        install_service
-    fi
+    echo "Installed $DOWNLOADED_ASSET to $INSTALL_DIR"
 
     if ! path_contains_install_dir; then
         echo
@@ -1055,6 +465,8 @@ main() {
         echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc"
         echo "  source ~/.zshrc"
     fi
+
+    run_or_print_setup
 }
 
 if [[ "${BASH_SOURCE[0]-}" == "$0" || ( -z "${BASH_SOURCE[0]-}" && "$0" == "bash" ) ]]; then

--- a/scripts/tests/test_generate_native_runtime_release_manifest.py
+++ b/scripts/tests/test_generate_native_runtime_release_manifest.py
@@ -1,0 +1,68 @@
+import json
+import pathlib
+import subprocess
+import tarfile
+import tempfile
+import unittest
+
+
+SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "generate-native-runtime-release-manifest.sh"
+)
+
+
+class GenerateNativeRuntimeReleaseManifestTests(unittest.TestCase):
+    def test_generated_manifest_is_single_valid_json_document(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            package_dir = root / "meshllm-native-runtime-linux-aarch64-cpu"
+            package_dir.mkdir()
+            (package_dir / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "runtime": {
+                            "id": "meshllm-native-runtime-linux-aarch64-cpu",
+                            "mesh_version": "0.68.0",
+                            "skippy_abi": "0.1.25",
+                            "platform": {
+                                "os": "linux",
+                                "arch": "aarch64",
+                                "target": "aarch64-unknown-linux-gnu",
+                            },
+                            "backend": {"kind": "cpu"},
+                            "rank": 0,
+                            "libraries": ["lib/libllama.so"],
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            archive = root / "meshllm-native-runtime-linux-aarch64-cpu.tar.gz"
+            with tarfile.open(archive, "w:gz") as tar:
+                tar.add(package_dir, arcname=package_dir.name)
+
+            out = root / "native-runtimes.json"
+            subprocess.run(
+                [
+                    str(SCRIPT),
+                    "--tag",
+                    "v0.68.0",
+                    "--out",
+                    str(out),
+                    str(archive),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            with out.open(encoding="utf-8") as handle:
+                manifest = json.load(handle)
+
+            self.assertEqual(manifest["mesh_version"], "0.68.0")
+            self.assertEqual(len(manifest["artifacts"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_install_ps1.py
+++ b/scripts/tests/test_install_ps1.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import functools
+import hashlib
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+from threading import Thread
+import unittest
+from typing import Final
+import zipfile
+
+
+ROOT: Final = Path(__file__).resolve().parents[2]
+SCRIPT: Final = ROOT / "install.ps1"
+PWSH: Final = shutil.which("pwsh")
+HOST_ASSET: Final = "mesh-llm-x86_64-pc-windows-msvc.zip"
+FORBIDDEN_POLICY_STRINGS: Final = (
+    "runtime install",
+    "runtime prune",
+    "New-Service",
+    "sc.exe",
+)
+
+
+class InstallPs1StaticTests(unittest.TestCase):
+    def test_script_removes_runtime_and_service_policy_strings(self) -> None:
+        contents = SCRIPT.read_text(encoding="utf-8")
+
+        for forbidden in FORBIDDEN_POLICY_STRINGS:
+            self.assertNotIn(forbidden, contents)
+
+    def test_script_keeps_host_archive_and_setup_handoff_flags(self) -> None:
+        contents = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn(HOST_ASSET, contents)
+        self.assertIn("[switch]$NoSetup", contents)
+        self.assertIn("Run this next:", contents)
+        self.assertIn("mesh-llm.exe setup", contents)
+        self.assertIn("Legacy compatibility flag", contents)
+        self.assertNotIn("Get-RecommendedFlavor", contents)
+        self.assertNotIn("Choose-Flavor", contents)
+        self.assertNotIn("native-runtimes.json", contents)
+
+
+@unittest.skipUnless(PWSH, "pwsh not installed")
+class InstallPs1BehaviorTests(unittest.TestCase):
+    def test_interactive_install_runs_setup_and_warns_for_legacy_flavor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            result, calls = self._run_install(
+                tmp_path,
+                interactive=True,
+                args=["-Flavor", "cuda"],
+            )
+
+            self.assertEqual(result.returncode, 0, self._combined_output(result))
+            self.assertEqual(self._read_calls(calls), ["--version", "setup"])
+            self.assertIn("Installing Windows x64 host binary", result.stdout)
+            self.assertIn("Ignoring legacy -Flavor 'cuda'", self._combined_output(result))
+
+    def test_noninteractive_install_prints_setup_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            result, calls = self._run_install(tmp_path, interactive=False)
+
+            self.assertEqual(result.returncode, 0, self._combined_output(result))
+            self.assertEqual(self._read_calls(calls), ["--version"])
+            self.assertIn("Run this next:", result.stdout)
+            self.assertIn('mesh-llm.exe" setup', result.stdout)
+
+    def test_no_setup_prints_command_without_running_setup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            result, calls = self._run_install(
+                tmp_path,
+                interactive=True,
+                args=["-NoSetup"],
+            )
+
+            self.assertEqual(result.returncode, 0, self._combined_output(result))
+            self.assertEqual(self._read_calls(calls), ["--version"])
+            self.assertIn("Run this next:", result.stdout)
+            self.assertIn('mesh-llm.exe" setup', result.stdout)
+
+    def _run_install(
+        self,
+        tmp_path: Path,
+        *,
+        interactive: bool,
+        args: list[str] | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        install_dir = tmp_path / "bin"
+        install_dir.mkdir()
+        assets_dir = tmp_path / "assets"
+        assets_dir.mkdir()
+        calls = tmp_path / "mesh-llm-calls.log"
+        self._write_release_archive(assets_dir / HOST_ASSET, calls)
+
+        with AssetServer(assets_dir) as server:
+            env = os.environ.copy()
+            env["MESH_LLM_INSTALL_INTERACTIVE"] = "1" if interactive else "0"
+            env["MESH_LLM_INSTALL_TEST_ALLOW_NONWINDOWS"] = "1"
+            env["MESH_LLM_INSTALL_URL_BASE"] = server.base_url
+            command = [
+                PWSH,
+                "-NoProfile",
+                "-File",
+                str(SCRIPT),
+                "-InstallDir",
+                str(install_dir),
+                "-NoPathUpdate",
+                *(args or []),
+            ]
+            result = subprocess.run(
+                command,
+                cwd=tmp_path,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        return result, calls
+
+    def _write_release_archive(self, archive_path: Path, calls: Path) -> None:
+        script_contents = (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f"printf '%s\\n' \"$*\" >> {calls}\n"
+        )
+        digest = self._write_zip_with_executable(
+            archive_path,
+            member_name="mesh-bundle/mesh-llm.exe",
+            contents=script_contents,
+        )
+        archive_path.with_name(f"{archive_path.name}.sha256").write_text(
+            f"{digest}  {archive_path.name}\n",
+            encoding="utf-8",
+        )
+
+    def _write_zip_with_executable(
+        self,
+        archive_path: Path,
+        *,
+        member_name: str,
+        contents: str,
+    ) -> str:
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            info = zipfile.ZipInfo(member_name)
+            info.external_attr = 0o755 << 16
+            archive.writestr(info, contents)
+        return hashlib.sha256(archive_path.read_bytes()).hexdigest()
+
+    def _combined_output(self, result: subprocess.CompletedProcess[str]) -> str:
+        return f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    def _read_calls(self, calls: Path) -> list[str]:
+        if not calls.exists():
+            return []
+        return [line for line in calls.read_text(encoding="utf-8").splitlines() if line]
+
+
+class AssetServer:
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self._server = ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            functools.partial(SimpleHTTPRequestHandler, directory=str(root)),
+        )
+        self._thread = Thread(target=self._server.serve_forever, daemon=True)
+
+    @property
+    def base_url(self) -> str:
+        address = self._server.server_address
+        host = str(address[0])
+        port = address[1]
+        return f"http://{host}:{port}"
+
+    def __enter__(self) -> AssetServer:
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self._server.shutdown()
+        self._thread.join(timeout=5)
+        self._server.server_close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -65,6 +65,74 @@ class InstallScriptTests(unittest.TestCase):
                 "https://example.invalid/assets/mesh-llm-aarch64-unknown-linux-gnu.tar.gz",
             )
 
+    def test_release_target_helpers_keep_linux_aarch64_flavor_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            install_dir.mkdir()
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                """
+                export MESH_LLM_TEST_UNAME_S=Linux
+                export MESH_LLM_TEST_UNAME_M=aarch64
+                printf 'support=%s\\n' "$(platform_support_status)"
+                printf 'flavors=%s\\n' "$(supported_flavors)"
+                printf 'recommended=%s\\n' "$(recommended_flavor)"
+                printf 'cpu=%s\\n' "$(asset_name cpu)"
+                printf 'cuda=%s\\n' "$(asset_name cuda)"
+                """,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("support=supported", result.stdout)
+            self.assertIn("flavors=cuda cpu", result.stdout)
+            self.assertIn("recommended=cpu", result.stdout)
+            self.assertIn("cpu=mesh-llm-aarch64-unknown-linux-gnu.tar.gz", result.stdout)
+            self.assertIn("cuda=mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz", result.stdout)
+
+    def test_release_target_helpers_recommend_cuda_on_jetson_orin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            install_dir.mkdir()
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                """
+                export MESH_LLM_TEST_UNAME_S=Linux
+                export MESH_LLM_TEST_UNAME_M=aarch64
+                export MESH_LLM_TEST_TEGRA_MODEL='NVIDIA Jetson AGX Orin'
+                recommended_flavor
+                """,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "cuda")
+
+    def test_release_target_helpers_report_unsupported_armv7(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            install_dir.mkdir()
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                """
+                export MESH_LLM_TEST_UNAME_S=Linux
+                export MESH_LLM_TEST_UNAME_M=armv7l
+                printf 'support=%s\\n' "$(platform_support_status)"
+                platform_error_message
+                """,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("support=recognized-unsupported", result.stdout)
+            self.assertIn("Linux/arm", result.stdout)
+
     def test_download_release_archive_falls_back_to_mesh_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -112,6 +112,33 @@ class InstallScriptTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip(), "cuda")
 
+    def test_detect_cuda_major_reads_ldconfig_libcudart_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            install_dir.mkdir()
+            wrappers = tmp_path / "wrappers"
+            wrappers.mkdir()
+            ldconfig = wrappers / "ldconfig"
+            ldconfig.write_text(
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' 'libcudart.so.12 (libc6,AArch64) => /usr/local/cuda/lib64/libcudart.so.12'\n",
+                encoding="utf-8",
+            )
+            ldconfig.chmod(0o755)
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                f"""
+                export PATH={shlex_quote(str(wrappers))}:$PATH
+                detect_cuda_major
+                """,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "12")
+
     def test_release_target_helpers_report_unsupported_armv7(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -44,6 +44,27 @@ class InstallScriptTests(unittest.TestCase):
             self.assertIn(f"asset={platform_asset}", result.stdout)
             self.assertIn(f"archive={tmp_path / platform_asset}", result.stdout)
 
+    def test_release_url_honors_test_asset_base_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            install_dir.mkdir()
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                """
+                RELEASE_URL_BASE=https://example.invalid/assets/
+                release_url mesh-llm-aarch64-unknown-linux-gnu.tar.gz
+                """,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.strip(),
+                "https://example.invalid/assets/mesh-llm-aarch64-unknown-linux-gnu.tar.gz",
+            )
+
     def test_download_release_archive_falls_back_to_mesh_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -35,6 +35,7 @@ class InstallScriptTests(unittest.TestCase):
                 release_url() {{
                     printf 'file://{assets_dir}/%s\\n' "$1"
                 }}
+                INSTALL_VERBOSE=1
                 download_release_archive "{tmp_path}" "{platform_asset}"
                 printf 'asset=%s\\narchive=%s\\n' "$DOWNLOADED_ASSET" "$DOWNLOADED_ARCHIVE"
                 """,
@@ -177,6 +178,7 @@ class InstallScriptTests(unittest.TestCase):
                 release_url() {{
                     printf 'file://{assets_dir}/%s\\n' "$1"
                 }}
+                INSTALL_VERBOSE=1
                 download_release_archive "{tmp_path}" "{platform_asset}"
                 printf 'asset=%s\\narchive=%s\\n' "$DOWNLOADED_ASSET" "$DOWNLOADED_ARCHIVE"
                 """,
@@ -216,6 +218,41 @@ class InstallScriptTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(calls.read_text(encoding="utf-8"), "setup\n")
             self.assertFalse(tools.exists())
+            self.assertIn("↓ Fetching mesh-llm release...", result.stdout)
+            self.assertIn("Installed mesh-llm to", result.stdout)
+            self.assertNotIn("Release channel:", result.stdout)
+            self.assertNotIn("Verified checksum:", result.stdout)
+            self.assertNotIn("Running post-install setup:", result.stdout)
+
+    def test_main_verbose_output_keeps_download_details(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, calls, tools = self._run_main(
+                tmp,
+                interactive=True,
+                args=["--verbose"],
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(calls.read_text(encoding="utf-8"), "setup --verbose\n")
+            self.assertFalse(tools.exists())
+            self.assertIn("Release channel: stable", result.stdout)
+            self.assertIn("Verified checksum:", result.stdout)
+            self.assertIn("Installed mesh-llm-aarch64-apple-darwin.tar.gz", result.stdout)
+            self.assertIn("Running post-install setup:", result.stdout)
+            self.assertNotIn("↓ Fetching mesh-llm release...", result.stdout)
+
+    def test_main_env_verbose_forwards_to_setup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, calls, tools = self._run_main(
+                tmp,
+                interactive=True,
+                extra_exports="INSTALL_VERBOSE=1",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(calls.read_text(encoding="utf-8"), "setup --verbose\n")
+            self.assertFalse(tools.exists())
+            self.assertIn("Release channel: stable", result.stdout)
 
     def test_main_prints_setup_command_when_noninteractive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -224,8 +261,10 @@ class InstallScriptTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertFalse(calls.exists())
             self.assertFalse(tools.exists())
+            self.assertIn("↓ Fetching mesh-llm release...", result.stdout)
             self.assertIn("Run this next:", result.stdout)
             self.assertIn("/mesh-llm setup", result.stdout)
+            self.assertNotIn("Release channel:", result.stdout)
 
     def test_main_prints_setup_command_when_no_setup_is_requested(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -236,6 +275,23 @@ class InstallScriptTests(unittest.TestCase):
             self.assertFalse(tools.exists())
             self.assertIn("Run this next:", result.stdout)
             self.assertIn("/mesh-llm setup", result.stdout)
+
+    def test_main_downloads_recommended_cuda_asset_on_jetson_orin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _calls, _tools = self._run_main(
+                tmp,
+                interactive=False,
+                args=["--no-setup"],
+                os_name="Linux",
+                arch="aarch64",
+                tegra_model="NVIDIA Jetson AGX Orin",
+                archive_name="mesh-llm-aarch64-unknown-linux-gnu-cuda-13.tar.gz",
+                extra_exports="detect_cuda_major() { printf '13\\n'; }",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Installed mesh-llm to", result.stdout)
+            self.assertNotIn("mesh-llm-aarch64-unknown-linux-gnu-cuda-13.tar.gz", result.stdout)
 
     def test_legacy_service_flags_pass_through_to_setup_without_shell_service_calls(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -258,6 +314,11 @@ class InstallScriptTests(unittest.TestCase):
         *,
         interactive: bool,
         args: list[str] | None = None,
+        os_name: str = "Darwin",
+        arch: str = "arm64",
+        tegra_model: str = "",
+        archive_name: str = "mesh-llm-aarch64-apple-darwin.tar.gz",
+        extra_exports: str = "",
     ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
         tmp_path = Path(tmp_dir)
         install_dir = tmp_path / "bin"
@@ -266,7 +327,7 @@ class InstallScriptTests(unittest.TestCase):
         assets_dir.mkdir()
         calls = tmp_path / "mesh-llm-calls.log"
         tools = tmp_path / "service-tools.log"
-        archive_path = assets_dir / "mesh-llm-aarch64-apple-darwin.tar.gz"
+        archive_path = assets_dir / archive_name
         self._write_release_archive(archive_path, calls)
         wrappers = self._write_service_wrappers(tmp_path / "wrappers", tools)
         joined_args = " ".join(shlex_quote(arg) for arg in (args or []))
@@ -278,9 +339,11 @@ class InstallScriptTests(unittest.TestCase):
             release_url() {{
                 printf 'file://{assets_dir}/%s\\n' "$1"
             }}
+            {extra_exports}
             export MESH_LLM_TEST_INTERACTIVE={'1' if interactive else '0'}
-            export MESH_LLM_TEST_UNAME_S=Darwin
-            export MESH_LLM_TEST_UNAME_M=arm64
+            export MESH_LLM_TEST_UNAME_S={shlex_quote(os_name)}
+            export MESH_LLM_TEST_UNAME_M={shlex_quote(arch)}
+            export MESH_LLM_TEST_TEGRA_MODEL={shlex_quote(tegra_model)}
             main --install-dir {shlex_quote(str(install_dir))} {joined_args}
             """,
         )

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
+import shlex
 import subprocess
+import tarfile
 import tempfile
 import textwrap
 import unittest
+from typing import Final
 
 
-ROOT = Path(__file__).resolve().parents[2]
-SCRIPT = ROOT / "install.sh"
+ROOT: Final = Path(__file__).resolve().parents[2]
+SCRIPT: Final = ROOT / "install.sh"
 
 
 class InstallScriptTests(unittest.TestCase):
@@ -21,9 +25,8 @@ class InstallScriptTests(unittest.TestCase):
             assets_dir = tmp_path / "assets"
             assets_dir.mkdir()
             platform_asset = "mesh-llm-aarch64-apple-darwin.tar.gz"
-            (assets_dir / platform_asset).write_text("platform\n", encoding="utf-8")
-            (assets_dir / "native-runtimes.json").write_text("{}\n", encoding="utf-8")
-            (assets_dir / "mesh-bundle.tar.gz").write_text("fallback\n", encoding="utf-8")
+            self._write_file_with_checksum(assets_dir / platform_asset, "platform\n")
+            self._write_file_with_checksum(assets_dir / "mesh-bundle.tar.gz", "fallback\n")
 
             result = self._run_helper(
                 tmp_path,
@@ -41,7 +44,7 @@ class InstallScriptTests(unittest.TestCase):
             self.assertIn(f"asset={platform_asset}", result.stdout)
             self.assertIn(f"archive={tmp_path / platform_asset}", result.stdout)
 
-    def test_download_release_archive_falls_back_to_runtime_mesh_bundle(self) -> None:
+    def test_download_release_archive_falls_back_to_mesh_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             install_dir = tmp_path / "bin"
@@ -49,8 +52,7 @@ class InstallScriptTests(unittest.TestCase):
             assets_dir = tmp_path / "assets"
             assets_dir.mkdir()
             platform_asset = "mesh-llm-aarch64-apple-darwin.tar.gz"
-            (assets_dir / "native-runtimes.json").write_text("{}\n", encoding="utf-8")
-            (assets_dir / "mesh-bundle.tar.gz").write_text("fallback\n", encoding="utf-8")
+            self._write_file_with_checksum(assets_dir / "mesh-bundle.tar.gz", "fallback\n")
 
             result = self._run_helper(
                 tmp_path,
@@ -67,7 +69,7 @@ class InstallScriptTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("asset=mesh-bundle.tar.gz", result.stdout)
             self.assertIn(f"archive={tmp_path / 'mesh-bundle.tar.gz'}", result.stdout)
-            self.assertIn("Using runtime-enabled mesh bundle", result.stdout)
+            self.assertIn("Using runtime-enabled mesh bundle fallback", result.stdout)
 
     def test_download_release_archive_fails_without_old_or_new_release_shape(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -91,106 +93,82 @@ class InstallScriptTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("could not download release archive", result.stderr)
 
-    def test_missing_native_runtime_manifest_is_silent_and_optional(self) -> None:
+    def test_main_runs_setup_interactively(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            install_dir = tmp_path / "bin"
-            install_dir.mkdir()
-            calls = tmp_path / "calls.log"
-            self._write_fake_mesh_llm(
-                install_dir / "mesh-llm",
-                f"""
-                if [[ "$*" == "runtime install --help" ]]; then
-                    exit 0
-                fi
-                echo "$*" >> {calls}
-                exit 0
-                """,
-            )
-
-            result = self._run_helper(
-                tmp_path,
-                install_dir,
-                f"""
-                release_url() {{
-                    printf 'file://{tmp_path}/missing-native-runtimes.json\\n'
-                }}
-                install_recommended_native_runtime "{tmp_path}"
-                """,
-            )
+            result, calls, tools = self._run_main(tmp, interactive=True)
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual(result.stdout, "")
-            self.assertEqual(result.stderr, "")
+            self.assertEqual(calls.read_text(encoding="utf-8"), "setup\n")
+            self.assertFalse(tools.exists())
+
+    def test_main_prints_setup_command_when_noninteractive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, calls, tools = self._run_main(tmp, interactive=False)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
             self.assertFalse(calls.exists())
+            self.assertFalse(tools.exists())
+            self.assertIn("Run this next:", result.stdout)
+            self.assertIn("/mesh-llm setup", result.stdout)
 
-    def test_old_binary_without_runtime_command_skips_manifest_lookup(self) -> None:
+    def test_main_prints_setup_command_when_no_setup_is_requested(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            install_dir = tmp_path / "bin"
-            install_dir.mkdir()
-            release_url_calls = tmp_path / "release-url-calls.log"
-            self._write_fake_mesh_llm(
-                install_dir / "mesh-llm",
-                """
-                exit 2
-                """,
-            )
+            result, calls, tools = self._run_main(tmp, interactive=True, args=["--no-setup"])
 
-            result = self._run_helper(
-                tmp_path,
-                install_dir,
-                f"""
-                release_url() {{
-                    echo called >> {release_url_calls}
-                    return 1
-                }}
-                install_recommended_native_runtime "{tmp_path}"
-                """,
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(calls.exists())
+            self.assertFalse(tools.exists())
+            self.assertIn("Run this next:", result.stdout)
+            self.assertIn("/mesh-llm setup", result.stdout)
+
+    def test_legacy_service_flags_pass_through_to_setup_without_shell_service_calls(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, calls, tools = self._run_main(
+                tmp,
+                interactive=True,
+                args=["--service", "--no-start-service"],
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertFalse(release_url_calls.exists())
+            self.assertEqual(calls.read_text(encoding="utf-8"), "setup --service\n")
+            self.assertFalse(tools.exists())
+            self.assertNotIn("runtime install", calls.read_text(encoding="utf-8"))
+            self.assertNotIn("runtime prune", calls.read_text(encoding="utf-8"))
+            self.assertIn("forwarding it to `mesh-llm setup --service`", result.stderr)
 
-    def test_runtime_capable_binary_installs_available_manifest(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            install_dir = tmp_path / "bin"
-            install_dir.mkdir()
-            manifest = tmp_path / "native-runtimes-source.json"
-            manifest.write_text('{"runtimes":[]}\n', encoding="utf-8")
-            calls = tmp_path / "calls.log"
-            self._write_fake_mesh_llm(
-                install_dir / "mesh-llm",
-                f"""
-                if [[ "$*" == "runtime install --help" ]]; then
-                    exit 0
-                fi
-                echo "$*" >> {calls}
-                exit 0
-                """,
-            )
-
-            result = self._run_helper(
-                tmp_path,
-                install_dir,
-                f"""
-                release_url() {{
-                    printf 'file://{manifest}\\n'
-                }}
-                install_recommended_native_runtime "{tmp_path}"
-                """,
-            )
-
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn(
-                f"runtime install --manifest {tmp_path / 'native-runtimes.json'}",
-                calls.read_text(encoding="utf-8"),
-            )
-            self.assertIn(
-                "runtime prune --active-only",
-                calls.read_text(encoding="utf-8"),
-            )
+    def _run_main(
+        self,
+        tmp_dir: str,
+        *,
+        interactive: bool,
+        args: list[str] | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+        tmp_path = Path(tmp_dir)
+        install_dir = tmp_path / "bin"
+        install_dir.mkdir()
+        assets_dir = tmp_path / "assets"
+        assets_dir.mkdir()
+        calls = tmp_path / "mesh-llm-calls.log"
+        tools = tmp_path / "service-tools.log"
+        archive_path = assets_dir / "mesh-llm-aarch64-apple-darwin.tar.gz"
+        self._write_release_archive(archive_path, calls)
+        wrappers = self._write_service_wrappers(tmp_path / "wrappers", tools)
+        joined_args = " ".join(shlex_quote(arg) for arg in (args or []))
+        result = self._run_helper(
+            tmp_path,
+            install_dir,
+            f"""
+            export PATH={wrappers}:$PATH
+            release_url() {{
+                printf 'file://{assets_dir}/%s\\n' "$1"
+            }}
+            export MESH_LLM_TEST_INTERACTIVE={'1' if interactive else '0'}
+            export MESH_LLM_TEST_UNAME_S=Darwin
+            export MESH_LLM_TEST_UNAME_M=arm64
+            main --install-dir {shlex_quote(str(install_dir))} {joined_args}
+            """,
+        )
+        return result, calls, tools
 
     def _run_helper(
         self,
@@ -204,9 +182,9 @@ class InstallScriptTests(unittest.TestCase):
             f"""
             set -euo pipefail
             source {SCRIPT}
-            INSTALL_DIR={install_dir}
+            INSTALL_DIR={shlex_quote(str(install_dir))}
             {body}
-            """
+            """,
         )
         return subprocess.run(
             ["bash", "-c", script],
@@ -217,12 +195,48 @@ class InstallScriptTests(unittest.TestCase):
             check=False,
         )
 
-    def _write_fake_mesh_llm(self, path: Path, body: str) -> None:
-        path.write_text(
-            "#!/usr/bin/env bash\nset -euo pipefail\n" + textwrap.dedent(body),
+    def _write_file_with_checksum(self, path: Path, contents: str) -> None:
+        path.write_text(contents, encoding="utf-8")
+        digest = hashlib.sha256(contents.encode("utf-8")).hexdigest()
+        path.with_name(f"{path.name}.sha256").write_text(f"{digest}  {path.name}\n", encoding="utf-8")
+
+    def _write_release_archive(self, archive_path: Path, calls: Path) -> None:
+        with tempfile.TemporaryDirectory() as bundle_tmp:
+            bundle_root = Path(bundle_tmp) / "mesh-bundle"
+            bundle_root.mkdir()
+            mesh_llm = bundle_root / "mesh-llm"
+            mesh_llm.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                f"printf '%s\\n' \"$*\" >> {calls}\n",
+                encoding="utf-8",
+            )
+            mesh_llm.chmod(0o755)
+            with tarfile.open(archive_path, "w:gz") as archive:
+                archive.add(bundle_root, arcname="mesh-bundle")
+        digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+        archive_path.with_name(f"{archive_path.name}.sha256").write_text(
+            f"{digest}  {archive_path.name}\n",
             encoding="utf-8",
         )
-        path.chmod(0o755)
+
+    def _write_service_wrappers(self, directory: Path, log_path: Path) -> str:
+        directory.mkdir()
+        for name in ("systemctl", "launchctl"):
+            script_path = directory / name
+            script_path.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                f"echo {name} >> {log_path}\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            script_path.chmod(0o755)
+        return str(directory)
+
+
+def shlex_quote(value: str) -> str:
+    return subprocess.list2cmdline([value]) if os.name == "nt" else shlex.quote(value)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -113,6 +113,37 @@ class InstallScriptTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip(), "cuda")
 
+    def test_checksum_from_sidecar_does_not_depend_on_awk_intervals(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            install_dir.mkdir()
+            wrappers = tmp_path / "wrappers"
+            wrappers.mkdir()
+            fake_awk = wrappers / "awk"
+            fake_awk.write_text(
+                "#!/usr/bin/env bash\n"
+                "echo 'mawk interval expressions are unavailable' >&2\n"
+                "exit 2\n",
+                encoding="utf-8",
+            )
+            fake_awk.chmod(0o755)
+            digest = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+            sidecar = tmp_path / "archive.tar.gz.sha256"
+            sidecar.write_text(f"{digest}  archive.tar.gz\n", encoding="utf-8")
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                f"""
+                export PATH={shlex_quote(str(wrappers))}:$PATH
+                checksum_from_sidecar {shlex_quote(str(sidecar))}
+                """,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), digest.lower())
+
     def test_detect_cuda_major_reads_ldconfig_libcudart_version(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)

--- a/website/src/_includes/components/cta-terminal.njk
+++ b/website/src/_includes/components/cta-terminal.njk
@@ -16,11 +16,16 @@
 
   <div class="cta-terminal-body">
     <div class="cta-terminal-block">
-      <p class="comment"># Install Mesh (macOS, Linux, Windows &middot; ~18 MB)</p>
+      <p class="comment"># Install the executable (macOS, Linux, Windows)</p>
       <p class="cta-install-command" data-install-command-display aria-live="polite"><span class="prompt">$</span> <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="value">https://meshllm.cloud/install.sh</span> <span class="pipe">|</span> <span class="cmd">bash</span></p>
       <template data-install-template="curl"><span class="prompt">$</span> <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="value">https://meshllm.cloud/install.sh</span> <span class="pipe">|</span> <span class="cmd">bash</span></template>
       <template data-install-template="brew"><span class="prompt">$</span> <span class="cmd">brew</span> <span class="cmd">install</span> <span class="value">mesh-llm/tap/mesh-llm</span></template>
       <template data-install-template="cargo"><span class="prompt">$</span> <span class="cmd">cargo</span> <span class="cmd">install</span> <span class="value">mesh-llm</span></template>
+    </div>
+
+    <div class="cta-terminal-block">
+      <p class="comment"># Finish setup</p>
+      <p><span class="prompt">$</span> <span class="cmd">mesh-llm</span> <span class="cmd">setup</span></p>
     </div>
 
     <div class="cta-terminal-block">

--- a/website/src/_includes/components/cta-terminal.njk
+++ b/website/src/_includes/components/cta-terminal.njk
@@ -16,7 +16,7 @@
 
   <div class="cta-terminal-body">
     <div class="cta-terminal-block">
-      <p class="comment"># Install the executable (macOS, Linux, Windows)</p>
+      <p class="comment"># Install the executable (macOS, Linux)</p>
       <p class="cta-install-command" data-install-command-display aria-live="polite"><span class="prompt">$</span> <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="value">https://meshllm.cloud/install.sh</span> <span class="pipe">|</span> <span class="cmd">bash</span></p>
       <template data-install-template="curl"><span class="prompt">$</span> <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="value">https://meshllm.cloud/install.sh</span> <span class="pipe">|</span> <span class="cmd">bash</span></template>
       <template data-install-template="brew"><span class="prompt">$</span> <span class="cmd">brew</span> <span class="cmd">install</span> <span class="value">mesh-llm/tap/mesh-llm</span></template>

--- a/website/src/_includes/sections/hero.njk
+++ b/website/src/_includes/sections/hero.njk
@@ -32,6 +32,13 @@
             <i data-lucide="copy" aria-hidden="true"></i>
           </button>
         </div>
+        <div class="hero-setup flex min-h-12 min-w-0 items-center gap-2 overflow-hidden rounded-mesh border border-line-soft bg-void/80 px-3 shadow-terminal" aria-label="Finish setup">
+          <code class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs sm:text-sm">
+            <span class="prompt">$</span>
+            <span class="cmd">mesh-llm</span>
+            <span class="cmd">setup</span>
+          </code>
+        </div>
         <a class="hero-public inline-flex min-h-12 items-center justify-center gap-2 rounded-mesh px-4 text-sm font-semibold" href="{{ site.publicMeshUrl }}">
           <span>Public mesh</span>
           <i data-lucide="share-2" aria-hidden="true"></i>

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -34,12 +34,6 @@ Local source builds may include build metadata, such as `mesh-llm 0.72.1+gABCDEF
 
 ## Start here (common tasks)
 
-Finish a fresh install:
-
-```bash
-mesh-llm setup
-```
-
 If you want to:
 
 1. Finish a fresh install:

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -10,6 +10,8 @@ Catalog id definition: a catalog id is the model id shown in `mesh-llm models re
 ```bash
 mesh-llm --help
 mesh-llm <command> --help
+mesh-llm setup --help
+mesh-llm doctor --help
 mesh-llm serve --help
 mesh-llm client --help
 mesh-llm --help-advanced
@@ -32,34 +34,52 @@ Local source builds may include build metadata, such as `mesh-llm 0.72.1+gABCDEF
 
 ## Start here (common tasks)
 
+Finish a fresh install:
+
+```bash
+mesh-llm setup
+```
+
 If you want to:
 
-1. Start serving right away:
+1. Finish a fresh install:
+
+```bash
+mesh-llm setup
+```
+
+2. Start serving on this machine:
+
+```bash
+mesh-llm serve --model Qwen3-0.6B-Q4_K_M
+```
+
+3. Join the public mesh:
 
 ```bash
 mesh-llm serve --auto
 ```
 
-2. Find a model you can run:
+4. Find a model you can run:
 
 ```bash
 mesh-llm models search gemma --gguf
 mesh-llm models search smoll --mlx
 ```
 
-3. Inspect a model before downloading:
+5. Inspect a model before downloading:
 
 ```bash
 mesh-llm models show unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL
 ```
 
-4. Download a model:
+6. Download a model:
 
 ```bash
 mesh-llm models download unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL
 ```
 
-5. Check what is already installed:
+7. Check what is already installed:
 
 ```bash
 mesh-llm models installed
@@ -72,15 +92,54 @@ If you want to start serving, join a mesh, or run as an API-only client, start h
 Examples:
 
 ```bash
+mesh-llm setup
 mesh-llm serve
 mesh-llm serve --model Qwen3-0.6B-Q4_K_M
 mesh-llm client --auto
 ```
 
-Use `mesh-llm serve --help` for the common serving flags, including `--model`,
-`--gguf`, `--auto`, `--join`, ports, and logging. Use
-`mesh-llm client --help` for client-only mesh operation when this machine should
-join or discover a mesh without serving a local model.
+### `setup`
+
+Use this to finish a fresh install after the executable is on your `PATH`.
+
+`mesh-llm setup` downloads and configures the native runtime, can install and
+enable the background service on supported macOS and Linux machines, and only
+shows the GitHub star prompt when it is interactive and eligible. The star
+prompt defaults to Yes, and `--yes` or `--no-interactive` skip it without
+starring anything.
+
+Usage:
+
+```bash
+mesh-llm setup
+mesh-llm setup --service
+mesh-llm setup --no-service --skip-runtime
+mesh-llm setup --yes
+```
+
+Switches:
+
+- `--yes`: automatically answer yes to setup prompts. This accepts the service prompt and skips the GitHub star prompt.
+- `--no-interactive`: run without prompting. When service is not requested, setup prints guidance to rerun with `--service`.
+- `--service`: install and enable the background service.
+- `--no-service`: skip installing and enabling the background service.
+- `--skip-runtime`: skip downloading or configuring the native runtime.
+
+On Windows, `--service` is unsupported.
+
+### `doctor`
+
+Use this only when troubleshooting a failed install or runtime problem. It gathers local status, runtime diagnostics, and logs.
+
+Usage:
+
+```bash
+mesh-llm doctor
+```
+
+Switches:
+
+- `--json`: machine-readable output.
 
 Runtime switches:
 

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -11,6 +11,7 @@ Catalog id definition: a catalog id is the model id shown in `mesh-llm models re
 mesh-llm --help
 mesh-llm <command> --help
 mesh-llm setup --help
+mesh-llm uninstall --help
 mesh-llm doctor --help
 mesh-llm serve --help
 mesh-llm client --help
@@ -79,6 +80,13 @@ mesh-llm models download unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL
 mesh-llm models installed
 ```
 
+8. Remove the executable and setup-owned files:
+
+```bash
+mesh-llm uninstall --dry-run
+mesh-llm uninstall --yes
+```
+
 ## Runtime entrypoints (`serve` / `client`)
 
 If you want to start serving, join a mesh, or run as an API-only client, start here.
@@ -100,7 +108,8 @@ Use this to finish a fresh install after the executable is on your `PATH`.
 enable the background service on supported macOS and Linux machines, and only
 shows the GitHub star prompt when it is interactive and eligible. The star
 prompt defaults to Yes, and `--yes` or `--no-interactive` skip it without
-starring anything.
+starring anything. Default output is concise; use `--verbose` when you want
+service paths, commands, log locations, and detailed setup status.
 
 Usage:
 
@@ -109,6 +118,7 @@ mesh-llm setup
 mesh-llm setup --service
 mesh-llm setup --no-service --skip-runtime
 mesh-llm setup --yes
+mesh-llm setup --verbose
 ```
 
 Switches:
@@ -118,8 +128,46 @@ Switches:
 - `--service`: install and enable the background service.
 - `--no-service`: skip installing and enabling the background service.
 - `--skip-runtime`: skip downloading or configuring the native runtime.
+- `--verbose`: print detailed service paths, commands, log locations, and setup status.
 
 On Windows, `--service` is unsupported.
+
+### `uninstall`
+
+Use this to remove a Mesh executable install and setup-owned service/runtime files from a machine.
+
+By default, uninstall stops tracked `mesh-llm` processes, disables and removes
+the per-user service when present, removes setup-owned service helper files,
+removes the native-runtime cache, and removes the executable last. It preserves
+`~/.mesh-llm` configuration and identity data unless you explicitly pass
+`--purge-config`.
+
+Usage:
+
+```bash
+mesh-llm uninstall --dry-run
+mesh-llm uninstall --yes
+mesh-llm uninstall --yes --keep-cache
+mesh-llm uninstall --yes --purge-config
+mesh-llm uninstall --verbose --dry-run
+```
+
+Switches:
+
+- `--dry-run`: print the cleanup plan without changing the machine.
+- `--yes`: run without a confirmation prompt.
+- `--json`: print dry-run plans and outcomes as JSON.
+- `--verbose`: print detailed cleanup steps and removed paths.
+- `--keep-cache`: preserve downloaded native runtimes.
+- `--keep-service-files`: preserve setup-owned service helper files.
+- `--purge-config`: remove `~/.mesh-llm` configuration and identity data.
+- `--keep-config`: explicitly preserve configuration and identity data.
+- `--binary-path <PATH>`: remove a specific executable path.
+
+If the setup service configuration directory contains unrelated files,
+uninstall leaves that directory in place and reports a warning instead of
+recursively deleting it. Default text output is concise; use `--verbose` when
+you want the full cleanup plan or exact removed paths.
 
 ### `doctor`
 

--- a/website/src/docs/pages/hardware-support.md
+++ b/website/src/docs/pages/hardware-support.md
@@ -6,12 +6,12 @@ Mesh can run on one machine or across several machines. The release flavor contr
 
 | Machine | Recommended flavor | Install behavior |
 |---|---|---|
-| Apple Silicon Mac | `metal` | macOS installer selects it automatically. |
-| Linux NVIDIA (all architectures) | `cuda` | Linux installer selects CUDA when NVIDIA tooling or devices are detected. |
+| Apple Silicon Mac | `metal` | Setup selects Metal automatically. |
+| Linux NVIDIA (all architectures) | `cuda` | Setup selects CUDA when a compatible published runtime matches the host CUDA toolkit and GPU architecture. |
 | Linux AMD | `rocm` | Use when ROCm/HIP is installed and supported by the GPU. |
 | Linux Vulkan-capable GPU | `vulkan` | Useful when CUDA/ROCm are not available. |
-| Linux ARM64 | `cpu` | Published ARM64 Linux bundle is CPU-only. |
-| Windows NVIDIA | `cuda` | Windows installer detects NVIDIA when possible. |
+| Linux ARM64 | `cuda` or `cpu` | NVIDIA Jetson/Orin-class hosts should use CUDA when the release publishes a compatible ARM64 CUDA runtime; otherwise setup falls back to CPU. |
+| Windows NVIDIA | `cuda` | Setup selects CUDA when a compatible published runtime matches the host. |
 | Windows AMD | `rocm` | Use when the Windows HIP runtime is available. |
 | Any supported OS | `cpu` | Slowest, but useful for testing and API-only workflows. |
 

--- a/website/src/docs/pages/installing-linux.md
+++ b/website/src/docs/pages/installing-linux.md
@@ -28,6 +28,17 @@ The installer downloads the `mesh-llm` executable and adds `~/.local/bin` to you
 
 Run `mesh-llm setup` to finish machine setup. See the [CLI guide](/docs/pages/CLI/) for the setup flags.
 
+## Uninstall
+
+```sh
+mesh-llm uninstall --dry-run
+mesh-llm uninstall --yes
+```
+
+On Linux, uninstall disables the per-user systemd unit when present, removes
+setup-owned service files, removes the native-runtime cache, and removes the
+executable last. It preserves `~/.mesh-llm` unless you pass `--purge-config`.
+
 ## Advanced install
 
 Install the latest prerelease:

--- a/website/src/docs/pages/installing-linux.md
+++ b/website/src/docs/pages/installing-linux.md
@@ -20,26 +20,13 @@ Check the install:
 mesh-llm --version
 ```
 
-## Flavor selection
-
-The installer auto-detects your GPU and selects the best bundle. Supported Linux flavors:
-
-| Flavor | Hardware | Notes |
-|---|---|---|
-| `cuda` | NVIDIA (all architectures) | Selected when NVIDIA tooling or devices detected |
-| `rocm` | AMD GPUs with ROCm/HIP | Use when ROCm is installed |
-| `vulkan` | Vulkan-capable GPUs | Useful when CUDA/ROCm not available |
-| `cpu` | Any Linux x86_64 or ARM64 | ARM64 bundles are CPU-only |
-
-Force a specific flavor:
-
-```sh
-curl -fsSL https://meshllm.cloud/install.sh | bash -s -- --flavor cuda
-```
-
 ## What the installer does
 
-The installer detects your Linux hardware, selects the matching release bundle, downloads the Mesh release, installs the `mesh-llm` binary, and adds `~/.local/bin` to your user `PATH` when needed.
+The installer downloads the `mesh-llm` executable and adds `~/.local/bin` to your user `PATH` when needed. After install, run `mesh-llm setup` to finish runtime configuration and, if you want it, the background service.
+
+## Next step
+
+Run `mesh-llm setup` to finish machine setup. See the [CLI guide](/docs/pages/CLI/) for the setup flags.
 
 ## Advanced install
 
@@ -54,10 +41,6 @@ Install to a custom location:
 ```sh
 curl -fsSL https://meshllm.cloud/install.sh | bash -s -- --install-dir "$HOME/bin"
 ```
-
-## Next step
-
-Run the [Quickstart](/docs/pages/quickstart/) to start a private node and open the console.
 
 ## See also
 

--- a/website/src/docs/pages/installing-macos.md
+++ b/website/src/docs/pages/installing-macos.md
@@ -36,6 +36,17 @@ The installer downloads the `mesh-llm` executable and adds `~/.local/bin` to you
 
 Run `mesh-llm setup` to finish machine setup. See the [CLI guide](/docs/pages/CLI/) for the setup flags.
 
+## Uninstall
+
+```sh
+mesh-llm uninstall --dry-run
+mesh-llm uninstall --yes
+```
+
+On macOS, uninstall boots out the per-user launchd agent when present, removes
+setup-owned service files, removes the native-runtime cache, and removes the
+executable last. It preserves `~/.mesh-llm` unless you pass `--purge-config`.
+
 ## Advanced install
 
 Install the latest prerelease:

--- a/website/src/docs/pages/installing-macos.md
+++ b/website/src/docs/pages/installing-macos.md
@@ -30,23 +30,11 @@ brew install mesh-llm/tap/mesh-llm
 
 ## What the installer does
 
-The installer detects your Mac hardware, selects the `metal` bundle (optimized for Apple Silicon), downloads the matching Mesh release, installs the `mesh-llm` binary, and adds `~/.local/bin` to your user `PATH` when needed.
+The installer downloads the `mesh-llm` executable and adds `~/.local/bin` to your user `PATH` when needed. After install, run `mesh-llm setup` to finish runtime configuration and, if you want it, the background service.
 
-## Force a flavor
+## Next step
 
-The macOS installer auto-detects `metal`. Force a different flavor when auto-detection is wrong or you want to test a specific backend:
-
-```sh
-curl -fsSL https://meshllm.cloud/install.sh | bash -s -- --flavor vulkan
-```
-
-Available macOS flavors:
-
-| Flavor | Use case |
-|---|---|
-| `metal` | Apple Silicon (default, recommended) |
-| `vulkan` | Vulkan-capable GPUs via MoltenVK |
-| `cpu` | CPU-only (slowest, useful for API-only nodes) |
+Run `mesh-llm setup` to finish machine setup. See the [CLI guide](/docs/pages/CLI/) for the setup flags.
 
 ## Advanced install
 
@@ -61,10 +49,6 @@ Install to a custom location:
 ```sh
 curl -fsSL https://meshllm.cloud/install.sh | bash -s -- --install-dir "$HOME/bin"
 ```
-
-## Next step
-
-Run the [Quickstart](/docs/pages/quickstart/) to start a private node and open the console.
 
 ## See also
 

--- a/website/src/docs/pages/installing-mesh.md
+++ b/website/src/docs/pages/installing-mesh.md
@@ -8,13 +8,13 @@ Mesh runs on macOS, Linux, and Windows. Choose your platform for detailed instal
 
 ## Choose your platform
 
-- [Installing on macOS](/docs/pages/installing-macos/) &mdash; Apple Silicon (Metal), Homebrew, flavors
-- [Installing on Linux](/docs/pages/installing-linux/) &mdash; CUDA, ROCm, Vulkan, CPU
-- [Installing on Windows](/docs/pages/installing-windows/) &mdash; CUDA, ROCm, Vulkan, CPU
+- [Installing on macOS](/docs/pages/installing-macos/) (Apple Silicon, Homebrew)
+- [Installing on Linux](/docs/pages/installing-linux/) (platform details)
+- [Installing on Windows](/docs/pages/installing-windows/) (platform details)
 
 ## What the installer does
 
-The installer detects the best release bundle for your machine, downloads the matching Mesh release, installs the `mesh-llm` binary, and adds the install directory to your user `PATH` when needed.
+The installer downloads the `mesh-llm` executable and adds the install directory to your user `PATH` when needed. After install, run `mesh-llm setup` to finish runtime configuration and service setup.
 
 Default install locations:
 
@@ -31,7 +31,7 @@ mesh-llm --version
 
 ## Next step
 
-Run the [Quickstart](/docs/pages/quickstart/) to start a private node and open the console.
+Run `mesh-llm setup` to finish machine setup, then follow the [Quickstart](/docs/pages/quickstart/) to start a private node and open the console.
 
 ## See also
 

--- a/website/src/docs/pages/installing-mesh.md
+++ b/website/src/docs/pages/installing-mesh.md
@@ -33,6 +33,23 @@ mesh-llm --version
 
 Run `mesh-llm setup` to finish machine setup, then follow the [Quickstart](/docs/pages/quickstart/) to start a private node and open the console.
 
+## Uninstall
+
+Preview what Mesh would remove:
+
+```sh
+mesh-llm uninstall --dry-run
+```
+
+Remove the executable, setup-owned service files, and native-runtime cache:
+
+```sh
+mesh-llm uninstall --yes
+```
+
+Uninstall preserves `~/.mesh-llm` configuration and identity data by default.
+Use `--purge-config` only when you intentionally want to remove that data too.
+
 ## See also
 
 - [Hardware support](/docs/pages/hardware-support/)

--- a/website/src/docs/pages/installing-windows.md
+++ b/website/src/docs/pages/installing-windows.md
@@ -30,6 +30,16 @@ The installer downloads the `mesh-llm` executable and adds `%LOCALAPPDATA%\mesh-
 
 Run `mesh-llm.exe setup` to finish machine setup. See the [CLI guide](/docs/pages/CLI/) for the setup flags.
 
+## Uninstall
+
+```powershell
+mesh-llm.exe uninstall --dry-run
+mesh-llm.exe uninstall --yes
+```
+
+On Windows, uninstall removes the executable and native-runtime cache. It
+preserves `%USERPROFILE%\.mesh-llm` unless you pass `--purge-config`.
+
 ## Advanced install
 
 Install the latest prerelease:

--- a/website/src/docs/pages/installing-windows.md
+++ b/website/src/docs/pages/installing-windows.md
@@ -22,26 +22,13 @@ Check the install:
 mesh-llm --version
 ```
 
-## Flavor selection
-
-The installer auto-detects your GPU and selects the best bundle. Supported Windows flavors:
-
-| Flavor | Hardware | Notes |
-|---|---|---|
-| `cuda` | NVIDIA (all architectures) | Selected when NVIDIA detected |
-| `rocm` | AMD GPUs with HIP runtime | Use when HIP runtime is available |
-| `vulkan` | Vulkan-capable GPUs | Useful when CUDA/ROCm not available |
-| `cpu` | Any Windows x86_64 | Slowest, useful for API-only nodes |
-
-Force a specific flavor:
-
-```powershell
-& ([scriptblock]::Create((irm https://meshllm.cloud/install.ps1))) -Flavor cuda
-```
-
 ## What the installer does
 
-The installer detects your Windows hardware, selects the matching release bundle, downloads the Mesh release, installs the `mesh-llm` binary, and adds `%LOCALAPPDATA%\mesh-llm\bin` to your user `PATH` when needed.
+The installer downloads the `mesh-llm` executable and adds `%LOCALAPPDATA%\mesh-llm\bin` to your user `PATH` when needed. After install, run `mesh-llm.exe setup` to finish runtime configuration.
+
+## Next step
+
+Run `mesh-llm.exe setup` to finish machine setup. See the [CLI guide](/docs/pages/CLI/) for the setup flags.
 
 ## Advanced install
 
@@ -56,10 +43,6 @@ Install to a custom location:
 ```powershell
 & ([scriptblock]::Create((irm https://meshllm.cloud/install.ps1))) -InstallDir "$HOME\bin"
 ```
-
-## Next step
-
-Run the [Quickstart](/docs/pages/quickstart/) to start a private node and open the console.
 
 ## See also
 

--- a/website/src/docs/pages/quickstart.md
+++ b/website/src/docs/pages/quickstart.md
@@ -4,29 +4,13 @@ title: Quickstart
 
 # Quickstart
 
-The easiest way to try Mesh is to create your own private mesh. Start one node on this machine, send a chat message, then try an agent. Later, you can add more machines or invite other people to join the same private mesh.
+The easiest way to try Mesh is to create your own private mesh. Start one node on this machine, finish setup, send a chat message, then try an agent. Later, you can add more machines or invite other people to join the same private mesh.
 
-## 1. Install Mesh
+## 1. Install the executable
 
 Choose your platform for the fastest path:
 
-{% set macosQuick %}
-```sh
-curl -fsSL https://meshllm.cloud/install.sh | bash
-```
-{% endset %}
-{% set linuxQuick %}
-```sh
-curl -fsSL https://meshllm.cloud/install.sh | bash
-```
-{% endset %}
-{% set windowsQuick %}
-```powershell
-irm https://meshllm.cloud/install.ps1 | iex
-```
-{% endset %}
-
-**macOS** &mdash; Metal (Apple Silicon):
+**macOS**:
 
 ```sh
 curl -fsSL https://meshllm.cloud/install.sh | bash
@@ -34,7 +18,7 @@ curl -fsSL https://meshllm.cloud/install.sh | bash
 
 Full guide: [Installing on macOS](/docs/pages/installing-macos/)
 
-**Linux** &mdash; CUDA, ROCm, Vulkan, or CPU:
+**Linux**:
 
 ```sh
 curl -fsSL https://meshllm.cloud/install.sh | bash
@@ -42,7 +26,7 @@ curl -fsSL https://meshllm.cloud/install.sh | bash
 
 Full guide: [Installing on Linux](/docs/pages/installing-linux/)
 
-**Windows** &mdash; CUDA, ROCm, Vulkan, or CPU:
+**Windows**:
 
 ```powershell
 irm https://meshllm.cloud/install.ps1 | iex
@@ -52,7 +36,23 @@ Full guide: [Installing on Windows](/docs/pages/installing-windows/)
 
 Open a new terminal after install if the installer added Mesh to your `PATH`.
 
-## 2. Start one private node
+## 2. Finish setup
+
+Run the setup command after the executable is installed:
+
+```sh
+mesh-llm setup
+```
+
+On Windows PowerShell:
+
+```powershell
+mesh-llm.exe setup
+```
+
+On interactive macOS and Linux terminals, setup can offer to install and enable the background service. The GitHub star prompt only appears when interactive and eligible, and it defaults to Yes.
+
+## 3. Start one private node
 
 Use this model first on a 12GB+ machine:
 
@@ -79,7 +79,7 @@ If the model does not load, stop Mesh and use the [model picker](/docs/pages/cho
 mesh-llm stop
 ```
 
-## 3. Chat in the console
+## 4. Chat in the console
 
 Open:
 
@@ -95,7 +95,7 @@ Say hello in one sentence.
 
 This proves the node is running, the model loaded, and the local routing path works.
 
-## 4. Check the API
+## 5. Check the API
 
 List the models your local node can route to:
 
@@ -105,7 +105,7 @@ curl -s http://localhost:9337/v1/models | jq '.data[].id'
 
 You should see at least one model id. Use that id for direct API calls or agents.
 
-## 5. Try an agent
+## 6. Try an agent
 
 After console chat works, run one agent launcher:
 
@@ -129,7 +129,7 @@ mesh-llm pi --host 127.0.0.1:9337
 
 For tools without a Mesh launcher, configure an OpenAI-compatible provider with base URL `http://localhost:9337/v1` and API key `dummy`.
 
-## 6. Add another machine
+## 7. Add another machine
 
 Install Mesh on another machine and run the same command with the same mesh name:
 

--- a/website/src/docs/pages/troubleshooting.md
+++ b/website/src/docs/pages/troubleshooting.md
@@ -4,7 +4,7 @@ Start with these checks before changing configuration.
 
 ## Report a problem
 
-Run `mesh-llm doctor` before opening a bug report. The doctor output gives the Mesh LLM team the local status, runtime diagnostics, and logs needed to debug the issue.
+Use `mesh-llm doctor` when you need local status, runtime diagnostics, or logs for a bug report. It is for troubleshooting, not the normal install flow.
 
 Capture a doctor archive:
 


### PR DESCRIPTION
## Summary

This PR implements the setup-first installer flow from `.omo/plans/mesh-setup-installer.md` and promotes the behavior spec to `docs/specs/mesh-setup-installer.md`.

Key changes:
- Adds `mesh-llm setup` as the owner of native-runtime install/prune, optional service setup, and optional GitHub starring.
- Simplifies Unix and PowerShell installers so scripts only install the binary and hand off to `mesh-llm setup`.
- Keeps legacy installer flags compatibility-oriented, with warnings for policy now owned by setup.
- Adds setup tests for planning, orchestration, runtime/prune behavior, service generation, GitHub prompts, and non-interactive paths.
- Fails service setup closed when systemd/launchd start/enable/bootstrap/kickstart commands fail after service setup was requested.
- Adds `MESH_LLM_INSTALL_URL_BASE` for Unix installer branch/deployment tests, matching the existing PowerShell test override.
- Updates README, CLI docs, usage docs, website install docs, and generated website docs.

## Example

```
./install.sh
✓ Installed mesh-llm to /home/ndizazzo/.local/bin

? Install the background service? [Y/n] y
? Star Mesh-LLM/mesh-llm on GitHub? [Y/n] 

✓ Mesh setup complete
  Runtime  skipped (--skip-runtime)
  Service  running
  GitHub   starred
```

## Screenshot
<img width="1182" height="229" alt="image" src="https://github.com/user-attachments/assets/8c3a2d6a-93d4-41d9-8e0c-f90d511f31fc" />

## Review Findings Addressed

During review against the plan/spec I found and fixed:

- **Correctness: service setup failures were only warnings.** When service setup was requested, failed systemd/launchd activation could leave users believing setup succeeded. Added failing tests first, then changed service setup to return errors for requested activation failures.
- **Documentation/spec drift: root `mesh_setup_spec.md` was stale and untracked.** Replaced it with canonical `docs/specs/mesh-setup-installer.md` and linked it from the docs indexes.
- **Deployment-testability gap: Unix installer lacked an asset-base override.** Added `MESH_LLM_INSTALL_URL_BASE` and Bash coverage so branch release assets can be tested without unpublished GitHub release artifacts.
- **Release-manifest guardrail:** Added a regression test proving generated native-runtime release manifests are single valid JSON documents.

## Local Validation

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p mesh-llm-cli --lib`
- `cargo test -p mesh-llm-commands --lib`
- `cargo test -p mesh-llm --lib`
- `python3 -m unittest scripts.tests.test_install_sh`
- `python3 -m unittest scripts.tests.test_install_ps1` (PowerShell tests skipped where `pwsh` is unavailable locally)
- `python3 -m unittest scripts.tests.test_generate_native_runtime_release_manifest`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `just website-build`
- `just build`
- Local smoke: `./target/debug/mesh-llm setup --skip-runtime --no-service --no-interactive`

## Remote Deployment Validation

Validated on both `mesh1.patio51.com` and `mesh2.patio51.com`:

- Pulled branch `feature/revise-install-paths`.
- Stopped existing mesh processes and removed the old `~/.local/bin/mesh-llm` install.
- Ran `just release-build` successfully on each ARM host.
- Packaged each host's release binary into a local `mesh-llm-aarch64-unknown-linux-gnu.tar.gz` test asset with SHA256 sidecar.
- Ran branch installer with `MESH_LLM_INSTALL_URL_BASE=file:///tmp/mesh-setup-install-test/assets`.
- Confirmed checksum verification and install to `~/.local/bin`.
- Confirmed installed binary reports `mesh-llm 0.68.0`.
- Built CPU native-runtime packages on both hosts with `scripts/package-native-runtime.sh --build --backend cpu --target aarch64-unknown-linux-gnu`.
- Generated local `native-runtimes.json`, served it over localhost HTTP, and ran:
  `MESH_LLM_NATIVE_RUNTIME_MANIFEST_URL=http://127.0.0.1:8123/native-runtimes.json ~/.local/bin/mesh-llm setup --no-service --no-interactive`
- Confirmed setup installed `meshllm-native-runtime-linux-aarch64-cpu`, pruned/checked cache, and summarized cleanly.
- Re-ran setup on both hosts to confirm idempotent `already installed; cache already clean` behavior.

Note: the default setup manifest URL for this unreleased branch points at GitHub release `v0.68.0`, which does not exist yet, so remote validation used the supported native-runtime manifest override with locally packaged branch runtimes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided `mesh-llm setup` flow after installation, including optional background service setup and an optional GitHub star prompt.
  * Added `mesh-llm uninstall` with dry-run, confirmation, and retention options.
  * Updated install scripts to launch or print the setup command after installation.

* **Documentation**
  * Revised quickstart, CLI, install, troubleshooting, and website pages to reflect the new setup/uninstall flow and updated commands.

* **Bug Fixes**
  * Improved uninstall safety and service handling across supported platforms.
  * Cleaned up terminal output for process termination messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->