### PR TITLE
Use restored US relay alias by default

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -598,7 +598,7 @@ fn effective_relay_urls(policy: RelayPolicy, relay_urls: &[String]) -> Vec<Strin
     match policy {
         RelayPolicy::Disabled | RelayPolicy::ExplicitlyDisabled => Vec::new(),
         RelayPolicy::DefaultPublic if relay_urls.is_empty() => vec![
-            "https://usw1-2.relay.michaelneale.mesh-llm.iroh.link./".into(),
+            "https://usw1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
             "https://aps1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
         ],
         RelayPolicy::DefaultPublic => relay_urls.to_vec(),


### PR DESCRIPTION
🤖 Minimal relay default update.

Changes:
- Replace the default US managed relay URL from `usw1-2.relay.michaelneale.mesh-llm.iroh.link.` to `usw1-1.relay.michaelneale.mesh-llm.iroh.link.`.
- Keep the AP relay default unchanged.

Validation:
- `cargo test -p mesh-llm-host-runtime relay_policy_tests::default_policy_uses_managed_relays_when_no_urls_are_given --lib`

