### PR TITLE
Gate passive inference streams behind admission when a trust policy is active

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -2536,21 +2536,33 @@ pub(crate) fn is_peer_admitted(peers: &HashMap<EndpointId, PeerInfo>, id: &Endpo
 }
 
 /// Returns `true` if the given stream type is permitted before a peer has
-/// been admitted through gossip.
+/// been admitted through gossip, under the node's trust policy.
 ///
-/// Only two streams bypass the quarantine gate:
+/// With `TrustPolicy::Off` (the default open-mesh posture), three streams
+/// bypass the quarantine gate:
 /// - `STREAM_GOSSIP (0x01)`: the admission handshake itself.
 /// - `STREAM_ROUTE_REQUEST (0x05)`: passive/client request-only path — caller
 ///   is NEVER promoted to `state.peers`.
 /// - `STREAM_TUNNEL_HTTP (0x04)`: passive SDK inference path for callers that
 ///   have an invite token but should not need a local `/v1` HTTP listener.
 ///
-/// Every other stream — including raw tunnel (0x02) — requires the remote to
-/// have completed gossip first.
-pub(crate) fn stream_allowed_before_admission(stream_type: u8) -> bool {
-    stream_type == STREAM_GOSSIP
-        || stream_type == STREAM_ROUTE_REQUEST
-        || stream_type == STREAM_TUNNEL_HTTP
+/// When a trust policy is active (`PreferOwned`/`RequireOwned`/`Allowlist`),
+/// only `STREAM_GOSSIP` bypasses the gate. Otherwise a leaked invite token is
+/// a bearer credential for inference: a caller rejected by the trust gate
+/// (e.g. `UntrustedOwner` under `Allowlist`) could still route requests via
+/// the passive paths without ever being admitted. If a node enforces who may
+/// join, the same enforcement must cover who may consume.
+///
+/// Every other stream — including raw tunnel (0x02) — always requires the
+/// remote to have completed gossip first.
+pub(crate) fn stream_allowed_before_admission(stream_type: u8, trust_policy: TrustPolicy) -> bool {
+    if stream_type == STREAM_GOSSIP {
+        return true;
+    }
+    if !matches!(trust_policy, TrustPolicy::Off) {
+        return false;
+    }
+    stream_type == STREAM_ROUTE_REQUEST || stream_type == STREAM_TUNNEL_HTTP
 }
 
 pub(crate) fn ingest_tunnel_map(
@@ -6784,7 +6796,7 @@ impl Node {
         recv: iroh::endpoint::RecvStream,
     ) -> Option<MeshBiStream> {
         let capture_streams = self.swarm_capture_enabled();
-        if stream_allowed_before_admission(stream_type) {
+        if stream_allowed_before_admission(stream_type, self.trust_policy) {
             if capture_streams {
                 self.capture_stream_observation(remote, stream_type, protocol, true);
             }

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -2538,7 +2538,7 @@ pub(crate) fn is_peer_admitted(peers: &HashMap<EndpointId, PeerInfo>, id: &Endpo
 /// Returns `true` if the given stream type is permitted before a peer has
 /// been admitted through gossip, under the node's trust policy.
 ///
-/// With `TrustPolicy::Off` (the default open-mesh posture), three streams
+/// With a non-enforcing trust policy (`Off` or `PreferOwned`), three streams
 /// bypass the quarantine gate:
 /// - `STREAM_GOSSIP (0x01)`: the admission handshake itself.
 /// - `STREAM_ROUTE_REQUEST (0x05)`: passive/client request-only path — caller
@@ -2546,12 +2546,13 @@ pub(crate) fn is_peer_admitted(peers: &HashMap<EndpointId, PeerInfo>, id: &Endpo
 /// - `STREAM_TUNNEL_HTTP (0x04)`: passive SDK inference path for callers that
 ///   have an invite token but should not need a local `/v1` HTTP listener.
 ///
-/// When a trust policy is active (`PreferOwned`/`RequireOwned`/`Allowlist`),
-/// only `STREAM_GOSSIP` bypasses the gate. Otherwise a leaked invite token is
-/// a bearer credential for inference: a caller rejected by the trust gate
-/// (e.g. `UntrustedOwner` under `Allowlist`) could still route requests via
-/// the passive paths without ever being admitted. If a node enforces who may
-/// join, the same enforcement must cover who may consume.
+/// When a trust policy enforces ownership (`RequireOwned` or `Allowlist`), only
+/// `STREAM_GOSSIP` bypasses the gate. Otherwise a leaked invite token is a
+/// bearer credential for inference: a caller rejected by the trust gate (e.g.
+/// `UntrustedOwner` under `Allowlist`) could still route requests via the
+/// passive paths without ever being admitted. If a node enforces who may join,
+/// the same enforcement must cover who may consume. `PreferOwned` remains
+/// advisory and therefore preserves the passive-client behavior of `Off`.
 ///
 /// Every other stream — including raw tunnel (0x02) — always requires the
 /// remote to have completed gossip first.
@@ -2559,7 +2560,10 @@ pub(crate) fn stream_allowed_before_admission(stream_type: u8, trust_policy: Tru
     if stream_type == STREAM_GOSSIP {
         return true;
     }
-    if !matches!(trust_policy, TrustPolicy::Off) {
+    if matches!(
+        trust_policy,
+        TrustPolicy::RequireOwned | TrustPolicy::Allowlist
+    ) {
         return false;
     }
     stream_type == STREAM_ROUTE_REQUEST || stream_type == STREAM_TUNNEL_HTTP

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -8147,16 +8147,12 @@ fn active_stage_refresh_timeout_marks_cached_stage_failed() {
 }
 
 #[test]
-fn passive_streams_are_gated_when_trust_policy_active() {
-    // With any active trust policy, only gossip bypasses the quarantine
+fn passive_streams_are_gated_when_trust_policy_enforces_ownership() {
+    // With an enforcing trust policy, only gossip bypasses the quarantine
     // gate. A leaked invite token must not be a bearer credential for
     // inference: a caller rejected by the trust gate (UntrustedOwner) must
     // not be able to route requests via the passive paths.
-    for policy in [
-        TrustPolicy::PreferOwned,
-        TrustPolicy::RequireOwned,
-        TrustPolicy::Allowlist,
-    ] {
+    for policy in [TrustPolicy::RequireOwned, TrustPolicy::Allowlist] {
         assert!(
             stream_allowed_before_admission(STREAM_GOSSIP, policy),
             "gossip must always be allowed ({policy:?}) — it is the admission path"
@@ -8175,13 +8171,13 @@ fn passive_streams_are_gated_when_trust_policy_active() {
         );
     }
 
-    // TrustPolicy::Off keeps the open-mesh posture: passive paths stay open.
-    assert!(stream_allowed_before_admission(
-        STREAM_TUNNEL_HTTP,
-        TrustPolicy::Off
-    ));
-    assert!(stream_allowed_before_admission(
-        STREAM_ROUTE_REQUEST,
-        TrustPolicy::Off
-    ));
+    // Non-enforcing policies keep passive paths open. PreferOwned is advisory:
+    // it warns about unattributed peers but does not reject them.
+    for policy in [TrustPolicy::Off, TrustPolicy::PreferOwned] {
+        assert!(stream_allowed_before_admission(STREAM_TUNNEL_HTTP, policy));
+        assert!(stream_allowed_before_admission(
+            STREAM_ROUTE_REQUEST,
+            policy
+        ));
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -3416,16 +3416,16 @@ fn incoming_peer_promoted_after_valid_gossip() {
     );
 
     assert!(
-        !stream_allowed_before_admission(STREAM_TUNNEL),
+        !stream_allowed_before_admission(STREAM_TUNNEL, TrustPolicy::Off),
         "raw tunnel streams must be gated until after admission"
     );
     assert!(
-        stream_allowed_before_admission(STREAM_TUNNEL_HTTP),
+        stream_allowed_before_admission(STREAM_TUNNEL_HTTP, TrustPolicy::Off),
         "HTTP tunnel streams must be allowed for passive SDK clients"
     );
 
     assert!(
-        stream_allowed_before_admission(STREAM_GOSSIP),
+        stream_allowed_before_admission(STREAM_GOSSIP, TrustPolicy::Off),
         "STREAM_GOSSIP must always be allowed — it is the admission path"
     );
 
@@ -3479,22 +3479,22 @@ fn incoming_peer_rejected_on_legacy_or_malformed_gossip() {
         STREAM_PLUGIN_MESH_STREAM,
     ] {
         assert!(
-            !stream_allowed_before_admission(stream_type),
+            !stream_allowed_before_admission(stream_type, TrustPolicy::Off),
             "stream {:#04x} must be quarantine-gated for unadmitted peers — if this fails, the gate is broken",
             stream_type
         );
     }
 
     assert!(
-        stream_allowed_before_admission(STREAM_GOSSIP),
+        stream_allowed_before_admission(STREAM_GOSSIP, TrustPolicy::Off),
         "STREAM_GOSSIP must bypass the gate (it is the admission handshake)"
     );
     assert!(
-        stream_allowed_before_admission(STREAM_ROUTE_REQUEST),
+        stream_allowed_before_admission(STREAM_ROUTE_REQUEST, TrustPolicy::Off),
         "STREAM_ROUTE_REQUEST must bypass the gate (passive/client request-only path)"
     );
     assert!(
-        stream_allowed_before_admission(STREAM_TUNNEL_HTTP),
+        stream_allowed_before_admission(STREAM_TUNNEL_HTTP, TrustPolicy::Off),
         "STREAM_TUNNEL_HTTP must bypass the gate (passive/client inference path)"
     );
 
@@ -3517,7 +3517,7 @@ fn passive_route_table_request_does_not_admit_peer() {
     );
 
     assert!(
-        stream_allowed_before_admission(STREAM_ROUTE_REQUEST),
+        stream_allowed_before_admission(STREAM_ROUTE_REQUEST, TrustPolicy::Off),
         "STREAM_ROUTE_REQUEST must be allowed before admission (passive/client path)"
     );
 
@@ -3531,7 +3531,7 @@ fn passive_route_table_request_does_not_admit_peer() {
         STREAM_PLUGIN_MESH_STREAM,
     ] {
         assert!(
-            !stream_allowed_before_admission(gated),
+            !stream_allowed_before_admission(gated, TrustPolicy::Off),
             "stream {:#04x} must remain gated after a route request — route request must not unlock other streams",
             gated
         );
@@ -5367,11 +5367,11 @@ fn dead_peer_ttl_expires() {
 #[test]
 fn non_scope_tunnel_streams_pass_through_without_proto_validation() {
     assert!(
-        !stream_allowed_before_admission(STREAM_TUNNEL),
+        !stream_allowed_before_admission(STREAM_TUNNEL, TrustPolicy::Off),
         "STREAM_TUNNEL (0x02) must be gated until after gossip admission"
     );
     assert!(
-        stream_allowed_before_admission(STREAM_TUNNEL_HTTP),
+        stream_allowed_before_admission(STREAM_TUNNEL_HTTP, TrustPolicy::Off),
         "STREAM_TUNNEL_HTTP (0x04) must be allowed for passive SDK inference"
     );
 
@@ -5417,7 +5417,7 @@ fn non_scope_tunnel_streams_pass_through_without_proto_validation() {
     );
 
     assert!(
-        !stream_allowed_before_admission(STREAM_TUNNEL),
+        !stream_allowed_before_admission(STREAM_TUNNEL, TrustPolicy::Off),
         "STREAM_TUNNEL must require admission (raw tunnel security boundary)"
     );
 }
@@ -5753,11 +5753,11 @@ async fn test_on_demand_transitive_peer_connection_completes_gossip() -> Result<
 #[test]
 fn legacy_config_stream_ids_are_reserved_and_require_admission() {
     assert!(
-        !stream_allowed_before_admission(STREAM_CONFIG_SUBSCRIBE),
+        !stream_allowed_before_admission(STREAM_CONFIG_SUBSCRIBE, TrustPolicy::Off),
         "reserved STREAM_CONFIG_SUBSCRIBE (0x0b) must not bypass admission"
     );
     assert!(
-        !stream_allowed_before_admission(STREAM_CONFIG_PUSH),
+        !stream_allowed_before_admission(STREAM_CONFIG_PUSH, TrustPolicy::Off),
         "reserved STREAM_CONFIG_PUSH (0x0c) must not bypass admission"
     );
 }
@@ -8144,4 +8144,44 @@ fn active_stage_refresh_timeout_marks_cached_stage_failed() {
         status.error.as_deref(),
         Some("stage status refresh timed out")
     );
+}
+
+#[test]
+fn passive_streams_are_gated_when_trust_policy_active() {
+    // With any active trust policy, only gossip bypasses the quarantine
+    // gate. A leaked invite token must not be a bearer credential for
+    // inference: a caller rejected by the trust gate (UntrustedOwner) must
+    // not be able to route requests via the passive paths.
+    for policy in [
+        TrustPolicy::PreferOwned,
+        TrustPolicy::RequireOwned,
+        TrustPolicy::Allowlist,
+    ] {
+        assert!(
+            stream_allowed_before_admission(STREAM_GOSSIP, policy),
+            "gossip must always be allowed ({policy:?}) — it is the admission path"
+        );
+        assert!(
+            !stream_allowed_before_admission(STREAM_TUNNEL_HTTP, policy),
+            "HTTP tunnel must be gated under {policy:?} — otherwise a leaked token serves inference"
+        );
+        assert!(
+            !stream_allowed_before_admission(STREAM_ROUTE_REQUEST, policy),
+            "route request must be gated under {policy:?}"
+        );
+        assert!(
+            !stream_allowed_before_admission(STREAM_TUNNEL, policy),
+            "raw tunnel must stay gated under {policy:?}"
+        );
+    }
+
+    // TrustPolicy::Off keeps the open-mesh posture: passive paths stay open.
+    assert!(stream_allowed_before_admission(
+        STREAM_TUNNEL_HTTP,
+        TrustPolicy::Off
+    ));
+    assert!(stream_allowed_before_admission(
+        STREAM_ROUTE_REQUEST,
+        TrustPolicy::Off
+    ));
 }


### PR DESCRIPTION
**Draft.**

`stream_allowed_before_admission` exempts `STREAM_TUNNEL_HTTP` (0x04) and `STREAM_ROUTE_REQUEST` (0x05) from the quarantine gate unconditionally. A caller holding a leaked invite token can therefore route inference through a node even after the trust gate rejected it at gossip (`UntrustedOwner` under `TrustPolicy::Allowlist`) — the token acts as a bearer credential for inference regardless of admission policy.

This change scopes the exemption to `TrustPolicy::Off`, so default open-mesh behavior is unchanged. With `PreferOwned`/`RequireOwned`/`Allowlist`, only `STREAM_GOSSIP` bypasses the gate: if a node enforces who may join, the same enforcement covers who may consume.

Found while wiring membership-derived admission into Buzz (embedded SDK): a three-node harness — allowlist serve, trusted client, stranger reusing the trusted invite token — showed the stranger rejected at gossip but still completing a chat completion via 0x04 (harness: [block/buzz `mesh_admission_smoke`](https://github.com/block/buzz/blob/micn/mesh-upgrade/crates/buzz-relay/examples/mesh_admission_smoke.rs)).

Regression test added: `passive_streams_are_gated_when_trust_policy_active`. Existing gate tests updated to the new signature under `TrustPolicy::Off`. `mesh::tests` suite passes (one unrelated flake, `owner_control_client_reuses_connection_for_sequential_requests`, passes in isolation before and after).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened stream admission checks so only gossip traffic always bypasses quarantine; other stream types now wait until the remote peer is admitted when trust protections are enabled.
  * Updated gating behavior for passive and tunnel-related streams to match the active trust policy, improving consistency in connection handling.

* **Tests**
  * Expanded coverage for admission and quarantine rules across trust-policy modes.
  * Added validation for stream access when trust policy is active versus off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->