### PR TITLE
fix(ui): keep chat streaming in hidden tabs

### DIFF
--- a/crates/mesh-llm-ui/src/lib/streaming.test.ts
+++ b/crates/mesh-llm-ui/src/lib/streaming.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { hasBlobContent, parseApiErrorBody } from '@/lib/streaming'
+import { createRafBatcher, hasBlobContent, parseApiErrorBody } from '@/lib/streaming'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('createRafBatcher', () => {
+  it('publishes updates without waiting for animation frames in a hidden tab', () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame')
+    const onUpdate = vi.fn()
+
+    createRafBatcher(onUpdate).push('background response')
+
+    expect(onUpdate).toHaveBeenCalledWith('background response')
+    expect(requestFrame).not.toHaveBeenCalled()
+  })
+})
 
 // ---------------------------------------------------------------------------
 // hasBlobContent

--- a/crates/mesh-llm-ui/src/lib/streaming.test.ts
+++ b/crates/mesh-llm-ui/src/lib/streaming.test.ts
@@ -15,6 +15,22 @@ describe('createRafBatcher', () => {
     expect(onUpdate).toHaveBeenCalledWith('background response')
     expect(requestFrame).not.toHaveBeenCalled()
   })
+
+  it('cancels a pending animation frame when the tab becomes hidden', () => {
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame')
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+    const onUpdate = vi.fn()
+    const batcher = createRafBatcher(onUpdate)
+
+    batcher.push('visible response')
+    const frame = requestFrame.mock.results[0].value
+    visibility.mockReturnValue('hidden')
+    batcher.push('background response')
+
+    expect(cancelFrame).toHaveBeenCalledWith(frame)
+    expect(onUpdate).toHaveBeenCalledWith('background response')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/crates/mesh-llm-ui/src/lib/streaming.ts
+++ b/crates/mesh-llm-ui/src/lib/streaming.ts
@@ -72,6 +72,17 @@ export function createRafBatcher(callback: (text: string) => void) {
     /** Call on every stream update — stores the latest text snapshot + raf check. */
     push(text: string) {
       latest = text
+      // Browsers suspend requestAnimationFrame in background tabs. Publish
+      // network-driven stream updates directly there so generation keeps
+      // advancing while the user works in another tab.
+      if (document.visibilityState === 'hidden') {
+        if (raf) {
+          window.cancelAnimationFrame(raf)
+          raf = 0
+        }
+        callback(latest)
+        return
+      }
       if (!raf) {
         raf = window.requestAnimationFrame(() => {
           raf = 0


### PR DESCRIPTION
## Summary

- publish streamed chat snapshots immediately while the document is hidden
- cancel a queued animation frame before the hidden-tab update to avoid duplicate publication
- retain animation-frame batching for visible tabs

Closes #950.

## Validation

- `pnpm test -- src/lib/streaming.test.ts` (17 passed)
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec prettier src/lib/streaming.ts src/lib/streaming.test.ts --check`
- `git diff --check`

The repository-wide test run completed with 892 passing, 3 skipped, and 6 unrelated existing UI/timing failures. The repository-wide Prettier check also currently reports 509 files outside this change; both changed files pass Prettier directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Streaming updates now continue to render promptly when the app is in a background browser tab.
  - Pending animation-frame batching is cancelled when the tab becomes hidden, while the latest buffered content is still delivered.

- **Tests**
  - Expanded coverage for streaming batching behavior, including hidden-tab immediate updates and cancellation during visibility transitions.
  - Restored mocks after each test to keep the suite isolated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->