### PR TITLE
chore: synchronize release version management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,14 +3613,14 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llama-quant-ffi"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "llama-spec-bench"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-api-client"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "hex",
  "mesh-llm-client",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-api-server"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "mesh-llm-api-client",
@@ -3803,11 +3803,11 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-build-info"
-version = "0.68.0"
+version = "0.72.1"
 
 [[package]]
 name = "mesh-llm-cli"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-client"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-commands"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-config"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-console-server"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "mesh-llm-ui",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-embedded-runtime"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "mesh-llm-host-runtime",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-events"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-ffi"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "mesh-llm-node",
  "mesh-llm-sdk",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-gpu-bench"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-guardrails"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3962,14 +3962,14 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-hardware-profile"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "mesh-llm-native-runtime",
 ]
 
 [[package]]
 name = "mesh-llm-host-runtime"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-identity"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "argon2",
  "base64",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-native-runtime"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-node"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "mesh-llm-types",
@@ -4110,7 +4110,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-nodejs"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "mesh-llm-sdk",
  "napi",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-plugin"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-plugin-manager"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-protocol"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -4167,14 +4167,14 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-routing"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "iroh",
 ]
 
 [[package]]
 name = "mesh-llm-runtime-install"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-sdk"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "mesh-llm-api-client",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-skills"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-system"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-test-harness"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "reqwest 0.12.28",
  "serde_json",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-tui"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-types"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "hex",
  "serde",
@@ -4280,14 +4280,14 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-ui"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "include_dir",
 ]
 
 [[package]]
 name = "mesh-mixture-of-agents"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "async-trait",
  "mesh-llm-guardrails",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "metrics-server"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "model-artifact"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "model-hf"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4391,7 +4391,7 @@ dependencies = [
 
 [[package]]
 name = "model-package"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4410,14 +4410,14 @@ dependencies = [
 
 [[package]]
 name = "model-ref"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "model-resolver"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "model-artifact",
@@ -5225,7 +5225,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openai-frontend"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -7367,7 +7367,7 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skippy-bench"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7384,7 +7384,7 @@ dependencies = [
 
 [[package]]
 name = "skippy-cache"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -7393,14 +7393,14 @@ dependencies = [
 
 [[package]]
 name = "skippy-coordinator"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "skippy-correctness"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7417,18 +7417,18 @@ dependencies = [
 
 [[package]]
 name = "skippy-ffi"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "skippy-metrics"
-version = "0.68.0"
+version = "0.72.1"
 
 [[package]]
 name = "skippy-model-package"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7446,7 +7446,7 @@ dependencies = [
 
 [[package]]
 name = "skippy-prompt"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -7463,7 +7463,7 @@ dependencies = [
 
 [[package]]
 name = "skippy-protocol"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "prost",
  "prost-build",
@@ -7473,7 +7473,7 @@ dependencies = [
 
 [[package]]
 name = "skippy-quantize"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7486,7 +7486,7 @@ dependencies = [
 
 [[package]]
 name = "skippy-runtime"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -7500,7 +7500,7 @@ dependencies = [
 
 [[package]]
 name = "skippy-server"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "skippy-topology"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -9762,7 +9762,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.68.0"
+version = "0.72.1"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,14 +66,14 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "0.68.0"
+version = "0.72.1"
 
 [workspace.dependencies]
 anyhow = "1"
 blake3 = "1"
 clap = { version = "4", features = ["derive"] }
-mesh-llm-build-info = { path = "crates/mesh-llm-build-info", version = "0.68.0" }
-mesh-llm-skills = { path = "crates/mesh-llm-skills", version = "0.68.0" }
+mesh-llm-build-info = { path = "crates/mesh-llm-build-info", version = "0.72.1" }
+mesh-llm-skills = { path = "crates/mesh-llm-skills", version = "0.72.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/Justfile
+++ b/Justfile
@@ -139,6 +139,10 @@ build-runtime backend="" cuda_arch="" rocm_arch="":
 
 # Build release artifacts for the current platform.
 
+# Prepare, publish, and watch a GitHub release from main.
+release version *ARGS:
+    @scripts/release.sh "{{ version }}" {{ ARGS }}
+
 # Release builds default to dynamic native runtimes. Set
 # MESH_LLM_DYNAMIC_NATIVE_RUNTIME=0 when validating a release binary with
 # branch-local llama.cpp ABI changes embedded.

--- a/crates/mesh-client/Cargo.toml
+++ b/crates/mesh-client/Cargo.toml
@@ -23,11 +23,11 @@ host-io = ["mesh-llm-identity/host-io"]
 # tracing, sha2, ed25519-dalek, hex, uuid, url, http, base64, async-trait, httparse
 # (httparse is a transitive dep of iroh; not in forbidden list)
 iroh = "1.0.0"
-mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.68.0", default-features = false }
-mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.68.0" }
-mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.68.0" }
-mesh-llm-types = { path = "../mesh-llm-types", version = "0.68.0" }
-model-artifact = { path = "../model-artifact", version = "0.68.0" }
+mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.72.1", default-features = false }
+mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.72.1" }
+mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.72.1" }
+mesh-llm-types = { path = "../mesh-llm-types", version = "0.72.1" }
+model-artifact = { path = "../model-artifact", version = "0.72.1" }
 async-trait = "0.1"
 httparse = "1"
 tokio = { version = "1", features = ["io-util", "sync", "net", "time", "rt-multi-thread"] }

--- a/crates/mesh-llm-api-client/Cargo.toml
+++ b/crates/mesh-llm-api-client/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "network-programming"]
 host-io = ["mesh-client/host-io"]
 
 [dependencies]
-mesh-client = { package = "mesh-llm-client", version = "0.68.0", path = "../mesh-client" }
+mesh-client = { package = "mesh-llm-client", version = "0.72.1", path = "../mesh-client" }
 hex = "0.4"
 thiserror = "2"
 

--- a/crates/mesh-llm-api-server/Cargo.toml
+++ b/crates/mesh-llm-api-server/Cargo.toml
@@ -15,8 +15,8 @@ host-io = ["mesh-llm-api-client/host-io"]
 
 [dependencies]
 anyhow.workspace = true
-mesh-llm-api-client = { path = "../mesh-llm-api-client", version = "0.68.0" }
-mesh-llm-node = { path = "../mesh-llm-node", version = "0.68.0" }
+mesh-llm-api-client = { path = "../mesh-llm-api-client", version = "0.72.1" }
+mesh-llm-node = { path = "../mesh-llm-node", version = "0.72.1" }
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]

--- a/crates/mesh-llm-cli/Cargo.toml
+++ b/crates/mesh-llm-cli/Cargo.toml
@@ -17,5 +17,5 @@ workspace = true
 anyhow.workspace = true
 clap.workspace = true
 mesh-llm-build-info.workspace = true
-mesh-llm-events = { path = "../mesh-llm-events", version = "0.68.0" }
+mesh-llm-events = { path = "../mesh-llm-events", version = "0.72.1" }
 serde.workspace = true

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -23,16 +23,16 @@ hex = "0.4.3"
 iroh = "1.0.0"
 json5 = "1.3.1"
 mesh-llm-build-info.workspace = true
-mesh-llm-cli = { path = "../mesh-llm-cli", version = "0.68.0" }
-mesh-llm-config = { path = "../mesh-llm-config", version = "0.68.0" }
-mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.68.0" }
-mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager", version = "0.68.0" }
-mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.68.0", features = ["host-io"] }
-mesh-llm-runtime-install = { path = "../mesh-llm-runtime-install", version = "0.68.0" }
-mesh-llm-system = { path = "../mesh-llm-system", version = "0.68.0", features = ["skippy-devices"] }
-mesh-llm-tui = { path = "../mesh-llm-tui", version = "0.68.0" }
-model-package = { path = "../model-package", version = "0.68.0" }
-model-ref = { path = "../model-ref", version = "0.68.0" }
+mesh-llm-cli = { path = "../mesh-llm-cli", version = "0.72.1" }
+mesh-llm-config = { path = "../mesh-llm-config", version = "0.72.1" }
+mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.72.1" }
+mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager", version = "0.72.1" }
+mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.72.1", features = ["host-io"] }
+mesh-llm-runtime-install = { path = "../mesh-llm-runtime-install", version = "0.72.1" }
+mesh-llm-system = { path = "../mesh-llm-system", version = "0.72.1", features = ["skippy-devices"] }
+mesh-llm-tui = { path = "../mesh-llm-tui", version = "0.72.1" }
+model-package = { path = "../model-package", version = "0.72.1" }
+model-ref = { path = "../model-ref", version = "0.72.1" }
 rpassword = "5"
 reqwest = { version = "0.12", features = ["json"] }
 serde.workspace = true

--- a/crates/mesh-llm-config/Cargo.toml
+++ b/crates/mesh-llm-config/Cargo.toml
@@ -12,10 +12,10 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-mesh-llm-types = { path = "../mesh-llm-types", version = "0.68.0"  }
+mesh-llm-types = { path = "../mesh-llm-types", version = "0.72.1"  }
 semver = "1"
 serde = { workspace = true }
-skippy-protocol = { path = "../skippy-protocol", version = "0.68.0"  }
+skippy-protocol = { path = "../skippy-protocol", version = "0.72.1"  }
 toml = "0.9"
 toml_edit = "0.25"
 dirs = "6.0.0"

--- a/crates/mesh-llm-config/src/model/built_in_schema.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema.rs
@@ -1101,7 +1101,8 @@ fn tensor_split_schema() -> ConfigValueSchema {
 /// This list should be updated during the release process.
 fn known_mesh_llm_versions() -> &'static [&'static str] {
     &[
-        "0.68.0", "0.67.0", "0.66.0", "0.65.0", "0.64.0", "0.63.0", "0.62.0", "0.61.0", "0.60.0",
+        "0.72.1", "0.72.0", "0.71.0", "0.70.0", "0.69.0", "0.68.0", "0.67.0", "0.66.0", "0.65.0",
+        "0.64.0", "0.63.0", "0.62.0", "0.61.0", "0.60.0",
     ]
 }
 

--- a/crates/mesh-llm-config/src/model/built_in_schema/presentation.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema/presentation.rs
@@ -249,7 +249,7 @@ fn process_setting_presentation(rendered: &str) -> Option<SettingPresentation> {
             ATTESTATION_CATEGORY,
             10,
         )
-        .placeholder("0.68.0")
+        .placeholder("0.72.1")
         .hint("text")),
         "mesh_requirements.max_node_version" => Some(sp(
             "Maximum node version",

--- a/crates/mesh-llm-config/src/model/built_in_schema/presentation.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema/presentation.rs
@@ -249,7 +249,7 @@ fn process_setting_presentation(rendered: &str) -> Option<SettingPresentation> {
             ATTESTATION_CATEGORY,
             10,
         )
-        .placeholder("0.72.1")
+        .placeholder("0.69.0")
         .hint("text")),
         "mesh_requirements.max_node_version" => Some(sp(
             "Maximum node version",
@@ -257,7 +257,7 @@ fn process_setting_presentation(rendered: &str) -> Option<SettingPresentation> {
             ATTESTATION_CATEGORY,
             20,
         )
-        .placeholder("0.69.0")
+        .placeholder("0.72.1")
         .hint("text")),
         "mesh_requirements.min_protocol_version" => Some(sp(
             "Minimum protocol generation",

--- a/crates/mesh-llm-console-server/Cargo.toml
+++ b/crates/mesh-llm-console-server/Cargo.toml
@@ -13,5 +13,5 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-mesh-llm-ui = { path = "../mesh-llm-ui", version = "0.68.0", default-features = false }
+mesh-llm-ui = { path = "../mesh-llm-ui", version = "0.72.1", default-features = false }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }

--- a/crates/mesh-llm-embedded-runtime/Cargo.toml
+++ b/crates/mesh-llm-embedded-runtime/Cargo.toml
@@ -20,6 +20,5 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-mesh-llm-host-runtime = { path = "../mesh-llm-host-runtime", version = "0.68.0", default-features = false }
+mesh-llm-host-runtime = { path = "../mesh-llm-host-runtime", version = "0.72.1", default-features = false }
 serde_json.workspace = true
-

--- a/crates/mesh-llm-hardware-profile/Cargo.toml
+++ b/crates/mesh-llm-hardware-profile/Cargo.toml
@@ -12,5 +12,4 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.68.0" }
-
+mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.72.1" }

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -29,34 +29,34 @@ workspace = true
 [dependencies]
 bytes = "1"
 mesh-llm-build-info.workspace = true
-mesh-mixture-of-agents = { path = "../mesh-mixture-of-agents", version = "0.68.0"  }
-mesh-llm-config = { path = "../mesh-llm-config", version = "0.68.0"  }
-mesh-llm-events = { path = "../mesh-llm-events", version = "0.68.0"  }
-mesh-llm-plugin = { path = "../mesh-llm-plugin", version = "0.68.0"  }
-mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager", version = "0.68.0"  }
-mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.68.0", features = ["host-io"]  }
-mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.68.0"  }
-mesh-llm-runtime-install = { path = "../mesh-llm-runtime-install", version = "0.68.0"  }
-mesh-llm-guardrails = { path = "../mesh-llm-guardrails", version = "0.68.0"  }
-mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.68.0"  }
-mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.68.0"  }
-mesh-llm-system = { path = "../mesh-llm-system", version = "0.68.0", features = ["skippy-devices"]  }
-mesh-llm-types = { path = "../mesh-llm-types", version = "0.68.0"  }
-mesh-llm-ui = { path = "../mesh-llm-ui", version = "0.68.0", default-features = false  }
-mesh-llm-node = { path = "../mesh-llm-node", version = "0.68.0"  }
-mesh-llm-api-server = { path = "../mesh-llm-api-server", version = "0.68.0"  }
-mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = "0.68.0", features = ["host-io"]  }
-model-artifact = { path = "../model-artifact", version = "0.68.0"  }
-model-hf = { path = "../model-hf", version = "0.68.0"  }
-model-package = { path = "../model-package", version = "0.68.0"  }
-model-ref = { path = "../model-ref", version = "0.68.0"  }
-model-resolver = { path = "../model-resolver", version = "0.68.0"  }
-openai-frontend = { path = "../openai-frontend", version = "0.68.0"  }
-skippy-protocol = { path = "../skippy-protocol", version = "0.68.0"  }
-skippy-coordinator = { path = "../skippy-coordinator", version = "0.68.0"  }
-skippy-runtime = { path = "../skippy-runtime", version = "0.68.0"  }
-skippy-server = { path = "../skippy-server", version = "0.68.0"  }
-skippy-topology = { path = "../skippy-topology", version = "0.68.0"  }
+mesh-mixture-of-agents = { path = "../mesh-mixture-of-agents", version = "0.72.1"  }
+mesh-llm-config = { path = "../mesh-llm-config", version = "0.72.1"  }
+mesh-llm-events = { path = "../mesh-llm-events", version = "0.72.1"  }
+mesh-llm-plugin = { path = "../mesh-llm-plugin", version = "0.72.1"  }
+mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager", version = "0.72.1"  }
+mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.72.1", features = ["host-io"]  }
+mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.72.1"  }
+mesh-llm-runtime-install = { path = "../mesh-llm-runtime-install", version = "0.72.1"  }
+mesh-llm-guardrails = { path = "../mesh-llm-guardrails", version = "0.72.1"  }
+mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.72.1"  }
+mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.72.1"  }
+mesh-llm-system = { path = "../mesh-llm-system", version = "0.72.1", features = ["skippy-devices"]  }
+mesh-llm-types = { path = "../mesh-llm-types", version = "0.72.1"  }
+mesh-llm-ui = { path = "../mesh-llm-ui", version = "0.72.1", default-features = false  }
+mesh-llm-node = { path = "../mesh-llm-node", version = "0.72.1"  }
+mesh-llm-api-server = { path = "../mesh-llm-api-server", version = "0.72.1"  }
+mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = "0.72.1", features = ["host-io"]  }
+model-artifact = { path = "../model-artifact", version = "0.72.1"  }
+model-hf = { path = "../model-hf", version = "0.72.1"  }
+model-package = { path = "../model-package", version = "0.72.1"  }
+model-ref = { path = "../model-ref", version = "0.72.1"  }
+model-resolver = { path = "../model-resolver", version = "0.72.1"  }
+openai-frontend = { path = "../openai-frontend", version = "0.72.1"  }
+skippy-protocol = { path = "../skippy-protocol", version = "0.72.1"  }
+skippy-coordinator = { path = "../skippy-coordinator", version = "0.72.1"  }
+skippy-runtime = { path = "../skippy-runtime", version = "0.72.1"  }
+skippy-server = { path = "../skippy-server", version = "0.72.1"  }
+skippy-topology = { path = "../skippy-topology", version = "0.72.1"  }
 iroh = "1.0.0"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
@@ -116,7 +116,7 @@ tempfile = "3"
 
 [dev-dependencies]
 serial_test = "3"
-mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = "0.68.0"  }
+mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = "0.72.1"  }
 # Used by the gated-relay regression test to spawn an in-process iroh-relay
 # with AccessConfig::Restricted, then build a real iroh::Endpoint from our
 # relay_map_from_urls output and verify --relay-auth tokens reach the relay

--- a/crates/mesh-llm-host-runtime/tests/fixtures/config_schema_reference.json
+++ b/crates/mesh-llm-host-runtime/tests/fixtures/config_schema_reference.json
@@ -947,7 +947,7 @@
       "name": "blobstore",
       "enabled": true,
       "source_repository": "built-in",
-      "installed_version": "0.68.0",
+      "installed_version": "0.72.1",
       "last_status": "built-in",
       "has_config_schema": false,
       "allow_unvalidated_config": false

--- a/crates/mesh-llm-native-runtime/README.md
+++ b/crates/mesh-llm-native-runtime/README.md
@@ -32,7 +32,7 @@ Each packaged runtime directory contains `manifest.json`:
 {
   "runtime": {
     "id": "meshllm-native-runtime-linux-x86_64-cuda13-sm120",
-    "mesh_version": "0.68.0",
+    "mesh_version": "0.72.1",
     "skippy_abi": "0.1.25",
     "platform": {
       "os": "linux",
@@ -87,18 +87,18 @@ Release jobs publish `native-runtimes.json`:
 
 ```json
 {
-  "mesh_version": "0.68.0",
+  "mesh_version": "0.72.1",
   "skippy_abi": "0.1.25",
   "artifacts": [
     {
       "id": "meshllm-native-runtime-linux-x86_64-cpu",
-      "mesh_version": "0.68.0",
+      "mesh_version": "0.72.1",
       "skippy_abi": "0.1.25",
       "platform": { "os": "linux", "arch": "x86_64" },
       "backend": { "kind": "cpu" },
       "rank": 0,
       "libraries": ["lib/libllama.so"],
-      "url": "https://github.com/Mesh-LLM/mesh-llm/releases/download/v0.68.0/meshllm-native-runtime-linux-x86_64-cpu.tar.gz",
+      "url": "https://github.com/Mesh-LLM/mesh-llm/releases/download/v0.72.1/meshllm-native-runtime-linux-x86_64-cpu.tar.gz",
       "sha256": "2f1c..."
     }
   ]
@@ -157,7 +157,7 @@ use std::path::PathBuf;
 #     manifest: NativeRuntimeReleaseManifest,
 # ) -> anyhow::Result<()> {
 let cache = NativeRuntimeCache::new("/tmp/mesh-llm/native-runtimes");
-let resolution = NativeRuntimeResolver::new("0.68.0", profile, manifest, cache)
+let resolution = NativeRuntimeResolver::new("0.72.1", profile, manifest, cache)
     .with_skippy_abi_version("0.1.25")
     .with_bundle_dirs(vec![PathBuf::from("./meshllm-native-runtime-linux-x86_64-cpu")])
     .resolve(&RuntimeSelection::Recommended)?;
@@ -252,7 +252,7 @@ Generate the release manifest:
 
 ```bash
 scripts/generate-native-runtime-release-manifest.sh \
-  --tag v0.68.0 \
+  --tag v0.72.1 \
   --out dist/native-runtimes/native-runtimes.json \
   dist/native-runtimes/*.tar.gz
 ```

--- a/crates/mesh-llm-node/Cargo.toml
+++ b/crates/mesh-llm-node/Cargo.toml
@@ -13,10 +13,10 @@ host = []
 
 [dependencies]
 anyhow.workspace = true
-mesh-llm-types = { path = "../mesh-llm-types", version = "0.68.0" }
-model-artifact = { path = "../model-artifact", version = "0.68.0" }
-model-hf = { path = "../model-hf", version = "0.68.0" }
-model-ref = { path = "../model-ref", version = "0.68.0" }
+mesh-llm-types = { path = "../mesh-llm-types", version = "0.72.1" }
+model-artifact = { path = "../model-artifact", version = "0.72.1" }
+model-hf = { path = "../model-hf", version = "0.72.1" }
+model-ref = { path = "../model-ref", version = "0.72.1" }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/mesh-llm-nodejs/Cargo.toml
+++ b/crates/mesh-llm-nodejs/Cargo.toml
@@ -16,7 +16,7 @@ default = ["embedded-runtime"]
 embedded-runtime = []
 
 [dependencies]
-mesh-llm-sdk = { path = "../mesh-llm-sdk", version = "0.68.0", default-features = false, features = ["client", "node", "console", "serving"] }
+mesh-llm-sdk = { path = "../mesh-llm-sdk", version = "0.72.1", default-features = false, features = ["client", "node", "console", "serving"] }
 napi = { version = "2.16.17", features = ["napi4", "tokio_rt"] }
 napi-derive = "2.16.13"
 serde_json.workspace = true

--- a/crates/mesh-llm-runtime-install/Cargo.toml
+++ b/crates/mesh-llm-runtime-install/Cargo.toml
@@ -18,13 +18,13 @@ flate2 = "1"
 futures-util = "0.3"
 hex = "0.4"
 mesh-llm-build-info.workspace = true
-mesh-llm-hardware-profile = { path = "../mesh-llm-hardware-profile", version = "0.68.0" }
-mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.68.0" }
+mesh-llm-hardware-profile = { path = "../mesh-llm-hardware-profile", version = "0.72.1" }
+mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.72.1" }
 reqwest = { version = "0.12", features = ["stream", "json"] }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-skippy-ffi = { path = "../skippy-ffi", version = "0.68.0", default-features = false }
+skippy-ffi = { path = "../skippy-ffi", version = "0.72.1", default-features = false }
 tar = "0.4"
 tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util", "rt"] }

--- a/crates/mesh-llm-sdk/Cargo.toml
+++ b/crates/mesh-llm-sdk/Cargo.toml
@@ -31,11 +31,11 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-mesh-llm-api-client = { path = "../mesh-llm-api-client", version = "0.68.0", optional = true }
-mesh-llm-api-server = { path = "../mesh-llm-api-server", version = "0.68.0", optional = true }
-mesh-llm-console-server = { path = "../mesh-llm-console-server", version = "0.68.0", optional = true }
-mesh-llm-embedded-runtime = { path = "../mesh-llm-embedded-runtime", version = "0.68.0", optional = true }
-mesh-llm-runtime-install = { path = "../mesh-llm-runtime-install", version = "0.68.0", optional = true }
+mesh-llm-api-client = { path = "../mesh-llm-api-client", version = "0.72.1", optional = true }
+mesh-llm-api-server = { path = "../mesh-llm-api-server", version = "0.72.1", optional = true }
+mesh-llm-console-server = { path = "../mesh-llm-console-server", version = "0.72.1", optional = true }
+mesh-llm-embedded-runtime = { path = "../mesh-llm-embedded-runtime", version = "0.72.1", optional = true }
+mesh-llm-runtime-install = { path = "../mesh-llm-runtime-install", version = "0.72.1", optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }

--- a/crates/mesh-llm-sdk/README.md
+++ b/crates/mesh-llm-sdk/README.md
@@ -23,7 +23,7 @@ checked against the exact Skippy ABI version.
 
 ```toml
 [dependencies]
-mesh-llm-sdk = "0.68.0"
+mesh-llm-sdk = "0.72.1"
 ```
 
 ```rust,no_run
@@ -45,7 +45,7 @@ client.disconnect().await;
 
 ```toml
 [dependencies]
-mesh-llm-sdk = { version = "0.68.0", features = ["serving"] }
+mesh-llm-sdk = { version = "0.72.1", features = ["serving"] }
 ```
 
 ```rust,no_run
@@ -71,7 +71,7 @@ Enable `serving` to use native-runtime install/update APIs:
 
 ```toml
 [dependencies]
-mesh-llm-sdk = { version = "0.68.0", features = ["serving"] }
+mesh-llm-sdk = { version = "0.72.1", features = ["serving"] }
 ```
 
 ```rust,no_run

--- a/crates/mesh-llm-system/Cargo.toml
+++ b/crates/mesh-llm-system/Cargo.toml
@@ -15,13 +15,13 @@ dirs = "6.0.0"
 hex = "0.4.3"
 libc = "0.2.183"
 mesh-llm-build-info.workspace = true
-mesh-llm-gpu-bench = { path = "../mesh-llm-gpu-bench", version = "0.68.0"  }
+mesh-llm-gpu-bench = { path = "../mesh-llm-gpu-bench", version = "0.72.1"  }
 reqwest = { version = "0.12", features = ["stream", "json"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-skippy-runtime = { path = "../skippy-runtime", version = "0.68.0", optional = true  }
+skippy-runtime = { path = "../skippy-runtime", version = "0.72.1", optional = true  }
 tracing = "0.1"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 

--- a/crates/mesh-llm-tui/Cargo.toml
+++ b/crates/mesh-llm-tui/Cargo.toml
@@ -19,7 +19,7 @@ anyhow.workspace = true
 arboard = "3"
 chrono = { version = "0.4", features = ["serde"] }
 crossterm = "0.28"
-mesh-llm-events = { path = "../mesh-llm-events", version = "0.68.0" }
+mesh-llm-events = { path = "../mesh-llm-events", version = "0.72.1" }
 ratatui = "0.30"
 serde_json.workspace = true
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }

--- a/crates/mesh-llm-ui/package-lock.json
+++ b/crates/mesh-llm-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mesh-llm-ui",
-  "version": "0.68.0",
+  "version": "0.72.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mesh-llm-ui",
-      "version": "0.68.0",
+      "version": "0.72.1",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@radix-ui/react-accordion": "^1.2.14",

--- a/crates/mesh-llm-ui/package.json
+++ b/crates/mesh-llm-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mesh-llm-ui",
   "private": true,
-  "version": "0.68.0",
+  "version": "0.72.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/crates/mesh-llm/Cargo.toml
+++ b/crates/mesh-llm/Cargo.toml
@@ -21,13 +21,13 @@ workspace = true
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 clap.workspace = true
-mesh-llm-cli = { path = "../mesh-llm-cli", version = "0.68.0" }
-mesh-llm-commands = { path = "../mesh-llm-commands", version = "0.68.0" }
+mesh-llm-cli = { path = "../mesh-llm-cli", version = "0.72.1" }
+mesh-llm-commands = { path = "../mesh-llm-commands", version = "0.72.1" }
 mesh-llm-host-runtime = { path = "../mesh-llm-host-runtime", default-features = false }
-mesh-llm-plugin = { path = "../mesh-llm-plugin", version = "0.68.0" }
-mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager", version = "0.68.0" }
-mesh-llm-system = { path = "../mesh-llm-system", version = "0.68.0", features = ["skippy-devices"] }
-mesh-llm-tui = { path = "../mesh-llm-tui", version = "0.68.0" }
+mesh-llm-plugin = { path = "../mesh-llm-plugin", version = "0.72.1" }
+mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager", version = "0.72.1" }
+mesh-llm-system = { path = "../mesh-llm-system", version = "0.72.1", features = ["skippy-devices"] }
+mesh-llm-tui = { path = "../mesh-llm-tui", version = "0.72.1" }
 reqwest = { version = "0.12", features = ["json"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mesh-llm/Cargo.toml
+++ b/crates/mesh-llm/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap.workspace = true
 mesh-llm-cli = { path = "../mesh-llm-cli", version = "0.72.1" }
 mesh-llm-commands = { path = "../mesh-llm-commands", version = "0.72.1" }
-mesh-llm-host-runtime = { path = "../mesh-llm-host-runtime", default-features = false }
+mesh-llm-host-runtime = { path = "../mesh-llm-host-runtime", version = "0.72.1", default-features = false }
 mesh-llm-plugin = { path = "../mesh-llm-plugin", version = "0.72.1" }
 mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager", version = "0.72.1" }
 mesh-llm-system = { path = "../mesh-llm-system", version = "0.72.1", features = ["skippy-devices"] }

--- a/crates/mesh-mixture-of-agents/Cargo.toml
+++ b/crates/mesh-mixture-of-agents/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1"
-mesh-llm-guardrails = { path = "../mesh-llm-guardrails", version = "0.68.0"  }
+mesh-llm-guardrails = { path = "../mesh-llm-guardrails", version = "0.72.1"  }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/model-artifact/Cargo.toml
+++ b/crates/model-artifact/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1"
-model-ref = { path = "../model-ref", version = "0.68.0" }
+model-ref = { path = "../model-ref", version = "0.72.1" }
 serde.workspace = true
 
 [dev-dependencies]

--- a/crates/model-hf/Cargo.toml
+++ b/crates/model-hf/Cargo.toml
@@ -13,8 +13,8 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
-model-artifact = { path = "../model-artifact", version = "0.68.0" }
-model-ref = { path = "../model-ref", version = "0.68.0" }
+model-artifact = { path = "../model-artifact", version = "0.72.1" }
+model-ref = { path = "../model-ref", version = "0.72.1" }
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"

--- a/crates/model-package/Cargo.toml
+++ b/crates/model-package/Cargo.toml
@@ -16,8 +16,8 @@ anyhow.workspace = true
 bytes = "1"
 chrono = "0.4"
 hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
-model-hf = { path = "../model-hf", version = "0.68.0"  }
-model-ref = { path = "../model-ref", version = "0.68.0"  }
+model-hf = { path = "../model-hf", version = "0.72.1"  }
+model-ref = { path = "../model-ref", version = "0.72.1"  }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/model-resolver/Cargo.toml
+++ b/crates/model-resolver/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 
 [dependencies]
 anyhow.workspace = true
-model-ref = { path = "../model-ref", version = "0.68.0"  }
-model-artifact = { path = "../model-artifact", version = "0.68.0"  }
+model-ref = { path = "../model-ref", version = "0.72.1"  }
+model-artifact = { path = "../model-artifact", version = "0.72.1"  }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/openai-frontend/Cargo.toml
+++ b/crates/openai-frontend/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = "0.1"
 axum = "0.8"
 futures-core = "0.3"
 futures-util = "0.3"
-mesh-llm-guardrails = { path = "../mesh-llm-guardrails", version = "0.68.0"  }
+mesh-llm-guardrails = { path = "../mesh-llm-guardrails", version = "0.72.1"  }
 serde.workspace = true
 serde_json.workspace = true
 tokio = { version = "1", features = ["time"] }

--- a/crates/skippy-cache/Cargo.toml
+++ b/crates/skippy-cache/Cargo.toml
@@ -14,4 +14,4 @@ path = "src/lib.rs"
 [dependencies]
 anyhow.workspace = true
 blake3.workspace = true
-skippy-protocol = { path = "../skippy-protocol", version = "0.68.0"  }
+skippy-protocol = { path = "../skippy-protocol", version = "0.72.1"  }

--- a/crates/skippy-runtime/Cargo.toml
+++ b/crates/skippy-runtime/Cargo.toml
@@ -13,7 +13,7 @@ dynamic-native-runtime = ["skippy-ffi/dynamic-runtime"]
 
 [dependencies]
 anyhow.workspace = true
-skippy-ffi = { path = "../skippy-ffi", version = "0.68.0", default-features = false  }
+skippy-ffi = { path = "../skippy-ffi", version = "0.72.1", default-features = false  }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/skippy-server/Cargo.toml
+++ b/crates/skippy-server/Cargo.toml
@@ -23,11 +23,11 @@ base64 = "0.22"
 blake3.workspace = true
 clap.workspace = true
 futures-util = "0.3"
-skippy-runtime = { path = "../skippy-runtime", version = "0.68.0"  }
-skippy-protocol = { path = "../skippy-protocol", version = "0.68.0"  }
-skippy-cache = { path = "../skippy-cache", version = "0.68.0"  }
-skippy-metrics = { path = "../skippy-metrics", version = "0.68.0"  }
-openai-frontend = { path = "../openai-frontend", version = "0.68.0"  }
+skippy-runtime = { path = "../skippy-runtime", version = "0.72.1"  }
+skippy-protocol = { path = "../skippy-protocol", version = "0.72.1"  }
+skippy-cache = { path = "../skippy-cache", version = "0.72.1"  }
+skippy-metrics = { path = "../skippy-metrics", version = "0.72.1"  }
+openai-frontend = { path = "../openai-frontend", version = "0.72.1"  }
 opentelemetry-proto = "0.31.0"
 serde.workspace = true
 serde_json.workspace = true

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -56,7 +56,7 @@ Add the Rust SDK facade crate:
 
 ```toml
 [dependencies]
-mesh-llm-sdk = "0.68.0"
+mesh-llm-sdk = "0.72.1"
 ```
 
 The default Rust SDK feature exposes client-side mesh APIs without depending on
@@ -80,7 +80,7 @@ Add the repo Swift package from a tagged GitHub release:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Mesh-LLM/mesh-llm", from: "0.68.0"),
+    .package(url: "https://github.com/Mesh-LLM/mesh-llm", from: "0.72.1"),
 ],
 targets: [
     .target(
@@ -137,7 +137,7 @@ Install the Node package in a Node.js or Electron app:
 ```json
 {
   "dependencies": {
-    "@meshllm/sdk": "0.68.0"
+    "@meshllm/sdk": "0.72.1"
   }
 }
 ```

--- a/docs/design/NATIVE_RUNTIMES.md
+++ b/docs/design/NATIVE_RUNTIMES.md
@@ -31,7 +31,7 @@ attestation format are implemented.
 
 A native runtime is identified by:
 
-- MeshLLM version, for example `0.68.0`
+- MeshLLM version, for example `0.72.1`
 - Skippy ABI, for example `0.1.25`
 - target operating system and architecture
 - backend kind, for example `cpu`, `metal`, `cuda`, `rocm`, or `vulkan`
@@ -330,7 +330,7 @@ Advanced users can pin runtime resolution in `~/.mesh-llm/config.toml`:
 
 ```toml
 [runtime.native_runtime]
-mesh_version = "0.68.0"
+mesh_version = "0.72.1"
 selection = "exact:meshllm-native-runtime-linux-x86_64-cuda12"
 ```
 

--- a/docs/sdk/node.md
+++ b/docs/sdk/node.md
@@ -7,7 +7,7 @@ Use `@meshllm/sdk` from npm for Node.js and Electron applications.
 ```json
 {
   "dependencies": {
-    "@meshllm/sdk": "0.68.0"
+    "@meshllm/sdk": "0.72.1"
   }
 }
 ```

--- a/docs/sdk/rust.md
+++ b/docs/sdk/rust.md
@@ -10,7 +10,7 @@ Client-only applications can use the default features:
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
-mesh-llm-sdk = "0.68.0"
+mesh-llm-sdk = "0.72.1"
 ```
 
 Serving applications need the `serving` feature:
@@ -20,7 +20,7 @@ Serving applications need the `serving` feature:
 anyhow = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-mesh-llm-sdk = { version = "0.68.0", features = ["serving"] }
+mesh-llm-sdk = { version = "0.72.1", features = ["serving"] }
 ```
 
 Add `console` with `serving` when the embedded node should serve packaged web

--- a/docs/sdk/swift.md
+++ b/docs/sdk/swift.md
@@ -6,7 +6,7 @@ Use the GitHub Swift package from tagged `Mesh-LLM/mesh-llm` releases.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Mesh-LLM/mesh-llm", from: "0.68.0"),
+    .package(url: "https://github.com/Mesh-LLM/mesh-llm", from: "0.72.1"),
 ],
 targets: [
     .target(

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -94,13 +94,69 @@ update_literal_version_references() {
     printf '%s\n' "$after" >"$file"
 }
 
+update_json_package_version_references() {
+    local file="$1"
+    local previous="$2"
+    local next="$3"
+    local before
+    local after
+
+    command -v node >/dev/null 2>&1 || {
+        echo "node is required on PATH to update JSON package versions" >&2
+        exit 1
+    }
+
+    before="$(cat "$file")"
+    after="$(
+        node - "$previous" "$next" "$file" <<'JS'
+const fs = require("fs");
+
+const [previous, next, file] = process.argv.slice(2);
+const input = fs.readFileSync(file, "utf8");
+const data = JSON.parse(input);
+let changed = false;
+
+function updateVersion(owner, label) {
+  if (!owner || !Object.prototype.hasOwnProperty.call(owner, "version")) {
+    return;
+  }
+  if (owner.version === next) {
+    return;
+  }
+  if (owner.version !== previous) {
+    throw new Error(`${file}: ${label}.version is ${owner.version}, expected ${previous}`);
+  }
+  owner.version = next;
+  changed = true;
+}
+
+updateVersion(data, "root");
+if (data.packages && data.packages[""]) {
+  updateVersion(data.packages[""], "packages[\"\"]");
+}
+
+process.stdout.write(changed ? `${JSON.stringify(data, null, 2)}\n` : input);
+JS
+    )"
+    if [[ "$before" == "$after" ]]; then
+        return
+    fi
+    printf '%s' "$after" >"$file"
+}
+
 update_known_mesh_versions() {
     local file="$1"
     local next="$2"
     local before
     local after
     before="$(cat "$file")"
-    if perl -0777 -ne 'exit((/"'"$next"'"/) ? 0 : 1)' "$file"; then
+    if perl -0777 -ne '
+        BEGIN {
+            $next = quotemeta($ARGV[0]);
+            shift @ARGV;
+        }
+        exit((/"$next"/) ? 0 : 1)
+    ' "$next" "$file"; then
         return
     fi
     after="$(perl -0777 -pe 's/(fn known_mesh_llm_versions\(\).*?\&\[\n\s*)/${1}"'"$next"'", /s' "$file")"
@@ -223,7 +279,14 @@ literal_version_files=(
 for relative_file in "${literal_version_files[@]}"; do
     file="$REPO_ROOT/$relative_file"
     require_file "$file"
-    update_literal_version_references "$file" "$previous_version" "$version"
+    case "$relative_file" in
+        crates/mesh-llm-ui/package.json | crates/mesh-llm-ui/package-lock.json | sdk/node/package.json)
+            update_json_package_version_references "$file" "$previous_version" "$version"
+            ;;
+        *)
+            update_literal_version_references "$file" "$previous_version" "$version"
+            ;;
+    esac
     versioned_files+=("$file")
 done
 

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -64,6 +64,53 @@ update_workspace_version() {
     printf '%s\n' "$after" >"$file"
 }
 
+read_workspace_version() {
+    local file="$1"
+    perl -0ne 'print "$1\n" if /\[workspace\.package\][^[]*?\nversion\s*=\s*"([^"]+)"/s' "$file"
+}
+
+update_literal_version_references() {
+    local file="$1"
+    local previous="$2"
+    local next="$3"
+    local before
+    local after
+    before="$(cat "$file")"
+    after="$(
+        perl -0777 -pe '
+            BEGIN {
+                $previous = quotemeta($ARGV[0]);
+                $next = $ARGV[1];
+                shift @ARGV;
+                shift @ARGV;
+            }
+            s/v$previous/v$next/g;
+            s/$previous/$next/g;
+        ' "$previous" "$next" "$file"
+    )"
+    if [[ "$before" == "$after" ]]; then
+        return
+    fi
+    printf '%s\n' "$after" >"$file"
+}
+
+update_known_mesh_versions() {
+    local file="$1"
+    local next="$2"
+    local before
+    local after
+    before="$(cat "$file")"
+    if perl -0777 -ne 'exit((/"'"$next"'"/) ? 0 : 1)' "$file"; then
+        return
+    fi
+    after="$(perl -0777 -pe 's/(fn known_mesh_llm_versions\(\).*?\&\[\n\s*)/${1}"'"$next"'", /s' "$file")"
+    if [[ "$before" == "$after" ]]; then
+        echo "failed to add $next to known mesh-llm versions in $file" >&2
+        exit 1
+    fi
+    printf '%s\n' "$after" >"$file"
+}
+
 update_versioned_path_dependency_versions() {
     local file="$1"
     local next="$2"
@@ -132,6 +179,11 @@ versioned_files=()
 
 workspace_manifest="$REPO_ROOT/Cargo.toml"
 require_file "$workspace_manifest"
+previous_version="$(read_workspace_version "$workspace_manifest")"
+if [[ -z "$previous_version" ]]; then
+    echo "failed to read [workspace.package].version from $workspace_manifest" >&2
+    exit 1
+fi
 update_workspace_version "$workspace_manifest" "$version"
 update_versioned_path_dependency_versions "$workspace_manifest" "$version"
 versioned_files+=("$workspace_manifest")
@@ -148,6 +200,37 @@ kotlin_build_file="$REPO_ROOT/sdk/kotlin/build.gradle.kts"
 require_file "$kotlin_build_file"
 update_gradle_project_version "$kotlin_build_file" "$version"
 versioned_files+=("$kotlin_build_file")
+
+literal_version_files=(
+    "crates/mesh-llm-native-runtime/README.md"
+    "crates/mesh-llm-sdk/README.md"
+    "crates/mesh-llm-ui/package.json"
+    "crates/mesh-llm-ui/package-lock.json"
+    "sdk/node/package.json"
+    "docs/sdk/node.md"
+    "docs/sdk/rust.md"
+    "docs/sdk/swift.md"
+    "docs/SDK.md"
+    "sdk/swift/README.md"
+    "sdk/swift/scripts/generate-swift-bindings.sh"
+    "website/src/docs/pages/CLI.md"
+    "docs/design/NATIVE_RUNTIMES.md"
+    "sdk/kotlin/README.md"
+    "sdk/kotlin/example/example-jvm/build.gradle.kts"
+    "crates/mesh-llm-config/src/model/built_in_schema/presentation.rs"
+)
+
+for relative_file in "${literal_version_files[@]}"; do
+    file="$REPO_ROOT/$relative_file"
+    require_file "$file"
+    update_literal_version_references "$file" "$previous_version" "$version"
+    versioned_files+=("$file")
+done
+
+known_versions_file="$REPO_ROOT/crates/mesh-llm-config/src/model/built_in_schema.rs"
+require_file "$known_versions_file"
+update_known_mesh_versions "$known_versions_file" "$version"
+versioned_files+=("$known_versions_file")
 
 echo "Refreshing Cargo.lock workspace package versions..."
 refresh_cargo_lock_versions

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+usage: scripts/release.sh <version|vversion> [--skip-gpu-bundles] [--canary]
+
+Runs a synchronous release from main:
+  1. verifies gh and the local git state
+  2. applies the release version bump
+  3. commits and pushes the release-prep source commit when needed
+  4. dispatches .github/workflows/release.yml
+  5. watches the GitHub Actions run until it succeeds or fails
+  6. generates GitHub release notes and attaches them to the release
+
+The command requires the current branch to be main and up to date with
+origin/main before it starts.
+EOF
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+require_command() {
+    local name="$1"
+    command -v "$name" >/dev/null 2>&1 || die "$name is required on PATH"
+}
+
+semver_from_arg() {
+    local raw="$1"
+    local version="${raw#v}"
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+        die "invalid version '$raw'; expected 0.72.1, v0.72.1, 0.72.1-rc1, etc."
+    fi
+    printf '%s\n' "$version"
+}
+
+ensure_version_format() {
+    local version="$1"
+    local context="$2"
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+        die "$context version '$version' is not a supported semantic version"
+    fi
+}
+
+read_workspace_version() {
+    perl -ne 'if (/^\s*version\s*=\s*"([^"]+)"/) { print "$1\n"; exit }' Cargo.toml
+}
+
+ensure_target_version_advances() {
+    local current="$1"
+    local target="$2"
+    local compare_status
+
+    set +e
+    python3 - "$current" "$target" <<'PY'
+import re
+import sys
+
+current, target = sys.argv[1:3]
+pattern = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$")
+
+
+def parse(value):
+    match = pattern.match(value)
+    if not match:
+        raise SystemExit(2)
+    major, minor, patch, prerelease = match.groups()
+    return (int(major), int(minor), int(patch), parse_prerelease(prerelease))
+
+
+def parse_prerelease(value):
+    if value is None:
+        return None
+    parts = []
+    for part in value.split("."):
+        if part.isdigit():
+            parts.append((0, int(part)))
+        else:
+            parts.append((1, part))
+    return parts
+
+
+def compare_prerelease(left, right):
+    if left is None and right is None:
+        return 0
+    if left is None:
+        return 1
+    if right is None:
+        return -1
+    for left_part, right_part in zip(left, right):
+        if left_part == right_part:
+            continue
+        return -1 if left_part < right_part else 1
+    if len(left) == len(right):
+        return 0
+    return -1 if len(left) < len(right) else 1
+
+
+current_version = parse(current)
+target_version = parse(target)
+
+for left, right in zip(current_version[:3], target_version[:3]):
+    if right > left:
+        raise SystemExit(0)
+    if right < left:
+        raise SystemExit(1)
+
+raise SystemExit(0 if compare_prerelease(target_version[3], current_version[3]) > 0 else 1)
+PY
+    compare_status="$?"
+    set -e
+
+    case "$compare_status" in
+        0)
+            ;;
+        1)
+            die "target version $target must be greater than current workspace version $current"
+            ;;
+        *)
+            die "failed to compare current version $current and target version $target"
+            ;;
+    esac
+}
+
+ensure_clean_worktree() {
+    if [[ -n "$(git status --porcelain)" ]]; then
+        git status --short >&2
+        die "working tree must be clean before release"
+    fi
+}
+
+ensure_main_is_current() {
+    local branch
+    branch="$(git branch --show-current)"
+    [[ "$branch" == "main" ]] || die "release must run from local main; current branch is '${branch:-detached}'"
+
+    git fetch origin main
+
+    local local_head
+    local remote_head
+    local_head="$(git rev-parse HEAD)"
+    remote_head="$(git rev-parse origin/main)"
+    [[ "$local_head" == "$remote_head" ]] || die "local main must match origin/main before release"
+}
+
+ensure_github_release_preflight() {
+    local tag="$1"
+
+    gh auth status >/dev/null 2>&1 || die "gh must be authenticated before release"
+    gh workflow view release.yml >/dev/null 2>&1 || die "GitHub Release workflow release.yml is not available"
+
+    if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+        die "local tag $tag already exists"
+    fi
+    if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+        die "remote tag $tag already exists on origin"
+    fi
+    if gh release view "$tag" >/dev/null 2>&1; then
+        die "GitHub release $tag already exists"
+    fi
+}
+
+confirm_release() {
+    local tag="$1"
+    local version="$2"
+    local current_version="$3"
+    local skip_gpu_bundles="$4"
+    local canary="$5"
+    local answer
+
+    cat <<EOF
+This will:
+  - verify the current branch is clean, local main, and equal to origin/main
+  - update release source files from $current_version to $version
+  - commit the source changes as "$tag: prepare release source" if anything changed
+  - push the release-prep commit directly to origin/main
+  - dispatch .github/workflows/release.yml for $tag
+  - watch the GitHub Actions release run until it succeeds or fails
+  - after a non-canary success, generate GitHub release notes and attach them to $tag
+
+Options:
+  - skip GPU bundles: $skip_gpu_bundles
+  - canary: $canary
+
+Continue? y/N
+EOF
+    read -r answer
+    case "$answer" in
+        y|Y|yes|YES)
+            ;;
+        *)
+            die "release cancelled"
+            ;;
+    esac
+}
+
+push_release_source_commit() {
+    local tag="$1"
+    local version="$2"
+    local current_version
+    current_version="$(read_workspace_version)"
+
+    echo "Current workspace version: $current_version"
+    echo "Target release version: $version"
+
+    scripts/release-version.sh "$version"
+
+    if git diff --quiet; then
+        echo "Release source files already match $version; no commit needed."
+    else
+        git add \
+            Cargo.toml \
+            Cargo.lock \
+            crates/*/Cargo.toml \
+            tools/*/Cargo.toml \
+            crates/mesh-llm-config/src/model/built_in_schema.rs \
+            crates/mesh-llm-config/src/model/built_in_schema/presentation.rs \
+            crates/mesh-llm-native-runtime/README.md \
+            crates/mesh-llm-sdk/README.md \
+            crates/mesh-llm-ui/package.json \
+            crates/mesh-llm-ui/package-lock.json \
+            docs/SDK.md \
+            docs/design/NATIVE_RUNTIMES.md \
+            docs/sdk/node.md \
+            docs/sdk/rust.md \
+            docs/sdk/swift.md \
+            sdk/kotlin/README.md \
+            sdk/kotlin/build.gradle.kts \
+            sdk/kotlin/example/example-jvm/build.gradle.kts \
+            sdk/node/package.json \
+            sdk/swift/README.md \
+            sdk/swift/scripts/generate-swift-bindings.sh \
+            website/src/docs/pages/CLI.md
+        git commit -m "$tag: prepare release source"
+    fi
+
+    git push origin HEAD:main
+}
+
+dispatch_release_workflow() {
+    local tag="$1"
+    local skip_gpu_bundles="$2"
+    local canary="$3"
+    local release_sha="$4"
+    local before
+    local run_id
+
+    before="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    echo "Dispatching Release workflow for $tag..." >&2
+    gh workflow run release.yml \
+        --ref main \
+        --raw-field "version=$tag" \
+        --raw-field "skip_gpu_bundles=$skip_gpu_bundles" \
+        --raw-field "canary=$canary"
+
+    echo "Waiting for GitHub to create the workflow run..." >&2
+    for _ in {1..30}; do
+        run_id="$(
+            gh run list \
+                --workflow release.yml \
+                --branch main \
+                --commit "$release_sha" \
+                --event workflow_dispatch \
+                --created ">=$before" \
+                --json databaseId,headSha,createdAt \
+                --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // empty'
+        )"
+        if [[ -n "$run_id" ]]; then
+            printf '%s\n' "$run_id"
+            return
+        fi
+        sleep 2
+    done
+
+    die "timed out waiting for Release workflow run to appear"
+}
+
+wait_for_release() {
+    local tag="$1"
+
+    for _ in {1..60}; do
+        if gh release view "$tag" >/dev/null 2>&1; then
+            return
+        fi
+        sleep 5
+    done
+
+    die "release $tag was not visible after the workflow completed"
+}
+
+attach_generated_release_notes() {
+    local tag="$1"
+    local version="$2"
+    local target_sha="$3"
+    local prerelease="$4"
+    local notes_file
+
+    notes_file="$(mktemp)"
+    trap 'rm -f "$notes_file"' RETURN
+
+    echo "Generating release notes for $tag..."
+    gh api "repos/{owner}/{repo}/releases/generate-notes" \
+        --method POST \
+        --field "tag_name=$tag" \
+        --field "target_commitish=$target_sha" \
+        --jq '.body' >"$notes_file"
+
+    echo "Attaching generated release notes to $tag..."
+    if [[ "$prerelease" == "true" ]]; then
+        gh release edit "$tag" --title "$tag" --notes-file "$notes_file" --prerelease
+    else
+        gh release edit "$tag" --title "$tag" --notes-file "$notes_file"
+    fi
+
+    echo "Release notes updated for $tag."
+}
+
+main() {
+    if [[ $# -lt 1 ]]; then
+        usage
+        exit 1
+    fi
+
+    if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+
+    local raw_version="$1"
+    shift
+
+    local skip_gpu_bundles="false"
+    local canary="false"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --skip-gpu-bundles)
+                skip_gpu_bundles="true"
+                ;;
+            --canary)
+                canary="true"
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                usage
+                die "unknown argument: $1"
+                ;;
+        esac
+        shift
+    done
+
+    require_command gh
+    require_command git
+    require_command perl
+    require_command python3
+
+    local version
+    local tag
+    local prerelease
+    version="$(semver_from_arg "$raw_version")"
+    tag="v$version"
+    prerelease="false"
+    if [[ "$version" == *-* ]]; then
+        prerelease="true"
+    fi
+
+    ensure_clean_worktree
+    ensure_main_is_current
+
+    local current_version
+    current_version="$(read_workspace_version)"
+    [[ -n "$current_version" ]] || die "could not read workspace version from Cargo.toml"
+    ensure_version_format "$current_version" "current workspace"
+    ensure_target_version_advances "$current_version" "$version"
+    ensure_github_release_preflight "$tag"
+
+    confirm_release "$tag" "$version" "$current_version" "$skip_gpu_bundles" "$canary"
+
+    push_release_source_commit "$tag" "$version"
+
+    local release_sha
+    local run_id
+    release_sha="$(git rev-parse HEAD)"
+    run_id="$(dispatch_release_workflow "$tag" "$skip_gpu_bundles" "$canary" "$release_sha")"
+
+    echo "Watching Release workflow run $run_id..."
+    gh run watch "$run_id" --compact --exit-status
+
+    if [[ "$canary" == "true" ]]; then
+        echo "Canary release workflow succeeded; no GitHub release was published."
+        return
+    fi
+
+    wait_for_release "$tag"
+    attach_generated_release_notes "$tag" "$version" "$release_sha" "$prerelease"
+
+    echo "Release complete: $tag ($release_sha)"
+}
+
+main "$@"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,7 +47,7 @@ ensure_version_format() {
 }
 
 read_workspace_version() {
-    perl -ne 'if (/^\s*version\s*=\s*"([^"]+)"/) { print "$1\n"; exit }' Cargo.toml
+    perl -0ne 'print "$1\n" if /\[workspace\.package\][^[]*?\nversion\s*=\s*"([^"]+)"/s' Cargo.toml
 }
 
 ensure_target_version_advances() {
@@ -55,8 +55,7 @@ ensure_target_version_advances() {
     local target="$2"
     local compare_status
 
-    set +e
-    python3 - "$current" "$target" <<'PY'
+    if python3 - "$current" "$target" <<'PY'
 import re
 import sys
 
@@ -111,8 +110,11 @@ for left, right in zip(current_version[:3], target_version[:3]):
 
 raise SystemExit(0 if compare_prerelease(target_version[3], current_version[3]) > 0 else 1)
 PY
-    compare_status="$?"
-    set -e
+    then
+        compare_status=0
+    else
+        compare_status="$?"
+    fi
 
     case "$compare_status" in
         0)

--- a/sdk/kotlin/README.md
+++ b/sdk/kotlin/README.md
@@ -32,7 +32,7 @@ Then depend on the SDK:
 
 ```kotlin
 dependencies {
-    implementation("ai.meshllm:meshllm-android:0.68.0")
+    implementation("ai.meshllm:meshllm-android:0.72.1")
 }
 ```
 

--- a/sdk/kotlin/build.gradle.kts
+++ b/sdk/kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "ai.meshllm"
-version = "0.68.0"
+version = "0.72.1"
 
 val androidArtifactId = "meshllm-android"
 

--- a/sdk/kotlin/example/example-jvm/build.gradle.kts
+++ b/sdk/kotlin/example/example-jvm/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
 }
 
 group = "ai.meshllm.example"
-version = "0.68.0"
+version = "0.72.1"
 
 repositories {
     mavenCentral()

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshllm/sdk",
-  "version": "0.68.0",
+  "version": "0.72.1",
   "description": "Node.js SDK for MeshLLM client and local serving applications",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/swift/README.md
+++ b/sdk/swift/README.md
@@ -11,7 +11,7 @@ Add to your app's `Package.swift` using a tagged release:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Mesh-LLM/mesh-llm", from: "0.68.0"),
+    .package(url: "https://github.com/Mesh-LLM/mesh-llm", from: "0.72.1"),
 ],
 targets: [
     .target(

--- a/sdk/swift/scripts/generate-swift-bindings.sh
+++ b/sdk/swift/scripts/generate-swift-bindings.sh
@@ -27,7 +27,7 @@ rm -f \
 cat > "$RUNNER_DIR/Cargo.toml" <<'EOF'
 [package]
 name = "swift_bindgen_runner"
-version = "0.68.0"
+version = "0.72.1"
 edition = "2021"
 
 [dependencies]

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -27,8 +27,8 @@ the complete runtime option surface.
 mesh-llm --version
 ```
 
-Release builds report the released package version, such as `mesh-llm 0.68.0`.
-Local source builds may include build metadata, such as `mesh-llm 0.68.0+gABCDEF.dirty`, so you can tell exactly which commit produced the binary. Compatibility checks, native-runtime cache paths, and release identity still use the plain release version.
+Release builds report the released package version, such as `mesh-llm 0.72.1`.
+Local source builds may include build metadata, such as `mesh-llm 0.72.1+gABCDEF.dirty`, so you can tell exactly which commit produced the binary. Compatibility checks, native-runtime cache paths, and release identity still use the plain release version.
 
 ## Start here (common tasks)
 


### PR DESCRIPTION
## Summary
- sync mesh-llm release/version surfaces to the current GitHub release, v0.72.1
- add `just release <version>` as a synchronous release-prep and publish command
- expand `scripts/release-version.sh` so future bumps update Rust crates, lockfile entries, SDK/package manifests, docs, config schema metadata, and website source examples together
- add fail-closed release preflight checks for invalid/non-advancing versions, existing tags/releases, dirty worktrees, and non-current `main`

## Rationale
The previous release workflow accepted a version input for build jobs, but it did not reliably produce and build from a source commit that contained the corresponding version bump. That made the repository drift from published releases and left multiple public surfaces stuck on older versions.

This PR makes the release commit the first-class source of truth. `just release <version>` prepares the versioned commit on `main`, pushes it, dispatches the GitHub release workflow against that commit, watches the run via `gh`, and then attaches generated release notes to the GitHub release after a successful non-canary build. That avoids release branches and keeps the release build tied to the commit containing the version update.

The release command also fails closed before it can publish an ambiguous release: the target version must parse as semver, advance from the workspace version, and not already exist as a local tag, remote tag, or GitHub release. This supports RC progression such as `0.72.0-rc1` to `0.72.0-rc3`, while preventing accidental rebuilds of an already released version.

## Validation
- `just test-all`
- `scripts/release-version.sh 0.72.1`
- `bash -n scripts/release.sh scripts/release-version.sh`
- `cargo metadata --format-version 1`
- `just check-release`
- `git diff --check`

Note: the first full `just test-all` attempt exposed the expected config schema snapshot drift after syncing the built-in plugin version, and Playwright Chromium needed to be installed for the updated Playwright version. After updating the snapshot and running `pnpm exec playwright install chromium`, the final full `just test-all` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new release helper command to streamline preparing and publishing GitHub releases.

* **Documentation**
  * Updated SDK, CLI, and runtime documentation/examples to reference release version `0.72.1`.
  * Refreshed install snippets across Rust, Node.js, Swift, Kotlin, and native runtime docs.

* **Chores**
  * Bumped workspace and package versions to `0.72.1` across the project.
  * Updated the supported version list and UI placeholders to align with the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->