### PR TITLE
Update model card logo URL

### DIFF
--- a/crates/model-package/src/script.rs
+++ b/crates/model-package/src/script.rs
@@ -138,7 +138,9 @@ mod tests {
         assert!(EMBEDDED_SCRIPT.contains("## Package Variant"));
         assert!(EMBEDDED_SCRIPT.contains("## What Is Included"));
         assert!(EMBEDDED_SCRIPT.contains("## Validation"));
-        assert!(EMBEDDED_SCRIPT.contains("docs/mesh-llm-logo.svg"));
+        assert!(
+            EMBEDDED_SCRIPT.contains("https://meshllm.cloud/assets/images/jelly-logo-wordmark.png")
+        );
         assert!(EMBEDDED_SCRIPT.contains("style=for-the-badge"));
         assert!(EMBEDDED_SCRIPT.contains("https://www.meshllm.cloud"));
         assert!(EMBEDDED_SCRIPT.contains("https://discord.gg/rs6fmc63eN"));

--- a/crates/model-package/src/scripts/split-model-job.sh
+++ b/crates/model-package/src/scripts/split-model-job.sh
@@ -665,7 +665,7 @@ tags:
 
 <div align="center">
   <a href="https://www.meshllm.cloud">
-    <img src="https://github.com/Mesh-LLM/mesh-llm/raw/main/docs/mesh-llm-logo.svg" alt="Mesh LLM" width="220">
+    <img src="https://meshllm.cloud/assets/images/jelly-logo-wordmark.png" alt="Mesh LLM" width="220">
   </a>
 
   <h1>{display_name}</h1>


### PR DESCRIPTION
## Summary

- Replace the model package README logo with the hosted Jelly wordmark asset.
- Update the embedded-script unit test so it guards the new model card logo URL.

## Why

Generated layer-package model cards still referenced the GitHub raw SVG logo. The generator should use `https://meshllm.cloud/assets/images/jelly-logo-wordmark.png` instead.

## Validation

- `cargo test -p model-package embedded_script_writes_rich_model_card`
- `cargo fmt --all --check`
- `cargo check -p model-package`
- `cargo clippy -p model-package --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the model card branding image to use a new hosted logo asset.
  * The embedded job script’s rich model card now shows the updated Jelly/MeshLLM wordmark instead of the previous SVG logo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->