### PR TITLE
Rely on cargo publish for crate status

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -227,6 +227,7 @@ publish after their upstream crates land.
 If crates.io rate-limits the non-prerelease publish chain after some crates
 have already uploaded, rerun `scripts/publish-crates.sh` for the same checked
 out release tag instead of recutting the GitHub release or moving the tag. The
-script checks crates.io before each real publish, skips crate versions that are
-already visible, and retries HTTP 429 new-crate rate-limit responses using the
-retry time from crates.io when one is provided.
+script relies on `cargo publish` to report crate versions that were already
+uploaded, continues past those already-uploaded crates, and retries HTTP 429
+new-crate rate-limit responses using the retry time from crates.io when one is
+provided.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -15,7 +15,6 @@ Environment:
   CRATES_IO_PUBLISH_MAX_ATTEMPTS        Real-publish retry attempts for crates.io 429s (default: 6)
   CRATES_IO_PUBLISH_RETRY_BASE_SECONDS Fallback retry base when crates.io gives no timestamp (default: 60)
   CRATES_IO_PUBLISH_RETRY_MAX_SECONDS  Fallback retry cap when crates.io gives no timestamp (default: 900)
-  CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS Set to 1 to allow publish when crates.io status cannot be verified (default: 0)
 USAGE
 }
 
@@ -41,15 +40,6 @@ require_nonnegative_int() {
     local value="$2"
     if [[ ! "$value" =~ ^[0-9]+$ ]]; then
         echo "${name} must be a non-negative integer" >&2
-        exit 1
-    fi
-}
-
-require_binary_flag() {
-    local name="$1"
-    local value="$2"
-    if [[ "$value" != "0" && "$value" != "1" ]]; then
-        echo "${name} must be 0 or 1" >&2
         exit 1
     fi
 }
@@ -103,13 +93,11 @@ fi
 max_attempts="${CRATES_IO_PUBLISH_MAX_ATTEMPTS:-6}"
 retry_base_seconds="${CRATES_IO_PUBLISH_RETRY_BASE_SECONDS:-60}"
 retry_max_seconds="${CRATES_IO_PUBLISH_RETRY_MAX_SECONDS:-900}"
-allow_unknown_status="${CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS:-0}"
 
 require_nonnegative_int CRATES_IO_PUBLISH_SETTLE_SECONDS "$sleep_seconds"
 require_positive_int CRATES_IO_PUBLISH_MAX_ATTEMPTS "$max_attempts"
 require_positive_int CRATES_IO_PUBLISH_RETRY_BASE_SECONDS "$retry_base_seconds"
 require_positive_int CRATES_IO_PUBLISH_RETRY_MAX_SECONDS "$retry_max_seconds"
-require_binary_flag CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS "$allow_unknown_status"
 
 if [[ "$dry_run" -eq 0 && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
     echo "CARGO_REGISTRY_TOKEN is required for real crates.io publishing" >&2
@@ -262,23 +250,7 @@ publish_crate_with_retry() {
     local crate="$1"
     local index="$2"
     local total="$3"
-    local attempt status delay
-
-    if [[ "$dry_run" -eq 0 ]]; then
-        status="$(registry_version_status "$crate")"
-        if [[ "$status" == "published" ]]; then
-            log "[${index}/${total}] ${crate}@${workspace_version} already published; skipping"
-            return 0
-        fi
-        if [[ "$status" == "unknown" ]]; then
-            if [[ "$allow_unknown_status" -ne 1 ]]; then
-                warn "[${index}/${total}] could not verify ${crate}@${workspace_version} on crates.io; aborting before publish"
-                warn "set CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS=1 to continue when registry status cannot be verified"
-                return 101
-            fi
-            warn "[${index}/${total}] could not verify ${crate}@${workspace_version} on crates.io; trying cargo publish because CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS=1"
-        fi
-    fi
+    local attempt delay
 
     attempt=1
     while [[ "$attempt" -le "$max_attempts" ]]; do
@@ -296,11 +268,6 @@ publish_crate_with_retry() {
 
         if [[ "$dry_run" -eq 0 ]] && publish_error_is_already_uploaded "$last_publish_output"; then
             log "[${index}/${total}] ${crate}@${workspace_version} already published according to cargo; continuing"
-            return 0
-        fi
-
-        if [[ "$dry_run" -eq 0 && "$(registry_version_status "$crate")" == "published" ]]; then
-            log "[${index}/${total}] ${crate}@${workspace_version} is now visible on crates.io; continuing"
             return 0
         fi
 

--- a/scripts/tests/test_publish_crates.py
+++ b/scripts/tests/test_publish_crates.py
@@ -106,10 +106,13 @@ class PublishCratesScriptTests(unittest.TestCase):
             self.assertIn("CARGO_REGISTRY_TOKEN is required", result.stderr)
             self.assertFalse((fixture.tmp_path / "cargo.log").exists())
 
-    def test_real_publish_skips_crate_version_that_is_already_published(self) -> None:
+    def test_real_publish_uses_cargo_to_detect_already_uploaded_versions(self) -> None:
         with PublishCratesFixture() as fixture:
-            fixture.write_curl_statuses({"model-ref": 200})
-            fixture.write_fake_cargo()
+            fixture.write_curl_statuses({"model-ref": 500})
+            fixture.write_fake_cargo(
+                fail_crates={"model-ref": 1},
+                failure_output="error: crate version is already uploaded\n",
+            )
             fixture.write_fake_sleep()
             fixture.write_fake_date()
 
@@ -121,50 +124,16 @@ class PublishCratesScriptTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
-            self.assertIn("model-ref@0.68.0 already published; skipping", result.stdout)
-            self.assertNotIn("-p model-ref", fixture.read_log("cargo.log"))
-
-    def test_real_publish_fails_closed_when_registry_status_is_unknown(self) -> None:
-        with PublishCratesFixture() as fixture:
-            fixture.write_curl_statuses({"model-ref": 500})
-            fixture.write_fake_cargo()
-            fixture.write_fake_sleep()
-            fixture.write_fake_date()
-
-            result = fixture.run(env={"CARGO_REGISTRY_TOKEN": "test-token"})
-
-            self.assertNotEqual(result.returncode, 0)
             self.assertIn(
-                "could not verify model-ref@0.68.0 on crates.io; aborting before publish",
-                result.stderr,
-            )
-            self.assertFalse((fixture.tmp_path / "cargo.log").exists())
-
-    def test_real_publish_can_opt_into_unknown_registry_status(self) -> None:
-        with PublishCratesFixture() as fixture:
-            fixture.write_curl_statuses({"model-ref": 500})
-            fixture.write_fake_cargo()
-            fixture.write_fake_sleep()
-            fixture.write_fake_date()
-
-            result = fixture.run(
-                env={
-                    "CARGO_REGISTRY_TOKEN": "test-token",
-                    "CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS": "1",
-                    "CRATES_IO_PUBLISH_SETTLE_SECONDS": "0",
-                }
-            )
-
-            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
-            self.assertIn(
-                "trying cargo publish because CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS=1",
-                result.stderr,
+                "model-ref@0.68.0 already published according to cargo; continuing",
+                result.stdout,
             )
             self.assertIn("-p model-ref", fixture.read_log("cargo.log"))
+            self.assertEqual(fixture.read_log("curl.log"), "")
 
-    def test_real_publish_rejects_invalid_unknown_status_opt_in(self) -> None:
+    def test_real_publish_does_not_probe_registry_before_cargo_publish(self) -> None:
         with PublishCratesFixture() as fixture:
-            fixture.write_curl_statuses({})
+            fixture.write_curl_statuses({"model-ref": 500})
             fixture.write_fake_cargo()
             fixture.write_fake_sleep()
             fixture.write_fake_date()
@@ -172,16 +141,13 @@ class PublishCratesScriptTests(unittest.TestCase):
             result = fixture.run(
                 env={
                     "CARGO_REGISTRY_TOKEN": "test-token",
-                    "CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS": "yes",
+                    "CRATES_IO_PUBLISH_SETTLE_SECONDS": "0",
                 }
             )
 
-            self.assertNotEqual(result.returncode, 0)
-            self.assertIn(
-                "CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS must be 0 or 1",
-                result.stderr,
-            )
-            self.assertFalse((fixture.tmp_path / "cargo.log").exists())
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn("-p model-ref", fixture.read_log("cargo.log"))
+            self.assertEqual(fixture.read_log("curl.log"), "")
 
     def test_cargo_failure_output_redacts_registry_token(self) -> None:
         with PublishCratesFixture() as fixture:


### PR DESCRIPTION
## Summary

- Remove the real-publish crates.io status probe from scripts/publish-crates.sh.
- Let cargo publish report already-uploaded crate versions and continue from that output.
- Keep dry-run dependency visibility checks and 429 retry behavior, and update release docs/tests.

## Why

crates.io now rejects the bare curl status probe with a data-access-policy 403, which caused the release publish job to abort before cargo publish ran. cargo publish is the authoritative publish path, so real publishes should rely on its responses instead of a separate preflight HTTP probe.

## Validation

- bash -n scripts/publish-crates.sh
- python3 -m unittest scripts.tests.test_publish_crates
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated publishing guidance to reflect the current retry behavior when crates are already uploaded or hit a temporary rate limit.

* **Bug Fixes**
  * Improved crate publishing so it continues past versions that were already uploaded.
  * Simplified rate-limit handling to retry using the wait time returned by the registry, with no extra registry status check beforehand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->