### PR TITLE
Validate installer bundles before replacing binaries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -601,8 +601,22 @@ remove_stale_binaries() {
     done < <(stale_binary_names)
 }
 
+validate_bundle() {
+    local bundle_dir="$1"
+    local binary="$bundle_dir/mesh-llm"
+    if [[ ! -f "$binary" ]]; then
+        echo "error: release archive did not contain an installable mesh-llm binary" >&2
+        return 1
+    fi
+    if [[ ! -x "$binary" ]]; then
+        echo "error: mesh-llm binary in release archive is not executable" >&2
+        return 1
+    fi
+}
+
 install_bundle() {
     local bundle_dir="$1"
+    validate_bundle "$bundle_dir"
     remove_stale_binaries
     local file
     for file in "$bundle_dir"/*; do

--- a/install.sh
+++ b/install.sh
@@ -622,7 +622,9 @@ setup_command_string() {
     local -a command=("$INSTALL_DIR/mesh-llm" setup)
     local token
     local rendered=""
-    command+=("${SETUP_ARGS[@]}")
+    if ((${#SETUP_ARGS[@]} > 0)); then
+        command+=("${SETUP_ARGS[@]}")
+    fi
     for token in "${command[@]}"; do
         printf -v rendered '%s%q ' "$rendered" "$token"
     done
@@ -641,7 +643,11 @@ run_or_print_setup() {
         else
             echo
         fi
-        "$binary" setup "${SETUP_ARGS[@]}"
+        if ((${#SETUP_ARGS[@]} > 0)); then
+            "$binary" setup "${SETUP_ARGS[@]}"
+        else
+            "$binary" setup
+        fi
         return 0
     fi
 

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -242,6 +242,35 @@ class InstallScriptTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("could not download release archive", result.stderr)
 
+    def test_install_bundle_preserves_existing_binary_when_replacement_is_missing(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            install_dir.mkdir()
+            installed_binary = install_dir / "mesh-llm"
+            installed_binary.write_text("existing binary\n", encoding="utf-8")
+            bundle_dir = tmp_path / "mesh-bundle"
+            bundle_dir.mkdir()
+            (bundle_dir / "README.txt").write_text("malformed bundle\n", encoding="utf-8")
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                f"install_bundle {shlex_quote(str(bundle_dir))}",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "did not contain an installable mesh-llm binary",
+                result.stderr,
+            )
+            self.assertEqual(
+                installed_binary.read_text(encoding="utf-8"),
+                "existing binary\n",
+            )
+
     def test_main_runs_setup_interactively(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result, calls, tools = self._run_main(tmp, interactive=True)


### PR DESCRIPTION
## Summary

- validate that an extracted release bundle contains a regular, executable `mesh-llm` binary
- perform validation before removing any existing installed binaries
- add a regression test proving a malformed bundle leaves the existing binary intact

## Why

The installer previously removed the working installation before checking that the extracted archive contained its replacement. A malformed or incorrectly packaged archive could therefore turn an update failure into a broken installation.

## Stack

This PR is stacked on #953 so the installer test suite runs with the Bash 3.2 empty-array fix. Its own commit is `ab5fa0ee` and can be reviewed independently; after #953 merges, this PR can target `main`.

## Validation

- `bash -n install.sh`
- `python3 -m unittest discover -s scripts/tests -p 'test_install*.py'` (22 passed, 3 Windows-only skips)

` shellcheck install.sh` still reports the pre-existing SC2064 warning on the intentionally pre-escaped cleanup trap; this PR does not alter that line.