### PR TITLE
Fix dispatched release version preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,9 @@ jobs:
           persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
       - uses: dtolnay/rust-toolchain@stable
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'
@@ -430,6 +433,9 @@ jobs:
           persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache native runtime CUDA backend build
         uses: actions/cache@v5
@@ -489,6 +495,9 @@ jobs:
           persist-credentials: false
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache native runtime ROCm backend build
         uses: actions/cache@v5

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -159,7 +159,7 @@ update_known_mesh_versions() {
     ' "$next" "$file"; then
         return
     fi
-    after="$(perl -0777 -pe 's/(fn known_mesh_llm_versions\(\).*?\&\[\n\s*)/${1}"'"$next"'", /s' "$file")"
+    after="$(perl -0777 -pe 's/(fn known_mesh_llm_versions\(\).*?\&\[\r?\n\s*)/${1}"'"$next"'", /s' "$file")"
     if [[ "$before" == "$after" ]]; then
         echo "failed to add $next to known mesh-llm versions in $file" >&2
         exit 1


### PR DESCRIPTION
## Summary

- install Node 24 in the native-runtime CUDA and ROCm container jobs before release version preparation
- accept both LF and CRLF when inserting the dispatched version into the built-in schema

## Root cause

The release version synchronization added two assumptions that are not true across the full release matrix. Native-runtime GPU containers did not have Node on `PATH`, and the known-version insertion regex required an LF immediately after `&[`, so Windows CRLF checkouts could not be updated. All 13 failed jobs stopped in `Prepare dispatched release version` for one of these reasons.

## Impact

Dispatched releases can prepare versions consistently in Linux GPU containers and Windows jobs, allowing the build matrix to proceed past version stamping.

## Validation

- `actionlint .github/workflows/release.yml`
- `just check-release`
- full isolated `scripts/release-version.sh v0.73.0` run with `built_in_schema.rs` converted to CRLF
- JSON validation for the updated UI package, lockfile, and Node SDK package
- `git diff --check`

Fixes the failure observed in https://github.com/Mesh-LLM/mesh-llm/actions/runs/29138753946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version updates to work reliably with files using either Unix or Windows line endings.

* **Chores**
  * Improved the reliability of Linux GPU build environments by ensuring Node.js is available during release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->