### PR TITLE
Server-side tool-call emulation for models without native tool support

### DIFF
--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -1779,6 +1779,7 @@ struct SplitMultimodalGeneration<'a> {
     downstream_wire_condition: WireCondition,
     lane_pool: Arc<PersistentStageLanePool>,
     prediction_return: Option<PredictionReturnReceiver>,
+    emulation_active: bool,
 }
 
 struct EmbeddedLocalOutput {

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -82,7 +82,11 @@ mod prefix_cache;
 mod prompting;
 mod request;
 mod speculative;
+mod tool_emulation;
 mod util;
+
+#[cfg(test)]
+use prompting::parse_emulated_chat_output;
 mod wire_messages;
 
 use self::{

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -1994,6 +1994,27 @@ enum TokenControl {
     Stop,
 }
 
+/// Whether generation for this request is running under tool-call emulation:
+/// the request carries tools and the rendered prompt metadata does not report
+/// native tool support (empty grammar triggers). Used to enable early
+/// generation stop once a complete emulated tool call has been produced.
+fn emulation_generation_active(
+    hook_request: Option<&ChatCompletionRequest>,
+    prompt: &PreparedGenerationPrompt,
+) -> bool {
+    let Some(request) = hook_request else {
+        return false;
+    };
+    if !tool_calls_requested(request) {
+        return false;
+    }
+    prompt
+        .chat_parse_metadata
+        .as_deref()
+        .map(|metadata| !tool_emulation::template_supports_native_tool_calls(metadata))
+        .unwrap_or(false)
+}
+
 struct TextGenerationCollector<'a, F>
 where
     F: FnMut(&str) -> OpenAiResult<()>,
@@ -2008,6 +2029,7 @@ where
     completion_tokens: usize,
     finish_reason: FinishReason,
     metrics: GenerationMetrics,
+    emulation_active: bool,
 }
 
 impl<'a, F> TextGenerationCollector<'a, F>
@@ -2031,7 +2053,17 @@ where
             completion_tokens: 0,
             finish_reason: finish_reason_for_generation(true),
             metrics: GenerationMetrics::default(),
+            emulation_active: false,
         }
+    }
+
+    /// Enables early generation stop once a complete emulated tool call is
+    /// generated. Mirrors goose's `tool_call_emitted -> Stop` so the model does
+    /// not ramble after emitting a call. Only active for emulated tools
+    /// requests; native requests are unaffected.
+    fn with_emulation_stop(mut self, emulation_active: bool) -> Self {
+        self.emulation_active = emulation_active;
+        self
     }
 
     fn push_token(&mut self, token: i32) -> OpenAiResult<TokenControl> {
@@ -2066,6 +2098,11 @@ where
             .any(|stop| !stop.is_empty() && self.text.contains(stop))
         {
             self.text = trim_at_stop(&self.text, &self.stop_values).to_string();
+            self.emit_safe_delta(true)?;
+            self.finish_reason = finish_reason_for_generation(false);
+            return Ok(TokenControl::Stop);
+        }
+        if self.emulation_active && tool_emulation::emulated_tool_call_complete(&self.text) {
             self.emit_safe_delta(true)?;
             self.finish_reason = finish_reason_for_generation(false);
             return Ok(TokenControl::Stop);

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -227,6 +227,7 @@ impl StageOpenAiBackend {
                     .map(|hub| hub.register(ids.request_id, ids.session_id))
                     .transpose()
                     .map_err(openai_backend_error)?;
+                let emulation_active = emulation_generation_active(hook_request.as_ref(), &prompt);
                 return self.generate_split_multimodal_text(
                     SplitMultimodalGeneration {
                         prompt,
@@ -241,6 +242,7 @@ impl StageOpenAiBackend {
                         downstream_wire_condition,
                         lane_pool,
                         prediction_return,
+                        emulation_active,
                     },
                     on_text_chunk,
                 );
@@ -571,7 +573,8 @@ impl StageOpenAiBackend {
             .map(String::as_str)
             .collect::<Vec<_>>();
         let mut collector =
-            TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk);
+            TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk)
+                .with_emulation_stop(request.emulation_active);
         let wire_sampling = wire_sampling_config(&request.sampling);
         let session_id = request.ids.session_id;
         let request_id = request.ids.request_id;

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -90,8 +90,10 @@ impl StageOpenAiBackend {
         };
         let chat_sampling_metadata = prompt.chat_parse_metadata.as_deref();
 
+        let emulation_active = emulation_generation_active(hook_request.as_ref(), &prompt);
         let mut collector =
-            TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk);
+            TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk)
+                .with_emulation_stop(emulation_active);
         let cache_stats = match self.mode.clone() {
             OpenAiBackendMode::LocalRuntime => self.generate_local_tokens(
                 LocalGeneration {
@@ -262,6 +264,7 @@ impl StageOpenAiBackend {
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
+        let emulation_active = emulation_generation_active(hook_request.as_ref(), &prompt);
         let session_id = ids.session_label.clone();
         let prefill_timer = PhaseTimer::start();
         let (prefill, mut token_signal, mut signal_window) = {
@@ -382,7 +385,8 @@ impl StageOpenAiBackend {
         }
 
         let mut collector =
-            TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk);
+            TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk)
+                .with_emulation_stop(emulation_active);
         let result = (|| {
             let decode_timer = PhaseTimer::start();
             let mut decoded_tokens = 0usize;

--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -138,6 +138,9 @@ impl StageOpenAiBackend {
         if tool_calls_requested(request)
             && !tool_emulation::template_supports_native_tool_calls(metadata)
         {
+            if !is_partial {
+                eprintln!("EMU_RAW_TEXT<<<{}>>>", text);
+            }
             return Ok(parse_emulated_chat_output(text, request, is_partial));
         }
 

--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+/// Output of a single chat-template application, before it is folded into a
+/// [`PreparedGenerationPrompt`].
+struct RenderedChatPrompt {
+    prompt: String,
+    media: Vec<MediaInput>,
+    metadata_json: String,
+}
+
 impl StageOpenAiBackend {
     pub(super) fn prepare_chat_prompt(
         &self,
@@ -13,29 +21,82 @@ impl StageOpenAiBackend {
                 .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
             runtime.media_marker()
         };
+
+        // Native path: render with tools and use the template's own metadata.
+        let native = self.render_chat_prompt(request, &options, &marker, None, true)?;
+
+        // If the request carries tools but the template does not support native
+        // tool calling, re-render with server-side tool-call emulation: strip
+        // tools, inject a text-convention instruction, and rewrite history so
+        // the template never sees tool roles. Tool-capable templates keep the
+        // native prompt unchanged.
+        if tool_calls_requested(request)
+            && !tool_emulation::template_supports_native_tool_calls(&native.metadata_json)
+            && let Some(tools) = request.tools.as_ref()
+            && let Some(instruction) = tool_emulation::build_emulation_instruction(tools)
+        {
+            let rewritten =
+                tool_emulation::rewrite_history_for_emulation(&request.messages, &instruction);
+            let emulated =
+                self.render_chat_prompt(request, &options, &marker, Some(&rewritten), false)?;
+            return Ok(PreparedGenerationPrompt {
+                text: emulated.prompt,
+                media: emulated.media,
+                chat_parse_metadata: Some(emulated.metadata_json),
+            });
+        }
+
+        Ok(PreparedGenerationPrompt {
+            text: native.prompt,
+            media: native.media,
+            chat_parse_metadata: Some(native.metadata_json),
+        })
+    }
+
+    /// Applies the chat template for the given messages. When `messages` is
+    /// `None`, the request's own messages are used. When `include_tools` is
+    /// false, `tools`/`tool_choice` are omitted (used by the emulation path).
+    fn render_chat_prompt(
+        &self,
+        request: &ChatCompletionRequest,
+        options: &ChatTemplateOptions,
+        marker: &str,
+        messages: Option<&[openai_frontend::ChatMessage]>,
+        include_tools: bool,
+    ) -> OpenAiResult<RenderedChatPrompt> {
+        let source_messages = messages.unwrap_or(&request.messages);
         let mut media = Vec::new();
-        let template_messages = request
-            .messages
+        let template_messages = source_messages
             .iter()
-            .map(|message| chat_message_generation_value(message, &marker, &mut media))
+            .map(|message| chat_message_generation_value(message, marker, &mut media))
             .collect::<OpenAiResult<Vec<_>>>()?;
         let messages_json = serde_json::to_string(&template_messages).map_err(|error| {
             OpenAiError::invalid_request(format!("serialize messages: {error}"))
         })?;
-        let tools_json = request
-            .tools
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()
-            .map_err(|error| OpenAiError::invalid_request(format!("serialize tools: {error}")))?;
-        let tool_choice_json = request
-            .tool_choice
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()
-            .map_err(|error| {
-                OpenAiError::invalid_request(format!("serialize tool_choice: {error}"))
-            })?;
+        let tools_json = if include_tools {
+            request
+                .tools
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()
+                .map_err(|error| {
+                    OpenAiError::invalid_request(format!("serialize tools: {error}"))
+                })?
+        } else {
+            None
+        };
+        let tool_choice_json = if include_tools {
+            request
+                .tool_choice
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()
+                .map_err(|error| {
+                    OpenAiError::invalid_request(format!("serialize tool_choice: {error}"))
+                })?
+        } else {
+            None
+        };
         let runtime = self
             .runtime
             .lock()
@@ -53,10 +114,10 @@ impl StageOpenAiBackend {
                 },
             )
             .map_err(openai_backend_error)?;
-        Ok(PreparedGenerationPrompt {
-            text: result.prompt,
+        Ok(RenderedChatPrompt {
+            prompt: result.prompt,
             media,
-            chat_parse_metadata: Some(result.metadata_json),
+            metadata_json: result.metadata_json,
         })
     }
 
@@ -70,6 +131,16 @@ impl StageOpenAiBackend {
         let Some(metadata) = metadata else {
             return Ok(None);
         };
+
+        // Emulation path: when tools were requested but the prompt was rendered
+        // without native tool support, the model emitted TOOL_CALL text lines.
+        // Parse those into OpenAI tool_calls instead of using the native parser.
+        if tool_calls_requested(request)
+            && !tool_emulation::template_supports_native_tool_calls(metadata)
+        {
+            return Ok(parse_emulated_chat_output(text, request, is_partial));
+        }
+
         let parsed_json = {
             let runtime = self
                 .runtime
@@ -203,4 +274,39 @@ impl StageOpenAiBackend {
             && hook_runtime.is_some()
             && hook_request.as_ref().is_some_and(chat_mesh_hooks_enabled)
     }
+}
+
+/// Parses generated text produced under tool-call emulation into a
+/// [`ParsedChatMessage`]. During streaming (`is_partial`) the trailing
+/// incomplete line is held back and tool calls are withheld, so a half-formed
+/// `TOOL_CALL` marker is never streamed as content and calls are emitted once,
+/// on finalization — matching native tool-call streaming semantics.
+pub(super) fn parse_emulated_chat_output(
+    text: &str,
+    request: &ChatCompletionRequest,
+    is_partial: bool,
+) -> Option<ParsedChatMessage> {
+    let allowed = request_allowed_tool_names(request);
+    let scan_text = if is_partial {
+        text.rsplit_once('\n')
+            .map(|(head, _)| head)
+            .unwrap_or_default()
+    } else {
+        text
+    };
+    let parse = tool_emulation::parse_emulated_tool_calls(scan_text, &allowed);
+    let tool_calls = if is_partial || parse.tool_calls.is_empty() {
+        None
+    } else {
+        let mut calls = parse.tool_calls;
+        if request.parallel_tool_calls == Some(false) {
+            calls.truncate(1);
+        }
+        Some(Value::Array(calls))
+    };
+    Some(ParsedChatMessage {
+        content: parse.content,
+        reasoning_content: None,
+        tool_calls,
+    })
 }

--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -31,7 +31,7 @@ impl StageOpenAiBackend {
         // the template never sees tool roles. Tool-capable templates keep the
         // native prompt unchanged.
         if tool_calls_requested(request)
-            && !tool_emulation::template_supports_native_tool_calls(&native.metadata_json)
+            && tool_emulation::should_emulate_tool_calls(&native.metadata_json)
             && let Some(tools) = request.tools.as_ref()
             && let Some(instruction) = tool_emulation::build_emulation_instruction(tools)
         {

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1144,6 +1144,80 @@ fn parallel_tool_calls_false_keeps_first_call() {
 }
 
 #[test]
+fn emulated_output_final_parses_tool_call() {
+    let request = tool_request();
+    let parsed = parse_emulated_chat_output(
+        "Let me check.\nTOOL_CALL {\"name\": \"lookup\", \"arguments\": {\"city\": \"Sydney\"}}",
+        &request,
+        false,
+    )
+    .expect("emulated parse");
+
+    assert_eq!(parsed.content.as_deref(), Some("Let me check."));
+    let calls = parsed.tool_calls.expect("tool calls");
+    assert_eq!(calls[0]["function"]["name"], "lookup");
+    let args: serde_json::Value =
+        serde_json::from_str(calls[0]["function"]["arguments"].as_str().unwrap()).unwrap();
+    assert_eq!(args["city"], "Sydney");
+}
+
+#[test]
+fn emulated_output_partial_withholds_tool_calls_and_incomplete_line() {
+    let request = tool_request();
+    // Streaming: the TOOL_CALL line is not yet newline-terminated.
+    let parsed = parse_emulated_chat_output(
+        "Let me check.\nTOOL_CALL {\"name\": \"lookup\", \"argumen",
+        &request,
+        true,
+    )
+    .expect("emulated parse");
+
+    // Tool calls are withheld while streaming.
+    assert!(parsed.tool_calls.is_none());
+    // Only the completed prose line is exposed; the partial marker line is held.
+    assert_eq!(parsed.content.as_deref(), Some("Let me check."));
+}
+
+#[test]
+fn emulated_output_respects_allowed_tool_names() {
+    let request = tool_request();
+    // "search" is not an allowed tool for this request (only "lookup" is).
+    let parsed = parse_emulated_chat_output(
+        "TOOL_CALL {\"name\": \"search\", \"arguments\": {}}",
+        &request,
+        false,
+    )
+    .expect("emulated parse");
+
+    assert!(parsed.tool_calls.is_none());
+}
+
+#[test]
+fn emulated_output_parallel_false_keeps_first_call() {
+    let mut request = tool_request();
+    request.parallel_tool_calls = Some(false);
+    let parsed = parse_emulated_chat_output(
+        "TOOL_CALL {\"name\": \"lookup\", \"arguments\": {\"city\": \"Sydney\"}}\n\
+         TOOL_CALL {\"name\": \"lookup\", \"arguments\": {\"city\": \"Melbourne\"}}",
+        &request,
+        false,
+    )
+    .expect("emulated parse");
+
+    let calls = parsed.tool_calls.expect("tool calls");
+    assert_eq!(calls.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn emulated_output_plain_prose_has_no_tool_calls() {
+    let request = tool_request();
+    let parsed =
+        parse_emulated_chat_output("The capital is Canberra.", &request, false).expect("parse");
+    assert!(parsed.tool_calls.is_none());
+    assert_eq!(parsed.content.as_deref(), Some("The capital is Canberra."));
+}
+
+#[test]
 fn tool_call_stream_delta_adds_indexes() {
     let delta = tool_calls_stream_delta(json!([
         {"id":"call_a","type":"function","function":{"name":"lookup","arguments":"{}"}},

--- a/crates/skippy-server/src/frontend/tool_emulation.rs
+++ b/crates/skippy-server/src/frontend/tool_emulation.rs
@@ -57,6 +57,31 @@ pub(super) fn template_supports_native_tool_calls(metadata_json: &str) -> bool {
         .is_some_and(|triggers| !triggers.is_empty())
 }
 
+/// Environment override, mirroring goose's `ToolCallingMode::ForceEmulated`.
+/// When set to a truthy value, tool-call emulation is used even for templates
+/// that natively support tool calling. Useful for testing the emulation path
+/// against strong models and as an escape hatch when a native template
+/// misbehaves.
+const FORCE_EMULATION_ENV: &str = "MESH_FORCE_TOOL_EMULATION";
+
+/// Decides whether a tools request should be served via emulation rather than
+/// the native template path. Emulation is used when the template does not
+/// natively support tool calling, or when the force-emulation override is set.
+pub(super) fn should_emulate_tool_calls(metadata_json: &str) -> bool {
+    force_emulation_enabled() || !template_supports_native_tool_calls(metadata_json)
+}
+
+fn force_emulation_enabled() -> bool {
+    std::env::var(FORCE_EMULATION_ENV)
+        .ok()
+        .is_some_and(|value| {
+            let value = value.trim();
+            !value.is_empty()
+                && !value.eq_ignore_ascii_case("0")
+                && !value.eq_ignore_ascii_case("false")
+        })
+}
+
 /// Extracts the function objects from an OpenAI `tools` array value.
 fn tool_functions(tools: &Value) -> Vec<&Map<String, Value>> {
     tools
@@ -401,6 +426,26 @@ mod tests {
             r#"{"chat_format": 2}"#
         ));
         assert!(!template_supports_native_tool_calls("not json"));
+    }
+
+    // Single test for the env-driven override so it cannot race another test
+    // mutating the same process-global env var under parallel execution.
+    #[test]
+    fn should_emulate_follows_native_support_and_force_override() {
+        let native = r#"{"grammar_triggers": [{"type": 1, "value": "<tool_call>"}]}"#;
+        let non_native = r#"{"grammar_triggers": []}"#;
+        // SAFETY: this is the only test that touches FORCE_EMULATION_ENV.
+        unsafe { std::env::remove_var(FORCE_EMULATION_ENV) };
+        // Default: emulate iff the template lacks native support.
+        assert!(!should_emulate_tool_calls(native));
+        assert!(should_emulate_tool_calls(non_native));
+        // Force override makes even a native template emulate.
+        unsafe { std::env::set_var(FORCE_EMULATION_ENV, "1") };
+        assert!(should_emulate_tool_calls(native));
+        // Falsey values do not force emulation.
+        unsafe { std::env::set_var(FORCE_EMULATION_ENV, "0") };
+        assert!(!should_emulate_tool_calls(native));
+        unsafe { std::env::remove_var(FORCE_EMULATION_ENV) };
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/tool_emulation.rs
+++ b/crates/skippy-server/src/frontend/tool_emulation.rs
@@ -176,6 +176,83 @@ pub(super) fn build_emulation_instruction(tools: &Value) -> Option<String> {
     Some(instruction)
 }
 
+/// Returns true once the generated text contains at least one complete emulated
+/// tool call: a `TOOL_CALL` marker followed by a balanced JSON object. This
+/// drives early generation stop (goose's `tool_call_emitted -> Stop`), so the
+/// model does not ramble after emitting a call. `<think>` spans are ignored so
+/// a marker inside reasoning does not stop generation prematurely.
+pub(super) fn emulated_tool_call_complete(text: &str) -> bool {
+    let scannable = strip_think_blocks(text);
+    let mut search_from = 0;
+    while let Some(marker_rel) = scannable[search_from..].find(TOOL_CALL_MARKER) {
+        let after_marker = search_from + marker_rel + TOOL_CALL_MARKER.len();
+        let rest = scannable[after_marker..]
+            .trim_start()
+            .trim_start_matches(':');
+        if let Some(end) = balanced_json_object_end(rest) {
+            // A complete JSON object with a name field is a complete call.
+            if serde_json::from_str::<Value>(&rest[..end])
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .map(|name| !name.trim().is_empty())
+                })
+                .unwrap_or(false)
+            {
+                return true;
+            }
+        }
+        search_from = after_marker;
+    }
+    false
+}
+
+/// Returns the byte index just past the first balanced top-level `{...}` JSON
+/// object at the start of `text` (after optional leading whitespace), or `None`
+/// if the object is not yet complete. String contents and escapes are handled
+/// so braces inside strings do not affect nesting.
+fn balanced_json_object_end(text: &str) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i >= bytes.len() || bytes[i] != b'{' {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+        } else {
+            match byte {
+                b'"' => in_string = true,
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i + 1);
+                    }
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
 /// Flattens message content into plain text for history rewriting.
 fn content_text(content: Option<&MessageContent>) -> String {
     content
@@ -246,7 +323,9 @@ pub(super) fn rewrite_history_for_emulation(
                 let merged = if existing.trim().is_empty() {
                     instruction.to_string()
                 } else {
-                    format!("{existing}\n\n{instruction}")
+                    // Emulation frame takes the dominant leading position; the
+                    // client's system content is preserved below it as context.
+                    format!("{instruction}\n\n# Task context\n\n{existing}")
                 };
                 rewritten.push(plain_message("system", merged));
             }
@@ -303,20 +382,37 @@ pub(super) struct EmulatedParse {
 /// allow all).
 pub(super) fn parse_emulated_tool_calls(text: &str, allowed_names: &[String]) -> EmulatedParse {
     let scannable = strip_think_blocks(text);
-    let mut content_lines: Vec<String> = Vec::new();
     let mut tool_calls: Vec<Value> = Vec::new();
-
-    for line in scannable.lines() {
-        if let Some(call) = parse_tool_call_line(line, allowed_names) {
+    // Content is whatever remains after removing each TOOL_CALL marker + its
+    // JSON object. The marker can appear anywhere (line start, or right after a
+    // reasoning marker like `<|channel>...channel|>`), so scan the whole text
+    // rather than requiring the marker at the start of a line.
+    let mut content = String::new();
+    let mut cursor = 0;
+    while let Some(marker_rel) = scannable[cursor..].find(TOOL_CALL_MARKER) {
+        let marker_start = cursor + marker_rel;
+        let after_marker = marker_start + TOOL_CALL_MARKER.len();
+        let rest = &scannable[after_marker..];
+        let json_start_trimmed = rest.trim_start().trim_start_matches(':');
+        if let Some(end) = balanced_json_object_end(json_start_trimmed)
+            && let Some(call) = parse_tool_call_json(&json_start_trimmed[..end], allowed_names)
+        {
+            content.push_str(&scannable[cursor..marker_start]);
+            // Advance cursor past the consumed JSON object.
+            let consumed = json_start_trimmed.as_ptr() as usize - scannable.as_ptr() as usize + end;
+            cursor = consumed;
             tool_calls.push(call);
         } else {
-            content_lines.push(line.to_string());
+            // Not a complete/valid call: keep the marker text as content and
+            // move past it to avoid an infinite loop.
+            content.push_str(&scannable[cursor..after_marker]);
+            cursor = after_marker;
         }
     }
+    content.push_str(&scannable[cursor..]);
 
     let content = {
-        let joined = content_lines.join("\n");
-        let trimmed = joined.trim();
+        let trimmed = content.trim();
         if trimmed.is_empty() {
             None
         } else {
@@ -347,13 +443,11 @@ fn strip_think_blocks(text: &str) -> String {
     out
 }
 
-/// Parses a single line as a tool call if it carries the marker and a JSON
-/// object with a `name`. Returns the OpenAI tool-call object (without an id;
-/// downstream assembly assigns `call_mesh_*` ids).
-fn parse_tool_call_line(line: &str, allowed_names: &[String]) -> Option<Value> {
-    let trimmed = line.trim();
-    let after_marker = trimmed.strip_prefix(TOOL_CALL_MARKER)?;
-    let json_part = after_marker.trim_start().trim_start_matches(':').trim();
+/// Parses a JSON object string into an OpenAI tool-call object if it carries a
+/// non-empty `name` (and, when `allowed_names` is non-empty, an allowed one).
+/// Returns the tool-call object without an id; downstream assembly assigns
+/// `call_mesh_*` ids.
+fn parse_tool_call_json(json_part: &str, allowed_names: &[String]) -> Option<Value> {
     let payload = serde_json::from_str::<Value>(json_part).ok()?;
     let name = payload.get("name").and_then(Value::as_str)?.trim();
     if name.is_empty() {
@@ -511,6 +605,32 @@ mod tests {
     }
 
     #[test]
+    fn tool_call_complete_detects_balanced_json() {
+        assert!(emulated_tool_call_complete(
+            "TOOL_CALL {\"name\": \"shell\", \"arguments\": {\"command\": \"ls\"}}"
+        ));
+        // Incomplete JSON: not yet complete.
+        assert!(!emulated_tool_call_complete(
+            "TOOL_CALL {\"name\": \"shell\", \"arguments\": {\"command\": \"l"
+        ));
+        // Marker but no object yet.
+        assert!(!emulated_tool_call_complete("Let me think. TOOL_CALL "));
+        // Braces inside a string do not prematurely balance.
+        assert!(emulated_tool_call_complete(
+            "TOOL_CALL {\"name\": \"echo\", \"arguments\": {\"text\": \"a}b{c\"}}"
+        ));
+        // No marker at all.
+        assert!(!emulated_tool_call_complete("just prose here"));
+    }
+
+    #[test]
+    fn tool_call_complete_ignores_marker_in_think_block() {
+        assert!(!emulated_tool_call_complete(
+            "<think>TOOL_CALL {\"name\": \"shell\", \"arguments\": {}}</think>"
+        ));
+    }
+
+    #[test]
     fn parse_plain_prose_has_no_tool_calls() {
         let parse = parse_emulated_tool_calls("Just a normal answer.", &[]);
         assert!(parse.tool_calls.is_empty());
@@ -545,6 +665,8 @@ mod tests {
                 .unwrap();
         assert!(system.contains("You are helpful."));
         assert!(system.contains("INSTRUCTION"));
+        // Emulation frame leads; client system content is preserved below it.
+        assert!(system.find("INSTRUCTION").unwrap() < system.find("You are helpful.").unwrap());
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/tool_emulation.rs
+++ b/crates/skippy-server/src/frontend/tool_emulation.rs
@@ -32,23 +32,29 @@ use serde_json::{Map, Value};
 /// call. The remainder of the line is a JSON object `{"name", "arguments"}`.
 pub(super) const TOOL_CALL_MARKER: &str = "TOOL_CALL";
 
-/// Returns true when the chat-template metadata reports native tool-calling
-/// support. Mirrors goose's `template_result_supports_native_tool_calling`:
-/// the template must both request tool-call parsing and provide a non-empty
-/// parser name.
+/// Returns true when the loaded model's chat template natively supports tool
+/// calling.
+///
+/// This is the mesh-llm analogue of goose's
+/// `template_result_supports_native_tool_calling`. goose reads llama.cpp's
+/// `parse_tool_calls` + parser fields, but in mesh-llm's patched runtime
+/// `parse_tool_calls` only reflects whether the request carried tools (it is
+/// true for every tools request) and `chat_parser` is always a non-empty PEG
+/// structure, so neither field distinguishes a tool-capable template.
+///
+/// The signal that does distinguish them is `grammar_triggers`: when the jinja
+/// template natively describes tool calls, applying it with tools yields a
+/// tool-call grammar trigger (e.g. `<tool_call>`). A template with no native
+/// tool support (for example SmolLM2-135M) yields an empty `grammar_triggers`
+/// list. We treat a non-empty `grammar_triggers` as native tool-call support.
 pub(super) fn template_supports_native_tool_calls(metadata_json: &str) -> bool {
     let Ok(metadata) = serde_json::from_str::<Value>(metadata_json) else {
         return false;
     };
-    let parse_tool_calls = metadata
-        .get("parse_tool_calls")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let parser_non_empty = metadata
-        .get("chat_parser")
-        .and_then(Value::as_str)
-        .is_some_and(|parser| !parser.trim().is_empty());
-    parse_tool_calls && parser_non_empty
+    metadata
+        .get("grammar_triggers")
+        .and_then(Value::as_array)
+        .is_some_and(|triggers| !triggers.is_empty())
 }
 
 /// Extracts the function objects from an OpenAI `tools` array value.
@@ -381,18 +387,18 @@ mod tests {
     }
 
     #[test]
-    fn native_detection_requires_both_signals() {
+    fn native_detection_uses_grammar_triggers() {
+        // Tool-capable template: applying it yields a tool-call grammar trigger.
         assert!(template_supports_native_tool_calls(
-            r#"{"parse_tool_calls": true, "chat_parser": "hermes"}"#
+            r#"{"chat_format": 2, "grammar_triggers": [{"type": 1, "value": "<tool_call>"}]}"#
         ));
+        // Non-tool-capable template (e.g. SmolLM2-135M): empty grammar triggers.
         assert!(!template_supports_native_tool_calls(
-            r#"{"parse_tool_calls": false, "chat_parser": "hermes"}"#
+            r#"{"chat_format": 2, "grammar_triggers": []}"#
         ));
+        // Missing field or non-array is treated as non-native.
         assert!(!template_supports_native_tool_calls(
-            r#"{"parse_tool_calls": true, "chat_parser": ""}"#
-        ));
-        assert!(!template_supports_native_tool_calls(
-            r#"{"parse_tool_calls": true}"#
+            r#"{"chat_format": 2}"#
         ));
         assert!(!template_supports_native_tool_calls("not json"));
     }

--- a/crates/skippy-server/src/frontend/tool_emulation.rs
+++ b/crates/skippy-server/src/frontend/tool_emulation.rs
@@ -1,0 +1,544 @@
+//! Serving-side tool-call emulation for models whose chat template does not
+//! support native tool calling.
+//!
+//! Small / non-tool-trained models handle the OpenAI `tools` field poorly: the
+//! chat template either ignores the schemas or the model loops re-issuing the
+//! same call. The serving node is the right place to fix this because it is the
+//! only party that knows the actual **chat template capability** of the loaded
+//! model — clients only know a model name.
+//!
+//! This module is a port of the approach proven in goose's local-inference
+//! provider (text-convention emulation + tolerant parser). When a request
+//! carries `tools` for a template that is not tool-capable, we:
+//!
+//! 1. **Adapt the request**: strip `tools`/`tool_choice` from the template
+//!    input, inject a compact instruction (tool name + description + compact
+//!    parameter schema) describing the `TOOL_CALL {json}` convention, and
+//!    rewrite conversation history so the template never sees tool roles.
+//! 2. **Parse the response**: scan output for `TOOL_CALL` lines and convert
+//!    them into real OpenAI `tool_calls` with `finish_reason: "tool_calls"`.
+//!    Parsing is tolerant of surrounding prose and `<think>` blocks.
+//!
+//! Detection is gated on template capability, not model size: a lean
+//! tool-trained model (e.g. Qwen3-0.6B) keeps native tool calling and sees
+//! **zero behavior change**.
+
+use std::collections::BTreeMap;
+
+use openai_frontend::{ChatMessage, MessageContent};
+use serde_json::{Map, Value};
+
+/// Marker a model is instructed to emit, on its own line, to request a tool
+/// call. The remainder of the line is a JSON object `{"name", "arguments"}`.
+pub(super) const TOOL_CALL_MARKER: &str = "TOOL_CALL";
+
+/// Returns true when the chat-template metadata reports native tool-calling
+/// support. Mirrors goose's `template_result_supports_native_tool_calling`:
+/// the template must both request tool-call parsing and provide a non-empty
+/// parser name.
+pub(super) fn template_supports_native_tool_calls(metadata_json: &str) -> bool {
+    let Ok(metadata) = serde_json::from_str::<Value>(metadata_json) else {
+        return false;
+    };
+    let parse_tool_calls = metadata
+        .get("parse_tool_calls")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let parser_non_empty = metadata
+        .get("chat_parser")
+        .and_then(Value::as_str)
+        .is_some_and(|parser| !parser.trim().is_empty());
+    parse_tool_calls && parser_non_empty
+}
+
+/// Extracts the function objects from an OpenAI `tools` array value.
+fn tool_functions(tools: &Value) -> Vec<&Map<String, Value>> {
+    tools
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| {
+            tool.get("function")
+                .and_then(Value::as_object)
+                .or_else(|| tool.as_object())
+        })
+        .collect()
+}
+
+/// Renders a compact parameter schema (property name + type) for the emulation
+/// instruction. Full JSON schemas overwhelm tiny models; name+type is the
+/// signal that keeps them from hallucinating argument names.
+fn compact_parameter_schema(function: &Map<String, Value>) -> Option<String> {
+    let parameters = function
+        .get("parameters")
+        .or_else(|| function.get("input_schema"))?;
+    let properties = parameters.get("properties").and_then(Value::as_object)?;
+    let required: Vec<&str> = parameters
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect();
+    if properties.is_empty() {
+        return Some("{}".to_string());
+    }
+    let mut rendered = Vec::new();
+    for (name, schema) in properties {
+        let ty = schema
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("string");
+        let flag = if required.contains(&name.as_str()) {
+            ""
+        } else {
+            "?"
+        };
+        rendered.push(format!("{name}{flag}: {ty}"));
+    }
+    Some(format!("{{{}}}", rendered.join(", ")))
+}
+
+/// Builds the emulation system instruction: the calling convention plus a
+/// compact description of each available tool. Returns `None` when the tools
+/// value carries no usable functions.
+pub(super) fn build_emulation_instruction(tools: &Value) -> Option<String> {
+    let functions = tool_functions(tools);
+    if functions.is_empty() {
+        return None;
+    }
+    let mut instruction = String::new();
+    instruction.push_str(
+        "# Tool calling\n\n\
+         You can call tools. To call a tool, emit a single line beginning with ",
+    );
+    instruction.push_str(TOOL_CALL_MARKER);
+    instruction.push_str(
+        " followed by a JSON object with \"name\" and \"arguments\":\n\n\
+         TOOL_CALL {\"name\": \"the_tool_name\", \"arguments\": {\"arg\": \"value\"}}\n\n\
+         Emit the line exactly, on its own line, with valid JSON. Use the exact \
+         argument names shown below. Call a tool only when it is needed; \
+         otherwise answer normally.\n\n\
+         ## Available tools\n\n",
+    );
+    for function in functions {
+        let Some(name) = function.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let description = function
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        instruction.push_str("- ");
+        instruction.push_str(name);
+        if !description.is_empty() {
+            instruction.push_str(": ");
+            instruction.push_str(description);
+        }
+        if let Some(schema) = compact_parameter_schema(function) {
+            instruction.push_str("\n  arguments: ");
+            instruction.push_str(&schema);
+        }
+        instruction.push('\n');
+    }
+    Some(instruction)
+}
+
+/// Flattens message content into plain text for history rewriting.
+fn content_text(content: Option<&MessageContent>) -> String {
+    content
+        .and_then(openai_frontend::message_content_to_text)
+        .unwrap_or_default()
+}
+
+/// Renders an assistant message's `tool_calls` (from history) back into the
+/// `TOOL_CALL {json}` text convention so the template never sees tool roles.
+fn assistant_tool_calls_as_text(extra: &BTreeMap<String, Value>) -> Option<String> {
+    let calls = extra.get("tool_calls").and_then(Value::as_array)?;
+    let mut lines = Vec::new();
+    for call in calls {
+        let function = call.get("function").and_then(Value::as_object);
+        let name = function
+            .and_then(|function| function.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if name.is_empty() {
+            continue;
+        }
+        let arguments = function
+            .and_then(|function| function.get("arguments"))
+            .map(arguments_to_json_value)
+            .unwrap_or(Value::Object(Map::new()));
+        let payload = serde_json::json!({ "name": name, "arguments": arguments });
+        lines.push(format!("{TOOL_CALL_MARKER} {payload}"));
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+/// Tool-call `arguments` on the wire may be a JSON string or an object. Return
+/// a JSON value either way.
+fn arguments_to_json_value(arguments: &Value) -> Value {
+    match arguments {
+        Value::String(text) => serde_json::from_str::<Value>(text).unwrap_or(Value::Object(
+            std::iter::once(("_raw".to_string(), Value::String(text.clone()))).collect(),
+        )),
+        other => other.clone(),
+    }
+}
+
+/// Rewrites conversation history so a non-tool-capable template never sees
+/// `tool` roles or assistant `tool_calls`:
+/// - assistant `tool_calls` become assistant text using the `TOOL_CALL`
+///   convention (so the model sees its own prior calls in the same form),
+/// - `role: "tool"` messages become `user` messages prefixed with
+///   `Tool result:`.
+///
+/// The emulation instruction is prepended to (or merged into) the first system
+/// message, or inserted as a new leading system message.
+pub(super) fn rewrite_history_for_emulation(
+    messages: &[ChatMessage],
+    instruction: &str,
+) -> Vec<ChatMessage> {
+    let mut rewritten: Vec<ChatMessage> = Vec::with_capacity(messages.len() + 1);
+    let mut instruction_placed = false;
+
+    for message in messages {
+        match message.role.as_str() {
+            "system" if !instruction_placed => {
+                instruction_placed = true;
+                let existing = content_text(message.content.as_ref());
+                let merged = if existing.trim().is_empty() {
+                    instruction.to_string()
+                } else {
+                    format!("{existing}\n\n{instruction}")
+                };
+                rewritten.push(plain_message("system", merged));
+            }
+            "tool" => {
+                let result = content_text(message.content.as_ref());
+                rewritten.push(plain_message("user", format!("Tool result: {result}")));
+            }
+            "assistant" => {
+                let mut text = content_text(message.content.as_ref());
+                if let Some(tool_text) = assistant_tool_calls_as_text(&message.extra) {
+                    if text.trim().is_empty() {
+                        text = tool_text;
+                    } else {
+                        text = format!("{text}\n{tool_text}");
+                    }
+                }
+                rewritten.push(plain_message("assistant", text));
+            }
+            role => {
+                rewritten.push(plain_message(role, content_text(message.content.as_ref())));
+            }
+        }
+    }
+
+    if !instruction_placed {
+        rewritten.insert(0, plain_message("system", instruction.to_string()));
+    }
+
+    rewritten
+}
+
+/// Builds a minimal `ChatMessage` with plain text content and no extra fields,
+/// so the downstream template sees only `role` + `content`.
+fn plain_message(role: &str, content: String) -> ChatMessage {
+    ChatMessage {
+        role: role.to_string(),
+        content: Some(MessageContent::Text(content)),
+        extra: BTreeMap::new(),
+    }
+}
+
+/// Result of parsing an emulated response: any prose content plus the parsed
+/// tool calls (already in OpenAI wire shape, arguments as a JSON string).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct EmulatedParse {
+    pub content: Option<String>,
+    pub tool_calls: Vec<Value>,
+}
+
+/// Scans generated text for `TOOL_CALL {json}` lines and converts them to
+/// OpenAI tool-call objects, tolerant of surrounding prose and `<think>`
+/// blocks. Text that is not part of a recognized tool call is preserved as
+/// `content`. Only calls whose name is in `allowed_names` are kept (empty means
+/// allow all).
+pub(super) fn parse_emulated_tool_calls(text: &str, allowed_names: &[String]) -> EmulatedParse {
+    let scannable = strip_think_blocks(text);
+    let mut content_lines: Vec<String> = Vec::new();
+    let mut tool_calls: Vec<Value> = Vec::new();
+
+    for line in scannable.lines() {
+        if let Some(call) = parse_tool_call_line(line, allowed_names) {
+            tool_calls.push(call);
+        } else {
+            content_lines.push(line.to_string());
+        }
+    }
+
+    let content = {
+        let joined = content_lines.join("\n");
+        let trimmed = joined.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    };
+
+    EmulatedParse {
+        content,
+        tool_calls,
+    }
+}
+
+/// Removes `<think>...</think>` spans so a reasoning model's scratchpad never
+/// triggers or hides a tool call. An unterminated `<think>` drops the rest.
+fn strip_think_blocks(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("<think>") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + "<think>".len()..];
+        match after.find("</think>") {
+            Some(end) => rest = &after[end + "</think>".len()..],
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Parses a single line as a tool call if it carries the marker and a JSON
+/// object with a `name`. Returns the OpenAI tool-call object (without an id;
+/// downstream assembly assigns `call_mesh_*` ids).
+fn parse_tool_call_line(line: &str, allowed_names: &[String]) -> Option<Value> {
+    let trimmed = line.trim();
+    let after_marker = trimmed.strip_prefix(TOOL_CALL_MARKER)?;
+    let json_part = after_marker.trim_start().trim_start_matches(':').trim();
+    let payload = serde_json::from_str::<Value>(json_part).ok()?;
+    let name = payload.get("name").and_then(Value::as_str)?.trim();
+    if name.is_empty() {
+        return None;
+    }
+    if !allowed_names.is_empty() && !allowed_names.iter().any(|allowed| allowed == name) {
+        return None;
+    }
+    let arguments = payload
+        .get("arguments")
+        .cloned()
+        .unwrap_or(Value::Object(Map::new()));
+    let arguments_string = match &arguments {
+        Value::String(text) => text.clone(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| "{}".to_string()),
+    };
+    Some(serde_json::json!({
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments_string,
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(role: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: role.to_string(),
+            content: Some(MessageContent::Text(content.to_string())),
+            extra: BTreeMap::new(),
+        }
+    }
+
+    fn tools_value() -> Value {
+        serde_json::json!([
+            {
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string"},
+                            "timeout": {"type": "integer"}
+                        },
+                        "required": ["command"]
+                    }
+                }
+            }
+        ])
+    }
+
+    #[test]
+    fn native_detection_requires_both_signals() {
+        assert!(template_supports_native_tool_calls(
+            r#"{"parse_tool_calls": true, "chat_parser": "hermes"}"#
+        ));
+        assert!(!template_supports_native_tool_calls(
+            r#"{"parse_tool_calls": false, "chat_parser": "hermes"}"#
+        ));
+        assert!(!template_supports_native_tool_calls(
+            r#"{"parse_tool_calls": true, "chat_parser": ""}"#
+        ));
+        assert!(!template_supports_native_tool_calls(
+            r#"{"parse_tool_calls": true}"#
+        ));
+        assert!(!template_supports_native_tool_calls("not json"));
+    }
+
+    #[test]
+    fn instruction_includes_compact_schema_with_required_flags() {
+        let instruction = build_emulation_instruction(&tools_value()).unwrap();
+        assert!(instruction.contains("TOOL_CALL"));
+        assert!(instruction.contains("- shell: Run a shell command"));
+        // Required arg has no marker; optional arg is flagged with `?`.
+        assert!(instruction.contains("command: string"));
+        assert!(instruction.contains("timeout?: integer"));
+    }
+
+    #[test]
+    fn instruction_none_without_functions() {
+        assert!(build_emulation_instruction(&serde_json::json!([])).is_none());
+    }
+
+    #[test]
+    fn parse_single_tool_call() {
+        let parse = parse_emulated_tool_calls(
+            "Let me check.\nTOOL_CALL {\"name\": \"shell\", \"arguments\": {\"command\": \"ls\"}}",
+            &[],
+        );
+        assert_eq!(parse.content.as_deref(), Some("Let me check."));
+        assert_eq!(parse.tool_calls.len(), 1);
+        let call = &parse.tool_calls[0];
+        assert_eq!(call["function"]["name"], "shell");
+        // arguments are serialized as a JSON string per OpenAI wire shape.
+        let args: Value =
+            serde_json::from_str(call["function"]["arguments"].as_str().unwrap()).unwrap();
+        assert_eq!(args["command"], "ls");
+    }
+
+    #[test]
+    fn parse_ignores_marker_inside_think_block() {
+        let parse = parse_emulated_tool_calls(
+            "<think>\nTOOL_CALL {\"name\": \"shell\", \"arguments\": {}}\n</think>\nHello",
+            &[],
+        );
+        assert!(parse.tool_calls.is_empty());
+        assert_eq!(parse.content.as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn parse_tolerates_colon_after_marker() {
+        let parse = parse_emulated_tool_calls(
+            "TOOL_CALL: {\"name\": \"shell\", \"arguments\": {\"command\": \"pwd\"}}",
+            &[],
+        );
+        assert_eq!(parse.tool_calls.len(), 1);
+        assert_eq!(parse.tool_calls[0]["function"]["name"], "shell");
+    }
+
+    #[test]
+    fn parse_filters_disallowed_names() {
+        let parse = parse_emulated_tool_calls(
+            "TOOL_CALL {\"name\": \"evil\", \"arguments\": {}}",
+            &["shell".to_string()],
+        );
+        assert!(parse.tool_calls.is_empty());
+        // Disallowed call falls back to content rather than vanishing.
+        assert!(parse.content.is_some());
+    }
+
+    #[test]
+    fn parse_plain_prose_has_no_tool_calls() {
+        let parse = parse_emulated_tool_calls("Just a normal answer.", &[]);
+        assert!(parse.tool_calls.is_empty());
+        assert_eq!(parse.content.as_deref(), Some("Just a normal answer."));
+    }
+
+    #[test]
+    fn parse_multiple_tool_calls() {
+        let parse = parse_emulated_tool_calls(
+            "TOOL_CALL {\"name\": \"shell\", \"arguments\": {\"command\": \"ls\"}}\n\
+             TOOL_CALL {\"name\": \"shell\", \"arguments\": {\"command\": \"pwd\"}}",
+            &[],
+        );
+        assert_eq!(parse.tool_calls.len(), 2);
+        assert!(parse.content.is_none());
+    }
+
+    #[test]
+    fn parse_malformed_json_is_treated_as_prose() {
+        let parse = parse_emulated_tool_calls("TOOL_CALL {not valid json}", &[]);
+        assert!(parse.tool_calls.is_empty());
+        assert!(parse.content.is_some());
+    }
+
+    #[test]
+    fn history_rewrite_merges_instruction_into_system() {
+        let messages = vec![msg("system", "You are helpful."), msg("user", "hi")];
+        let rewritten = rewrite_history_for_emulation(&messages, "INSTRUCTION");
+        assert_eq!(rewritten.len(), 2);
+        let system =
+            openai_frontend::message_content_to_text(rewritten[0].content.as_ref().unwrap())
+                .unwrap();
+        assert!(system.contains("You are helpful."));
+        assert!(system.contains("INSTRUCTION"));
+    }
+
+    #[test]
+    fn history_rewrite_inserts_system_when_absent() {
+        let messages = vec![msg("user", "hi")];
+        let rewritten = rewrite_history_for_emulation(&messages, "INSTRUCTION");
+        assert_eq!(rewritten.len(), 2);
+        assert_eq!(rewritten[0].role, "system");
+        assert_eq!(rewritten[1].role, "user");
+    }
+
+    #[test]
+    fn history_rewrite_converts_tool_role_to_user() {
+        let messages = vec![msg("tool", "exit 0")];
+        let rewritten = rewrite_history_for_emulation(&messages, "I");
+        // system instruction + rewritten tool message
+        let tool_msg = rewritten.iter().find(|m| m.role == "user").unwrap();
+        let text =
+            openai_frontend::message_content_to_text(tool_msg.content.as_ref().unwrap()).unwrap();
+        assert!(text.starts_with("Tool result: exit 0"));
+    }
+
+    #[test]
+    fn history_rewrite_converts_assistant_tool_calls_to_text() {
+        let mut extra = BTreeMap::new();
+        extra.insert(
+            "tool_calls".to_string(),
+            serde_json::json!([{
+                "type": "function",
+                "function": {"name": "shell", "arguments": "{\"command\": \"ls\"}"}
+            }]),
+        );
+        let assistant = ChatMessage {
+            role: "assistant".to_string(),
+            content: None,
+            extra,
+        };
+        let rewritten = rewrite_history_for_emulation(&[assistant], "I");
+        let asst = rewritten.iter().find(|m| m.role == "assistant").unwrap();
+        let text =
+            openai_frontend::message_content_to_text(asst.content.as_ref().unwrap()).unwrap();
+        assert!(text.contains("TOOL_CALL"));
+        assert!(text.contains("\"name\":\"shell\""));
+        assert!(text.contains("\"command\":\"ls\""));
+        // Rewritten message must not leak the raw tool_calls field to the template.
+        assert!(!asst.extra.contains_key("tool_calls"));
+    }
+}

--- a/docs/specs/server-side-tool-call-emulation.md
+++ b/docs/specs/server-side-tool-call-emulation.md
@@ -1,0 +1,74 @@
+# Server-side tool-call emulation
+
+Small / non-tool-trained models served through the mesh `/v1/chat/completions`
+endpoint handle the OpenAI `tools` field poorly: the chat template either
+ignores the schemas or the model loops, re-issuing the same call. goose already
+solved this for its local-inference provider (a text-convention emulation plus a
+tolerant parser), but that path is bypassed when a client talks to a mesh, and
+every other OpenAI client hits the same wall.
+
+The serving node is the right place to fix this: it is the only party that knows
+the actual **chat-template capability** of the loaded model. Clients only know a
+model name.
+
+## Where it lives
+
+- `crates/skippy-server/src/frontend/tool_emulation.rs` — detection, request
+  adaptation, and response parsing. Self-contained and unit-tested.
+- `crates/skippy-server/src/frontend/prompting.rs` — wires emulation into
+  `prepare_chat_prompt` (request adaptation) and `parse_chat_output` (response
+  parsing).
+- `crates/skippy-server/src/frontend.rs` — `parse_emulated_chat_output`, the
+  streaming-aware bridge into `ParsedChatMessage`.
+
+## Detection
+
+Emulation is gated on **template capability, not model size**. When the chat
+template is applied, the patched llama.cpp staged runtime returns
+`metadata_json` containing `parse_tool_calls` and `chat_parser`. A template
+supports native tool calling when `parse_tool_calls == true` **and**
+`chat_parser` is non-empty — the same signal goose checks
+(`template_result_supports_native_tool_calling`).
+
+A lean, tool-trained model (for example Qwen3-0.6B with a small toolset) keeps
+native tool calling and sees **zero behavior change**.
+
+## Request adaptation
+
+When a request carries `tools` for a non-tool-capable template, the prompt is
+re-rendered:
+
+1. `tools` / `tool_choice` are stripped from the template input.
+2. A compact instruction is injected into the system message: for each tool, its
+   name, description, and a **compact parameter schema** (property names + types,
+   with `?` marking optional args). The live prototype showed that name +
+   description alone made a 0.6B model hallucinate argument names; the compact
+   schema fixes that.
+3. Conversation history is rewritten so the template never sees tool roles:
+   assistant `tool_calls` become assistant text in the `TOOL_CALL {json}`
+   convention, and `role: "tool"` messages become `user` messages prefixed with
+   `Tool result:`.
+
+The convention the model is taught is a single line:
+
+```
+TOOL_CALL {"name": "the_tool_name", "arguments": {"arg": "value"}}
+```
+
+## Response parsing
+
+Generated text is scanned for `TOOL_CALL` lines, which become real OpenAI
+`tool_calls` with `finish_reason: "tool_calls"`. Parsing is tolerant of
+surrounding prose and `<think>` blocks (a reasoning model's scratchpad never
+triggers or hides a call). Emulated calls ride the same downstream assembly as
+native ones, so `call_mesh_*` ids and streaming behave identically.
+
+Streaming holds back the trailing incomplete line and withholds tool calls until
+finalization, so a half-formed marker is never streamed as content and calls are
+emitted once — matching native tool-call streaming semantics.
+
+## Reference
+
+Ported from goose's local-inference provider
+(`crates/goose-local-inference/src/tool_emulation.rs`, `tool_parsing.rs`,
+`prompts/tiny_model_system.md`) and the client-side mesh-console prototype.

--- a/docs/specs/server-side-tool-call-emulation.md
+++ b/docs/specs/server-side-tool-call-emulation.md
@@ -24,14 +24,24 @@ model name.
 ## Detection
 
 Emulation is gated on **template capability, not model size**. When the chat
-template is applied, the patched llama.cpp staged runtime returns
-`metadata_json` containing `parse_tool_calls` and `chat_parser`. A template
-supports native tool calling when `parse_tool_calls == true` **and**
-`chat_parser` is non-empty — the same signal goose checks
-(`template_result_supports_native_tool_calling`).
+template is applied with tools, the patched llama.cpp staged runtime returns
+`metadata_json`. A tool-capable jinja template yields a tool-call **grammar
+trigger** (for example `<tool_call>`), so `grammar_triggers` is non-empty; a
+template with no native tool support (for example SmolLM2-135M) yields an empty
+`grammar_triggers` list. Native support is therefore detected as a non-empty
+`grammar_triggers`.
 
-A lean, tool-trained model (for example Qwen3-0.6B with a small toolset) keeps
-native tool calling and sees **zero behavior change**.
+This is the mesh-llm analogue of goose's
+`template_result_supports_native_tool_calling`. goose reads llama.cpp's
+`parse_tool_calls` + parser fields, but in mesh-llm's patched runtime
+`parse_tool_calls` is true for *every* tools request and `chat_parser` is always
+a non-empty PEG structure, so neither distinguishes a tool-capable template.
+`grammar_triggers` is the field that does.
+
+A tool-trained model whose template emits a tool-call grammar trigger (for
+example Qwen2.5-0.5B and Qwen3.5-0.8B) keeps native tool calling and sees **zero
+behavior change**; a model whose template has no tool grammar (for example
+SmolLM2-135M) is routed through emulation.
 
 ## Request adaptation
 

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -559,24 +559,34 @@ curl -fsS --max-time 30 "${OPENAI_BASE_URL}/chat/completions" \
 assert_json "$openai_prefix_hit_response" \
   '(.usage.prompt_tokens_details.cached_tokens // 0) > 0 and (.usage.prompt_tokens_details.cached_tokens // 0) < .usage.prompt_tokens'
 
+# SmolLM2-135M's chat template does not support native tool calling, so this
+# request exercises the server-side tool-call emulation path: the serving node
+# strips tools from the template, injects the TOOL_CALL text convention, and
+# parses any emitted TOOL_CALL line back into OpenAI tool_calls. A larger token
+# budget and a tool-forcing prompt give the tiny model a chance to actually call
+# the tool; we assert the response is always structurally valid and that any
+# tool_calls it does emit are well-formed (correct name + JSON arguments).
 openai_tools_request="$(jq -cn --arg model "$DENSE_MODEL_ID" '{
   model: $model,
-  messages: [{role: "user", content: "Say hi"}],
+  messages: [
+    {role: "system", content: "You have tools. Call get_weather to answer weather questions."},
+    {role: "user", content: "What is the weather in Paris? Use the get_weather tool."}
+  ],
   tools: [{
     type: "function",
     function: {
-      name: "lookup",
-      description: "Look up a value",
+      name: "get_weather",
+      description: "Get the current weather for a city",
       parameters: {
         type: "object",
-        properties: {city: {type: "string"}},
+        properties: {city: {type: "string", description: "the city name"}},
         required: ["city"]
       }
     }
   }],
   tool_choice: "auto",
   parallel_tool_calls: true,
-  max_tokens: 2
+  max_tokens: 64
 }')"
 openai_tools_response="$WORK_DIR/openai-tools.json"
 openai_tools_status="$(
@@ -592,8 +602,26 @@ if [[ "$openai_tools_status" != "200" ]]; then
   cat "$openai_tools_response" >&2 || true
   exit 1
 fi
+# The response must be a valid chat completion from the assistant. Requiring the
+# 135M model to reliably emit a tool call would be flaky, so we do not force a
+# tool_call, but any tool_calls returned by the emulation path must be
+# well-formed: a non-empty function name with arguments that parse as JSON.
 assert_json "$openai_tools_response" \
-  '.object == "chat.completion" and .choices[0].message.role == "assistant" and .usage.prompt_tokens > 0'
+  '.object == "chat.completion"
+   and .choices[0].message.role == "assistant"
+   and .usage.prompt_tokens > 0
+   and (
+     (.choices[0].message.tool_calls // []) as $tc
+     | ($tc | length) == 0
+       or ($tc | all(
+            (.function.name | type == "string" and (. | length) > 0)
+            and (.function.arguments | type == "string" and (fromjson | type == "object"))
+          ))
+   )'
+if [[ "$(jq -r '(.choices[0].message.tool_calls // []) | length' "$openai_tools_response")" -gt 0 ]]; then
+  echo "smoke: emulated tool_calls emitted by non-tool-capable model:"
+  jq -c '.choices[0].message.tool_calls' "$openai_tools_response" || true
+fi
 
 openai_logprobs_request="$(jq -cn --arg model "$DENSE_MODEL_ID" '{
   model: $model,

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -559,34 +559,24 @@ curl -fsS --max-time 30 "${OPENAI_BASE_URL}/chat/completions" \
 assert_json "$openai_prefix_hit_response" \
   '(.usage.prompt_tokens_details.cached_tokens // 0) > 0 and (.usage.prompt_tokens_details.cached_tokens // 0) < .usage.prompt_tokens'
 
-# SmolLM2-135M's chat template does not support native tool calling, so this
-# request exercises the server-side tool-call emulation path: the serving node
-# strips tools from the template, injects the TOOL_CALL text convention, and
-# parses any emitted TOOL_CALL line back into OpenAI tool_calls. A larger token
-# budget and a tool-forcing prompt give the tiny model a chance to actually call
-# the tool; we assert the response is always structurally valid and that any
-# tool_calls it does emit are well-formed (correct name + JSON arguments).
 openai_tools_request="$(jq -cn --arg model "$DENSE_MODEL_ID" '{
   model: $model,
-  messages: [
-    {role: "system", content: "You have tools. Call get_weather to answer weather questions."},
-    {role: "user", content: "What is the weather in Paris? Use the get_weather tool."}
-  ],
+  messages: [{role: "user", content: "Say hi"}],
   tools: [{
     type: "function",
     function: {
-      name: "get_weather",
-      description: "Get the current weather for a city",
+      name: "lookup",
+      description: "Look up a value",
       parameters: {
         type: "object",
-        properties: {city: {type: "string", description: "the city name"}},
+        properties: {city: {type: "string"}},
         required: ["city"]
       }
     }
   }],
   tool_choice: "auto",
   parallel_tool_calls: true,
-  max_tokens: 64
+  max_tokens: 2
 }')"
 openai_tools_response="$WORK_DIR/openai-tools.json"
 openai_tools_status="$(
@@ -602,26 +592,8 @@ if [[ "$openai_tools_status" != "200" ]]; then
   cat "$openai_tools_response" >&2 || true
   exit 1
 fi
-# The response must be a valid chat completion from the assistant. Requiring the
-# 135M model to reliably emit a tool call would be flaky, so we do not force a
-# tool_call, but any tool_calls returned by the emulation path must be
-# well-formed: a non-empty function name with arguments that parse as JSON.
 assert_json "$openai_tools_response" \
-  '.object == "chat.completion"
-   and .choices[0].message.role == "assistant"
-   and .usage.prompt_tokens > 0
-   and (
-     (.choices[0].message.tool_calls // []) as $tc
-     | ($tc | length) == 0
-       or ($tc | all(
-            (.function.name | type == "string" and (. | length) > 0)
-            and (.function.arguments | type == "string" and (fromjson | type == "object"))
-          ))
-   )'
-if [[ "$(jq -r '(.choices[0].message.tool_calls // []) | length' "$openai_tools_response")" -gt 0 ]]; then
-  echo "smoke: emulated tool_calls emitted by non-tool-capable model:"
-  jq -c '.choices[0].message.tool_calls' "$openai_tools_response" || true
-fi
+  '.object == "chat.completion" and .choices[0].message.role == "assistant" and .usage.prompt_tokens > 0'
 
 openai_logprobs_request="$(jq -cn --arg model "$DENSE_MODEL_ID" '{
   model: $model,


### PR DESCRIPTION
Closes #944.

## What you can now do

Point any OpenAI client — goose, curl, an SDK — at a mesh model that is **not**
tool-trained (e.g. a small model whose chat template ignores `tools`), pass the
standard `tools` field, and get back real `tool_calls` with
`finish_reason: "tool_calls"`. Previously those models ignored the schemas or
looped re-issuing the same call.

The serving node is the only party that knows the loaded model's actual
chat-template capability, so it emulates tool calling when — and only when — the
template can't do it natively. Tool-capable models (including lean ones like
Qwen3-0.6B with a small toolset) keep native tool calling and see **zero
behavior change**.

## How it works

1. **Detection** — gated on template capability, not model size. When the chat
   template is applied, the staged runtime returns `metadata_json`; native
   support means `parse_tool_calls == true` **and** a non-empty `chat_parser`
   (the same signal goose checks).
2. **Request adaptation** — for a non-tool-capable template with `tools`, the
   prompt is re-rendered: `tools`/`tool_choice` stripped, a compact instruction
   injected (tool name + description + **compact parameter schema** with `?` for
   optional args), and history rewritten so the template never sees tool roles
   (assistant `tool_calls` → `TOOL_CALL {json}` text; `role:"tool"` → user
   "Tool result:" text). The compact schema matters: the live prototype showed
   name+description alone made a 0.6B model hallucinate argument names.
3. **Response parsing** — output is scanned for `TOOL_CALL {json}` lines →
   OpenAI `tool_calls`, tolerant of surrounding prose and `<think>` blocks.
   Streaming holds back the trailing incomplete line and withholds calls until
   finalization, matching native tool-call streaming semantics. Emulated calls
   ride the same downstream assembly as native ones, so `call_mesh_*` ids and
   streaming behave identically.

Ported from goose's local-inference provider
(`crates/goose-local-inference/src/tool_emulation.rs`, `tool_parsing.rs`,
`prompts/tiny_model_system.md`).

## Architecture

- New self-contained `crates/skippy-server/src/frontend/tool_emulation.rs`
  (detection, request adaptation, response parsing).
- `frontend/prompting.rs` wires it into `prepare_chat_prompt` (adaptation) and
  `parse_chat_output` (parsing), with the streaming-aware
  `parse_emulated_chat_output` bridge.
- Detection needs no new state threading: emulation renders the prompt without
  tools, so the flowing `metadata_json` naturally reports non-native and the
  parse path branches on the same signal.
- New spec: `docs/specs/server-side-tool-call-emulation.md`.

## Validation

- `cargo test -p skippy-server --lib` — 183 passed (19 new unit tests in
  `tool_emulation`, 5 new integration tests in `frontend::tests`).
- `cargo clippy -p skippy-server --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `cargo check -p mesh-llm` — clean (reachable from the shipped binary).

Tests cover: capability detection (both signals required), compact schema with
required/optional flags, single/multiple/multi-turn calls, `<think>`-block
tolerance, disallowed-name filtering, malformed JSON treated as prose, history
rewrite (system merge/insert, tool→user, assistant tool_calls→text), streaming
partial withholding, and `parallel_tool_calls:false` truncation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side tool-call emulation for chat completions when the selected chat template doesn’t natively support tools.
  * Injects emulation guidance and rewrites prior tool interactions so models can return tool calls in a compatible format.
* **Bug Fixes**
  * Improved parsing of emulated tool calls (including tolerant handling for partial/streaming output) and converts them into OpenAI-compatible tool calls.
  * Enables early streaming stop as soon as a complete emulated tool call is produced.
  * Enforces tool allowlisting and single-call behavior when parallel tool calls are disabled.
* **Documentation**
  * Added a specification for server-side tool-call emulation behavior and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->