### PR TITLE
Fix empty setup arguments in the Unix installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -622,7 +622,9 @@ setup_command_string() {
     local -a command=("$INSTALL_DIR/mesh-llm" setup)
     local token
     local rendered=""
-    command+=("${SETUP_ARGS[@]}")
+    if ((${#SETUP_ARGS[@]} > 0)); then
+        command+=("${SETUP_ARGS[@]}")
+    fi
     for token in "${command[@]}"; do
         printf -v rendered '%s%q ' "$rendered" "$token"
     done
@@ -641,7 +643,11 @@ run_or_print_setup() {
         else
             echo
         fi
-        "$binary" setup "${SETUP_ARGS[@]}"
+        if ((${#SETUP_ARGS[@]} > 0)); then
+            "$binary" setup "${SETUP_ARGS[@]}"
+        else
+            "$binary" setup
+        fi
         return 0
     fi
 


### PR DESCRIPTION
## What changed

- guard empty `SETUP_ARGS` before expanding the array under `set -u`
- invoke `mesh-llm setup` without an empty array expansion on the default path
- preserve argument forwarding for verbose and legacy service flags

## Why

The public installer initializes `SETUP_ARGS` as an empty array. On the stock macOS Bash 3.2, expanding an empty array under `set -u` raises `SETUP_ARGS[@]: unbound variable`. As a result, a default interactive or non-interactive install placed the binary and then exited before running or printing the setup command.

## Impact

Default macOS installs complete normally again. Linux behavior and non-empty setup argument forwarding are unchanged.

## Validation

- `python3 -m unittest scripts.tests.test_install_sh scripts.tests.test_install_ps1 scripts.tests.test_generate_native_runtime_release_manifest`
- 22 tests passed; 3 Windows-only tests skipped on macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation setup now works correctly when no optional setup arguments are provided.
  * Improved setup command handling to avoid errors caused by empty argument values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->