### PR TITLE
Fix Windows Vulkan native runtime release build

### DIFF
--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -130,6 +130,24 @@ if [[ ! -d "$LLAMA_WORKDIR/.git" ]]; then
   exit 1
 fi
 
+# The LunarG SDK ships GCC runtime DLLs in its Bin directories. GitHub Actions
+# prepends those directories to PATH, so a MinGW-built vulkan-shaders-gen can
+# load the SDK's older libstdc++ instead of the runtime matching its compiler
+# and fail with STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139). Keep the selected
+# compiler's runtime first; glslc remains discoverable later on PATH.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    if [[ "$LLAMA_BACKEND" == "vulkan" ]]; then
+      MINGW_CXX="$(command -v g++ || true)"
+      if [[ -n "$MINGW_CXX" ]]; then
+        MINGW_RUNTIME_DIR="$(dirname "$MINGW_CXX")"
+        export PATH="$MINGW_RUNTIME_DIR:$PATH"
+        echo "prioritizing MinGW runtime for Vulkan build: $MINGW_RUNTIME_DIR"
+      fi
+    fi
+    ;;
+esac
+
 SCCACHE_BIN="${SCCACHE:-${SCCACHE_PATH:-}}"
 if [[ -z "$SCCACHE_BIN" ]] && command -v sccache >/dev/null 2>&1; then
   SCCACHE_BIN="$(command -v sccache)"


### PR DESCRIPTION
## What changed

Prioritize the MinGW compiler runtime directory on `PATH` before configuring Windows Vulkan llama.cpp builds.

## Root cause

The release job [Build native runtime Windows x86_64 Vulkan](https://github.com/Mesh-LLM/mesh-llm/actions/runs/29139610349/job/86586589874) built `vulkan-shaders-gen.exe` with the runner's MinGW GCC 14 toolchain, then launched it with the LunarG Vulkan SDK `Bin` directories earlier on `PATH`. Those directories include older GCC runtime DLLs, so Windows loaded an incompatible `libstdc++` and the helper exited with `STATUS_ENTRYPOINT_NOT_FOUND` (`0xc0000139`) while generating shaders.

The compiler directory is now placed first for MinGW/MSYS/Cygwin Vulkan builds only. The Vulkan SDK remains on `PATH`, so `glslc` discovery is unchanged. Other platforms and backends are unaffected.

## Impact

Windows x86_64 Vulkan native runtime packaging can generate the embedded Vulkan shaders and complete the release artifact.

## Validation

- `bash -n scripts/build-llama.sh`
- `shellcheck scripts/build-llama.sh`
- `git diff --check`
- `just check-release`
- `just build`

The exact Windows failure path requires a Windows runner and will be verified by PR/release CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vulkan builds on MinGW, MSYS, and Cygwin environments.
  - Prevented incompatible runtime libraries from being selected during builds, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->