### PR TITLE
Pass reasoning format through Skippy chat templates

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/components/thinking-segments.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/components/thinking-segments.test.ts
@@ -24,6 +24,15 @@ describe('splitAssistantThinking', () => {
 
   it('splits Gemma channel thinking from final response text', () => {
     expect(
+      splitAssistantThinking('<|channel>thought\nCheck whether the prompt is a test.<channel|>Test received!')
+    ).toEqual([
+      { kind: 'thinking', text: '\nCheck whether the prompt is a test.', open: false },
+      { kind: 'response', text: 'Test received!' }
+    ])
+  })
+
+  it('splits legacy Gemma channel thinking from final response text', () => {
+    expect(
       splitAssistantThinking('<|channel|>thoughtCheck whether the prompt is a test.<channel|>Test received!')
     ).toEqual([
       { kind: 'thinking', text: 'Check whether the prompt is a test.', open: false },

--- a/crates/mesh-llm-ui/src/features/chat/components/thinking-segments.ts
+++ b/crates/mesh-llm-ui/src/features/chat/components/thinking-segments.ts
@@ -20,8 +20,8 @@ type TagMatch = {
 
 const THINK_OPEN_TAG = '<think>'
 const THINK_CLOSE_TAG = '</think>'
-const GEMMA_THOUGHT_CHANNEL_TAGS = ['<|channel|>thought', '<channel|>thought']
-const GEMMA_CHANNEL_BOUNDARY_TAGS = ['<|channel|>', '<channel|>']
+const GEMMA_THOUGHT_CHANNEL_TAGS = ['<|channel>thought', '<|channel|>thought', '<channel|>thought']
+const GEMMA_CHANNEL_BOUNDARY_TAGS = ['<|channel>', '<|channel|>', '<channel|>']
 
 function indexOfTag(value: string, tag: string, fromIndex: number) {
   for (let index = fromIndex; index <= value.length - tag.length; index += 1) {

--- a/crates/skippy-bench/src/token_lengths.rs
+++ b/crates/skippy-bench/src/token_lengths.rs
@@ -102,6 +102,7 @@ pub fn token_lengths(args: TokenLengthsArgs) -> Result<()> {
                 ChatTemplateOptions {
                     add_assistant: true,
                     enable_thinking: Some(args.enable_thinking),
+                    reasoning_format: None,
                 },
             )
             .with_context(|| {

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -1,6 +1,6 @@
 pub const ABI_VERSION_MAJOR: u32 = 0;
 pub const ABI_VERSION_MINOR: u32 = 1;
-pub const ABI_VERSION_PATCH: u32 = 27;
+pub const ABI_VERSION_PATCH: u32 = 28;
 pub const FEATURE_BACKEND_DEVICES: u64 = 1 << 23;
 pub const FEATURE_RUNTIME_EVENTS: u64 = 1 << 24;
 pub const FEATURE_NATIVE_MTP_N1: u64 = 1 << 25;
@@ -842,6 +842,7 @@ mod dynamic {
         override_enable_thinking: bool,
         enable_thinking: bool,
         parallel_tool_calls: bool,
+        reasoning_format: *const c_char,
         output_text: *mut c_char,
         output_text_capacity: usize,
         out_text_bytes: *mut usize,
@@ -966,6 +967,7 @@ mod dynamic {
         override_enable_thinking: bool,
         enable_thinking: bool,
         parallel_tool_calls: bool,
+        reasoning_format: *const c_char,
         output_text: *mut c_char,
         output_text_capacity: usize,
         out_text_bytes: *mut usize,
@@ -987,6 +989,7 @@ mod dynamic {
                 override_enable_thinking,
                 enable_thinking,
                 parallel_tool_calls,
+                reasoning_format,
                 output_text,
                 output_text_capacity,
                 out_text_bytes,
@@ -1491,6 +1494,7 @@ unsafe extern "C" {
         override_enable_thinking: bool,
         enable_thinking: bool,
         parallel_tool_calls: bool,
+        reasoning_format: *const c_char,
         output_text: *mut c_char,
         output_text_capacity: usize,
         out_text_bytes: *mut usize,

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -5,6 +5,24 @@ pub const FEATURE_BACKEND_DEVICES: u64 = 1 << 23;
 pub const FEATURE_RUNTIME_EVENTS: u64 = 1 << 24;
 pub const FEATURE_NATIVE_MTP_N1: u64 = 1 << 25;
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AbiVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+/// Whether a native runtime reporting `version` can back this binary's ABI
+/// bindings. Required symbol signatures may change between patches (for
+/// example `skippy_apply_chat_template_json` gained an argument in 0.1.28),
+/// so older runtimes must be rejected at load time.
+pub const fn runtime_abi_supported(version: AbiVersion) -> bool {
+    version.major == ABI_VERSION_MAJOR
+        && version.minor == ABI_VERSION_MINOR
+        && version.patch >= ABI_VERSION_PATCH
+}
+
 use std::ffi::{c_char, c_int, c_void};
 
 pub type LlamaLogCallback =
@@ -652,6 +670,37 @@ mod dynamic {
             .expect("MeshLLM native runtime library has not been loaded")
     }
 
+    type SkippyAbiVersionFn = unsafe extern "C" fn() -> AbiVersion;
+
+    fn check_runtime_abi(libraries: &[Library]) -> Result<(), NativeRuntimeLoadError> {
+        let mut abi_version = None;
+        for library in libraries.iter().rev() {
+            if let Ok(symbol) =
+                unsafe { library.get::<SkippyAbiVersionFn>(b"skippy_abi_version\0") }
+            {
+                abi_version = Some(unsafe { symbol() });
+                break;
+            }
+        }
+        let Some(version) = abi_version else {
+            return Err(NativeRuntimeLoadError::Load(
+                "native runtime symbol not found: skippy_abi_version".to_string(),
+            ));
+        };
+        if !runtime_abi_supported(version) {
+            return Err(NativeRuntimeLoadError::Load(format!(
+                "native runtime ABI {}.{}.{} is not compatible with required ABI {}.{}.{}",
+                version.major,
+                version.minor,
+                version.patch,
+                ABI_VERSION_MAJOR,
+                ABI_VERSION_MINOR,
+                ABI_VERSION_PATCH,
+            )));
+        }
+        Ok(())
+    }
+
     macro_rules! dynamic_symbols {
         ($($name:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret:ty)?;)+) => {
             #[allow(non_snake_case)]
@@ -677,6 +726,7 @@ mod dynamic {
                                 .map_err(|err| NativeRuntimeLoadError::Load(err.to_string()))?,
                         );
                     }
+                    check_runtime_abi(&libraries)?;
                     $(
                         let mut $name = None;
                         for library in libraries.iter().rev() {
@@ -1648,3 +1698,53 @@ unsafe extern "C" {
 }
 
 pub type Opaque = c_void;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const fn version(major: u32, minor: u32, patch: u32) -> AbiVersion {
+        AbiVersion {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    #[test]
+    fn accepts_current_and_newer_patch_runtimes() {
+        assert!(runtime_abi_supported(version(
+            ABI_VERSION_MAJOR,
+            ABI_VERSION_MINOR,
+            ABI_VERSION_PATCH,
+        )));
+        assert!(runtime_abi_supported(version(
+            ABI_VERSION_MAJOR,
+            ABI_VERSION_MINOR,
+            ABI_VERSION_PATCH + 1,
+        )));
+    }
+
+    #[test]
+    fn rejects_older_patch_runtimes() {
+        assert!(!runtime_abi_supported(version(
+            ABI_VERSION_MAJOR,
+            ABI_VERSION_MINOR,
+            ABI_VERSION_PATCH - 1,
+        )));
+    }
+
+    #[test]
+    fn rejects_major_and_minor_mismatches() {
+        assert!(!runtime_abi_supported(version(
+            ABI_VERSION_MAJOR + 1,
+            ABI_VERSION_MINOR,
+            ABI_VERSION_PATCH,
+        )));
+        assert!(!runtime_abi_supported(version(
+            ABI_VERSION_MAJOR,
+            ABI_VERSION_MINOR + 1,
+            ABI_VERSION_PATCH,
+        )));
+    }
+}

--- a/crates/skippy-prompt/src/prompt_cli/prompt_format.rs
+++ b/crates/skippy-prompt/src/prompt_cli/prompt_format.rs
@@ -44,6 +44,7 @@ fn format_messages_for_model_with_options(
             ChatTemplateOptions {
                 add_assistant,
                 enable_thinking,
+                reasoning_format: None,
             },
         )
         .with_context(|| {

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -4170,14 +4170,14 @@ mod tests {
     use serde_json::Value;
 
     use super::{
-        ChatTemplateMessage, FlashAttentionType, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
-        LLAMA_SERVER_DEFAULT_N_BATCH, LLAMA_SERVER_DEFAULT_N_UBATCH, ModelInfo,
-        NativeLogAggregator, NativeLogEvent, RuntimeConfig, RuntimeLoadMode,
-        SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH, SamplingConfig, StageModel, Status, TensorRole,
-        flush_native_log_writer, format_skippy_error, parse_cache_type, parse_layer_assign_index,
-        redirect_native_logs_to_file, register_filtered_native_logs, restore_native_logs,
-        set_filtered_native_logs_enabled, unregister_filtered_native_logs, write_native_log,
-        write_native_log_note,
+        ChatReasoningFormat, ChatTemplateJsonOptions, ChatTemplateMessage, FlashAttentionType,
+        GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0, LLAMA_SERVER_DEFAULT_N_BATCH,
+        LLAMA_SERVER_DEFAULT_N_UBATCH, ModelInfo, NativeLogAggregator, NativeLogEvent,
+        RuntimeConfig, RuntimeLoadMode, SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH, SamplingConfig,
+        StageModel, Status, TensorRole, flush_native_log_writer, format_skippy_error,
+        parse_cache_type, parse_layer_assign_index, redirect_native_logs_to_file,
+        register_filtered_native_logs, restore_native_logs, set_filtered_native_logs_enabled,
+        unregister_filtered_native_logs, write_native_log, write_native_log_note,
     };
     use std::{
         env,
@@ -4524,6 +4524,62 @@ mod tests {
         )?;
         assert!(prompt.contains("Template smoke prompt."));
         assert!(prompt.len() >= "Template smoke prompt.".len());
+        Ok(())
+    }
+
+    // Requires SKIPPY_CORRECTNESS_MODEL to point at a reasoning-capable model
+    // family whose chat parser extracts <think> blocks (e.g. Qwen3).
+    #[test]
+    fn chat_reasoning_markers_are_stripped_and_extracted_when_model_is_configured()
+    -> anyhow::Result<()> {
+        let Some(model_path) = correctness_model() else {
+            eprintln!("skipping chat reasoning smoke: SKIPPY_CORRECTNESS_MODEL is not set");
+            return Ok(());
+        };
+        let model = open_correctness_model(&model_path)?;
+        let rendered = model.apply_chat_template_json(
+            r#"[{"role":"user","content":"Say hi."}]"#,
+            ChatTemplateJsonOptions {
+                reasoning_format: Some(ChatReasoningFormat::Hidden),
+                ..ChatTemplateJsonOptions::default()
+            },
+        )?;
+        let metadata: Value = serde_json::from_str(&rendered.metadata_json)?;
+        assert_eq!(
+            metadata.get("reasoning_format").and_then(Value::as_str),
+            Some("auto"),
+        );
+
+        // The generation prompt may already open the thought block, in which
+        // case the model output continues inside it without the opening tag.
+        let generation_prompt = metadata
+            .get("generation_prompt")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let generated = if generation_prompt.contains("<think>") {
+            "Consider the greeting.</think>Hi there!"
+        } else {
+            "<think>Consider the greeting.</think>Hi there!"
+        };
+        let parsed = model.parse_chat_response_json(generated, &rendered.metadata_json, false)?;
+        let message: Value = serde_json::from_str(&parsed)?;
+        let content = message
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(
+            !content.contains("<think>") && !content.contains("</think>"),
+            "reasoning markers must be stripped from content: {content:?}"
+        );
+        assert!(
+            content.contains("Hi there!"),
+            "visible content must survive reasoning extraction: {content:?}"
+        );
+        assert_eq!(
+            message.get("reasoning_content").and_then(Value::as_str),
+            Some("Consider the greeting."),
+            "reasoning content must be extracted from the thought block"
+        );
         Ok(())
     }
 

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -1378,9 +1378,38 @@ impl ChatTemplateMessage {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatReasoningFormat {
+    Auto,
+    None,
+    Deepseek,
+    DeepseekLegacy,
+    Hidden,
+}
+
+impl ChatReasoningFormat {
+    pub const fn parser_name(self) -> &'static str {
+        match self {
+            Self::Auto | Self::Hidden => "auto",
+            Self::None => "none",
+            Self::Deepseek => "deepseek",
+            Self::DeepseekLegacy => "deepseek-legacy",
+        }
+    }
+
+    pub const fn parses_reasoning(self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    pub const fn exposes_reasoning(self) -> bool {
+        !matches!(self, Self::None | Self::Hidden)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChatTemplateOptions {
     pub add_assistant: bool,
     pub enable_thinking: Option<bool>,
+    pub reasoning_format: Option<ChatReasoningFormat>,
 }
 
 impl Default for ChatTemplateOptions {
@@ -1388,6 +1417,7 @@ impl Default for ChatTemplateOptions {
         Self {
             add_assistant: true,
             enable_thinking: None,
+            reasoning_format: None,
         }
     }
 }
@@ -1396,6 +1426,7 @@ impl Default for ChatTemplateOptions {
 pub struct ChatTemplateJsonOptions {
     pub add_assistant: bool,
     pub enable_thinking: Option<bool>,
+    pub reasoning_format: Option<ChatReasoningFormat>,
     pub tools_json: Option<String>,
     pub tool_choice_json: Option<String>,
     pub parallel_tool_calls: bool,
@@ -1406,6 +1437,7 @@ impl Default for ChatTemplateJsonOptions {
         Self {
             add_assistant: true,
             enable_thinking: None,
+            reasoning_format: None,
             tools_json: None,
             tool_choice_json: None,
             parallel_tool_calls: true,
@@ -2333,6 +2365,7 @@ impl StageModel {
             ChatTemplateOptions {
                 add_assistant,
                 enable_thinking: None,
+                reasoning_format: None,
             },
         )
     }
@@ -2435,6 +2468,16 @@ impl StageModel {
             .as_ref()
             .map(|value| value.as_ptr())
             .unwrap_or(ptr::null());
+        let reasoning_format = options
+            .reasoning_format
+            .map(ChatReasoningFormat::parser_name)
+            .map(CString::new)
+            .transpose()
+            .context("reasoning format contains an interior NUL byte")?;
+        let reasoning_format_ptr = reasoning_format
+            .as_ref()
+            .map(|value| value.as_ptr())
+            .unwrap_or(ptr::null());
 
         let mut prompt_bytes = 0usize;
         let mut metadata_bytes = 0usize;
@@ -2449,6 +2492,7 @@ impl StageModel {
                 options.enable_thinking.is_some(),
                 options.enable_thinking.unwrap_or(true),
                 options.parallel_tool_calls,
+                reasoning_format_ptr,
                 ptr::null_mut(),
                 0,
                 &mut prompt_bytes,
@@ -2477,6 +2521,7 @@ impl StageModel {
                 options.enable_thinking.is_some(),
                 options.enable_thinking.unwrap_or(true),
                 options.parallel_tool_calls,
+                reasoning_format_ptr,
                 prompt.as_mut_ptr().cast(),
                 prompt.len(),
                 &mut prompt_bytes,

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -43,7 +43,7 @@ use skippy_protocol::binary::{
 };
 use skippy_protocol::{MessageBase, SCHEMA_VERSION, StageConfig, StageTopology};
 use skippy_runtime::{
-    ActivationFrame, ChatTemplateJsonOptions, ChatTemplateOptions,
+    ActivationFrame, ChatReasoningFormat, ChatTemplateJsonOptions, ChatTemplateOptions,
     FlashAttentionType as RuntimeFlashAttentionType, GenerationSignalWindow,
     LogitBias as RuntimeLogitBias, MAX_LOGIT_BIAS, MediaInput, ModelInfo, RuntimeConfig,
     RuntimeLoadMode, SamplingConfig, StageModel, StageSession, TokenSignal,
@@ -1524,9 +1524,29 @@ fn tool_calls_requested(request: &ChatCompletionRequest) -> bool {
 
 fn chat_output_parser_required(
     request: &ChatCompletionRequest,
-    _template_options: &ChatTemplateOptions,
+    template_options: &ChatTemplateOptions,
 ) -> bool {
     tool_calls_requested(request)
+        || template_options
+            .reasoning_format
+            .is_some_and(ChatReasoningFormat::parses_reasoning)
+}
+
+fn template_exposes_reasoning(template_options: &ChatTemplateOptions) -> bool {
+    template_options
+        .reasoning_format
+        .is_some_and(ChatReasoningFormat::exposes_reasoning)
+}
+
+fn apply_reasoning_visibility(
+    parsed: Option<ParsedChatMessage>,
+    template_options: &ChatTemplateOptions,
+) -> Option<ParsedChatMessage> {
+    let mut parsed = parsed?;
+    if !template_exposes_reasoning(template_options) {
+        parsed.reasoning_content = None;
+    }
+    Some(parsed)
 }
 
 fn chat_response_from_generated_text(
@@ -1839,6 +1859,7 @@ struct ChatOutputStreamParser {
     backend: StageOpenAiBackend,
     request: ChatCompletionRequest,
     metadata: String,
+    emit_reasoning: bool,
     text: String,
     emitted_content: String,
     emitted_reasoning_content: String,
@@ -1846,11 +1867,17 @@ struct ChatOutputStreamParser {
 }
 
 impl ChatOutputStreamParser {
-    fn new(backend: StageOpenAiBackend, request: ChatCompletionRequest, metadata: String) -> Self {
+    fn new(
+        backend: StageOpenAiBackend,
+        request: ChatCompletionRequest,
+        metadata: String,
+        emit_reasoning: bool,
+    ) -> Self {
         Self {
             backend,
             request,
             metadata,
+            emit_reasoning,
             text: String::new(),
             emitted_content: String::new(),
             emitted_reasoning_content: String::new(),
@@ -1881,10 +1908,12 @@ impl ChatOutputStreamParser {
             return Ok(Vec::new());
         };
         let mut events = Vec::new();
-        if let Some(delta) = suffix_delta(
-            parsed.reasoning_content.as_deref(),
-            &mut self.emitted_reasoning_content,
-        ) {
+        if self.emit_reasoning
+            && let Some(delta) = suffix_delta(
+                parsed.reasoning_content.as_deref(),
+                &mut self.emitted_reasoning_content,
+            )
+        {
             events.push(GenerationStreamEvent::ReasoningDelta(delta));
         }
         if let Some(delta) = suffix_delta(parsed.content.as_deref(), &mut self.emitted_content) {

--- a/crates/skippy-server/src/frontend/backend.rs
+++ b/crates/skippy-server/src/frontend/backend.rs
@@ -17,7 +17,7 @@ impl OpenAiBackend for StageOpenAiBackend {
         apply_chat_request_defaults(&mut request, &self.request_defaults);
         ensure_chat_runtime_features_supported(&request)?;
         let sampling = chat_sampling_config(&request)?;
-        let template_options = chat_template_options(&request)?;
+        let template_options = chat_template_options(&request, &self.request_defaults)?;
         let parse_chat_output = chat_output_parser_required(&request, &template_options);
         let template_timer = PhaseTimer::start();
         let prompt = self.prepare_chat_prompt(&request, template_options)?;
@@ -65,6 +65,7 @@ impl OpenAiBackend for StageOpenAiBackend {
         } else {
             None
         };
+        let parsed_message = apply_reasoning_visibility(parsed_message, &template_options);
         let response =
             chat_response_from_generated_text(request.model.clone(), &output, parsed_message);
         let mut response_attrs = self.openai_attrs(&ids);
@@ -115,8 +116,9 @@ impl OpenAiBackend for StageOpenAiBackend {
         ensure_chat_runtime_features_supported(&request)?;
         let sampling = chat_sampling_config(&request)?;
         let include_usage = request.include_usage();
-        let template_options = chat_template_options(&request)?;
+        let template_options = chat_template_options(&request, &self.request_defaults)?;
         let parse_chat_output = chat_output_parser_required(&request, &template_options);
+        let emit_reasoning = template_exposes_reasoning(&template_options);
         let template_timer = PhaseTimer::start();
         let prompt = self.prepare_chat_prompt(&request, template_options)?;
         let mut template_attrs = self.openai_attrs(&ids);
@@ -151,6 +153,7 @@ impl OpenAiBackend for StageOpenAiBackend {
                 include_usage,
                 Some(request.clone()),
                 parse_chat_output,
+                emit_reasoning,
                 context,
                 ids,
             )
@@ -268,6 +271,7 @@ impl OpenAiBackend for StageOpenAiBackend {
                 sampling,
                 include_usage,
                 None,
+                false,
                 false,
                 context,
                 ids,
@@ -434,6 +438,7 @@ impl StageOpenAiBackend {
         include_usage: bool,
         hook_request: Option<ChatCompletionRequest>,
         parse_chat_output: bool,
+        emit_reasoning: bool,
         context: OpenAiRequestContext,
         ids: OpenAiGenerationIds,
     ) -> OpenAiResult<GenerationStream> {
@@ -456,6 +461,7 @@ impl StageOpenAiBackend {
                 backend.clone(),
                 request,
                 metadata,
+                emit_reasoning,
             ))
         } else {
             None

--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -108,6 +108,7 @@ impl StageOpenAiBackend {
                 ChatTemplateJsonOptions {
                     add_assistant: options.add_assistant,
                     enable_thinking: options.enable_thinking,
+                    reasoning_format: options.reasoning_format,
                     tools_json,
                     tool_choice_json,
                     parallel_tool_calls: request.parallel_tool_calls.unwrap_or(true),

--- a/crates/skippy-server/src/frontend/request.rs
+++ b/crates/skippy-server/src/frontend/request.rs
@@ -258,8 +258,22 @@ pub(super) fn completion_sampling_config(
 
 pub(super) fn chat_template_options(
     _request: &ChatCompletionRequest,
+    defaults: &EmbeddedOpenAiRequestDefaults,
 ) -> OpenAiResult<ChatTemplateOptions> {
-    Ok(ChatTemplateOptions::default())
+    Ok(ChatTemplateOptions {
+        reasoning_format: Some(chat_reasoning_format(defaults.reasoning_format)),
+        ..ChatTemplateOptions::default()
+    })
+}
+
+fn chat_reasoning_format(value: Option<EmbeddedReasoningFormat>) -> ChatReasoningFormat {
+    match value.unwrap_or(EmbeddedReasoningFormat::Hidden) {
+        EmbeddedReasoningFormat::Auto => ChatReasoningFormat::Auto,
+        EmbeddedReasoningFormat::None => ChatReasoningFormat::None,
+        EmbeddedReasoningFormat::Deepseek => ChatReasoningFormat::Deepseek,
+        EmbeddedReasoningFormat::DeepseekLegacy => ChatReasoningFormat::DeepseekLegacy,
+        EmbeddedReasoningFormat::Hidden => ChatReasoningFormat::Hidden,
+    }
 }
 
 pub(super) fn ensure_chat_runtime_features_supported(

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -981,6 +981,36 @@ fn plain_chat_does_not_require_chat_output_parser() {
 }
 
 #[test]
+fn hidden_reasoning_format_requires_chat_output_parser_for_plain_chat() {
+    let request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}]
+    }))
+    .unwrap();
+    let template_options = ChatTemplateOptions {
+        reasoning_format: Some(ChatReasoningFormat::Hidden),
+        ..ChatTemplateOptions::default()
+    };
+
+    assert!(chat_output_parser_required(&request, &template_options));
+}
+
+#[test]
+fn reasoning_format_none_leaves_plain_chat_unparsed() {
+    let request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}]
+    }))
+    .unwrap();
+    let template_options = ChatTemplateOptions {
+        reasoning_format: Some(ChatReasoningFormat::None),
+        ..ChatTemplateOptions::default()
+    };
+
+    assert!(!chat_output_parser_required(&request, &template_options));
+}
+
+#[test]
 fn tools_require_chat_output_parser() {
     assert!(chat_output_parser_required(
         &tool_request(),
@@ -1057,6 +1087,46 @@ fn chat_response_from_parsed_message_separates_reasoning_content() {
     );
     assert_eq!(message.tool_calls, None);
     assert_eq!(response.choices[0].finish_reason, Some(FinishReason::Stop));
+}
+
+#[test]
+fn hidden_reasoning_visibility_removes_reasoning_content() {
+    let parsed = ParsedChatMessage {
+        content: Some("Final answer.".to_string()),
+        reasoning_content: Some("Checked facts first.".to_string()),
+        tool_calls: None,
+    };
+    let template_options = ChatTemplateOptions {
+        reasoning_format: Some(ChatReasoningFormat::Hidden),
+        ..ChatTemplateOptions::default()
+    };
+
+    let visible = apply_reasoning_visibility(Some(parsed), &template_options)
+        .expect("parsed message should remain");
+
+    assert_eq!(visible.content.as_deref(), Some("Final answer."));
+    assert_eq!(visible.reasoning_content, None);
+}
+
+#[test]
+fn auto_reasoning_visibility_keeps_reasoning_content() {
+    let parsed = ParsedChatMessage {
+        content: Some("Final answer.".to_string()),
+        reasoning_content: Some("Checked facts first.".to_string()),
+        tool_calls: None,
+    };
+    let template_options = ChatTemplateOptions {
+        reasoning_format: Some(ChatReasoningFormat::Auto),
+        ..ChatTemplateOptions::default()
+    };
+
+    let visible = apply_reasoning_visibility(Some(parsed), &template_options)
+        .expect("parsed message should remain");
+
+    assert_eq!(
+        visible.reasoning_content.as_deref(),
+        Some("Checked facts first.")
+    );
 }
 
 #[test]
@@ -1965,9 +2035,11 @@ fn request_defaults_fill_omitted_chat_fields_only() {
     assert_eq!(sampling.repeat_penalty, 1.2);
     assert_eq!(sampling.penalty_last_n, 64);
     assert_eq!(sampling.logit_bias.len(), 2);
+    let template_options = chat_template_options(&request, &test_request_defaults()).unwrap();
+    assert_eq!(template_options.enable_thinking, None);
     assert_eq!(
-        chat_template_options(&request).unwrap().enable_thinking,
-        None
+        template_options.reasoning_format,
+        Some(ChatReasoningFormat::Hidden)
     );
     assert_eq!(request.reasoning, None);
     assert_eq!(
@@ -2055,9 +2127,11 @@ fn explicit_chat_request_values_override_request_defaults() {
     assert_eq!(sampling.repeat_penalty, 1.8);
     assert_eq!(sampling.penalty_last_n, 24);
     assert_eq!(sampling.logit_bias.len(), 1);
+    let template_options = chat_template_options(&request, &test_request_defaults()).unwrap();
+    assert_eq!(template_options.enable_thinking, None);
     assert_eq!(
-        chat_template_options(&request).unwrap().enable_thinking,
-        None
+        template_options.reasoning_format,
+        Some(ChatReasoningFormat::Hidden)
     );
     assert_eq!(
         GenerationTokenLimit::from_request(request.effective_max_tokens(), 64),
@@ -2134,8 +2208,43 @@ fn canonical_reasoning_does_not_override_chat_template_thinking() {
     }))
     .unwrap();
 
-    let options = chat_template_options(&request).unwrap();
+    let options =
+        chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, None);
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
+}
+
+#[test]
+fn chat_template_options_default_to_hidden_reasoning_parser() {
+    let request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
+        "messages": [{"role": "user", "content": "hello"}]
+    }))
+    .unwrap();
+
+    let options = chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default())
+        .expect("template options");
+
+    assert_eq!(options.enable_thinking, None);
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
+}
+
+#[test]
+fn request_default_reasoning_format_controls_chat_parser_mode() {
+    let request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
+        "messages": [{"role": "user", "content": "hello"}]
+    }))
+    .unwrap();
+    let defaults = EmbeddedOpenAiRequestDefaults {
+        reasoning_format: Some(EmbeddedReasoningFormat::None),
+        ..EmbeddedOpenAiRequestDefaults::default()
+    };
+
+    let options = chat_template_options(&request, &defaults).expect("template options");
+
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::None));
+    assert!(!chat_output_parser_required(&request, &options));
 }
 
 #[test]
@@ -2147,8 +2256,10 @@ fn reasoning_effort_does_not_override_chat_template_thinking() {
     }))
     .unwrap();
 
-    let options = chat_template_options(&request).unwrap();
+    let options =
+        chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, None);
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
 }
 
 #[test]
@@ -2160,8 +2271,10 @@ fn top_level_reasoning_effort_does_not_override_chat_template_thinking() {
     }))
     .unwrap();
 
-    let options = chat_template_options(&request).unwrap();
+    let options =
+        chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, None);
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
 }
 
 #[test]
@@ -2174,8 +2287,10 @@ fn provider_enable_thinking_does_not_override_chat_template_thinking() {
     }))
     .unwrap();
 
-    let options = chat_template_options(&request).unwrap();
+    let options =
+        chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, None);
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
 }
 
 #[test]
@@ -2187,8 +2302,10 @@ fn chat_template_kwargs_enable_thinking_does_not_override_template() {
     }))
     .unwrap();
 
-    let options = chat_template_options(&request).unwrap();
+    let options =
+        chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, None);
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
 }
 
 #[test]
@@ -2201,7 +2318,9 @@ fn thinking_boolean_aliases_do_not_override_chat_template_thinking() {
         }))
         .unwrap();
         assert_eq!(
-            chat_template_options(&request).unwrap().enable_thinking,
+            chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default())
+                .unwrap()
+                .enable_thinking,
             None,
             "top-level alias {field}"
         );
@@ -2213,7 +2332,9 @@ fn thinking_boolean_aliases_do_not_override_chat_template_thinking() {
         }))
         .unwrap();
         assert_eq!(
-            chat_template_options(&request).unwrap().enable_thinking,
+            chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default())
+                .unwrap()
+                .enable_thinking,
             None,
             "chat_template_kwargs alias {field}"
         );
@@ -2229,7 +2350,9 @@ fn reasoning_budget_does_not_override_chat_template_thinking() {
     }))
     .unwrap();
     assert_eq!(
-        chat_template_options(&request).unwrap().enable_thinking,
+        chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default())
+            .unwrap()
+            .enable_thinking,
         None
     );
 
@@ -2241,7 +2364,9 @@ fn reasoning_budget_does_not_override_chat_template_thinking() {
     }))
     .unwrap();
     assert_eq!(
-        chat_template_options(&request).unwrap().enable_thinking,
+        chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default())
+            .unwrap()
+            .enable_thinking,
         None
     );
 }

--- a/third_party/llama.cpp/patches/0011-Pass-reasoning-format-through-stage-chat-templates.patch
+++ b/third_party/llama.cpp/patches/0011-Pass-reasoning-format-through-stage-chat-templates.patch
@@ -1,0 +1,61 @@
+From 21f4cca9a98e72a916d949982e9e31cf99e2736a Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Fri, 3 Jul 2026 13:15:19 +1000
+Subject: [PATCH] Pass reasoning format through stage chat templates
+
+---
+ common/stage-chat.cpp   | 4 ++++
+ include/skippy.h        | 1 +
+ include/skippy/common.h | 2 +-
+ 3 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/common/stage-chat.cpp b/common/stage-chat.cpp
+index bde9fedab..3298ed669 100644
+--- a/common/stage-chat.cpp
++++ b/common/stage-chat.cpp
+@@ -230,6 +230,7 @@ enum skippy_status skippy_apply_chat_template_json(
+         bool override_enable_thinking,
+         bool enable_thinking,
+         bool parallel_tool_calls,
++        const char * reasoning_format_name,
+         char * output_text,
+         size_t output_text_capacity,
+         size_t * out_text_bytes,
+@@ -282,6 +283,9 @@ enum skippy_status skippy_apply_chat_template_json(
+             inputs.chat_template_kwargs["enable_think"] = value;
+             inputs.chat_template_kwargs["think_enabled"] = value;
+         }
++        if (reasoning_format_name != nullptr && reasoning_format_name[0] != '\0') {
++            inputs.reasoning_format = common_reasoning_format_from_name(reasoning_format_name);
++        }
+ 
+         common_chat_templates_ptr tmpls = common_chat_templates_init(native_model, "");
+         common_chat_params params = common_chat_templates_apply(tmpls.get(), inputs);
+diff --git a/include/skippy.h b/include/skippy.h
+index 0e94e95bd..a298bd70d 100644
+--- a/include/skippy.h
++++ b/include/skippy.h
+@@ -540,6 +540,7 @@ LLAMA_API enum skippy_status skippy_apply_chat_template_json(
+         bool override_enable_thinking,
+         bool enable_thinking,
+         bool parallel_tool_calls,
++        const char * reasoning_format,
+         char * output_text,
+         size_t output_text_capacity,
+         size_t * out_text_bytes,
+diff --git a/include/skippy/common.h b/include/skippy/common.h
+index cfb4a8fa9..0e1f03511 100644
+--- a/include/skippy/common.h
++++ b/include/skippy/common.h
+@@ -26,7 +26,7 @@ extern "C" {
+ 
+ #define SKIPPY_ABI_VERSION_MAJOR 0
+ #define SKIPPY_ABI_VERSION_MINOR 1
+-#define SKIPPY_ABI_VERSION_PATCH 27
++#define SKIPPY_ABI_VERSION_PATCH 28
+ 
+ enum skippy_feature {
+     SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
+-- 
+2.54.0
+


### PR DESCRIPTION
🤖 Opened by AI agent.

Summary:
- Pass Skippy chat-template reasoning_format into llama.cpp's established reasoning parser via the C ABI.
- Default embedded OpenAI chat templating to hidden reasoning parsing so Gemma 4 thought channels are removed from content but not exposed as reasoning_content unless configured.
- Add UI fallback coverage for real Gemma channel markers.

Validation:
- scripts/prepare-llama.sh pinned with a clean temp LLAMA_WORKDIR
- just build
- cargo fmt --all --check
- cargo test -p skippy-server --lib
- cargo test -p skippy-runtime --lib
- cargo test -p mesh-llm --lib
- cargo check -p mesh-llm
- cargo clippy -p skippy-server --all-targets -- -D warnings
- cargo clippy -p mesh-llm --all-targets -- -D warnings
- pnpm test -- src/features/chat/components/thinking-segments.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable reasoning/thinking visibility for chat templates, including support for formats that hide or expose reasoning content.
* **Bug Fixes**
  * Streaming and non-streaming parsing now consistently respects the selected reasoning visibility, preventing hidden reasoning from being emitted.
  * Improved Gemma “thought” section splitting to handle additional channel variants and newline-prefixed thought content.
  * Chat template rendering now passes through an explicit reasoning-format setting for more accurate template behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->